### PR TITLE
refactor: use pytempo for TempoTransaction instead of manual RLP encoding

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,7 @@ classifiers = [
 
 [project.optional-dependencies]
 tempo = [
-    "eth-account>=0.11.0",
-    "eth-utils>=4.0.0",
+    "pytempo @ git+https://github.com/tempoxyz/pytempo.git@main",
     "pydantic>=2.0",
 ]
 server = ["pydantic>=2.0"]
@@ -49,6 +48,9 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/mpay"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.ruff]
 line-length = 88

--- a/src/mpay/methods/tempo/account.py
+++ b/src/mpay/methods/tempo/account.py
@@ -67,6 +67,16 @@ class TempoAccount:
         """Get the account's Ethereum address."""
         return self._account.address
 
+    @property
+    def private_key(self) -> str:
+        """Get the private key as hex string for signing.
+
+        Note:
+            This is intentionally exposed for use with pytempo's
+            TempoTransaction.sign() method which requires the key as hex.
+        """
+        return self._account.key.hex()
+
     def sign_hash(self, msg_hash: bytes) -> bytes:
         """Sign a 32-byte hash, return 65-byte signature.
 

--- a/src/mpay/methods/tempo/client.py
+++ b/src/mpay/methods/tempo/client.py
@@ -218,8 +218,7 @@ class TempoMethod:
         Returns the raw signed transaction hex (0x76-prefixed).
         """
         import httpx
-        import rlp
-        from eth_utils import keccak, to_bytes
+        from pytempo import create_tempo_transaction
 
         if self.account is None:
             raise ValueError("No account configured")
@@ -267,57 +266,21 @@ class TempoMethod:
                 raise TransactionError("Failed to fetch gas price")
             gas_price = int(gas_result["result"], 16)
 
-            calls = [[to_bytes(hexstr=asset), 0, to_bytes(hexstr=transfer_data)]]
-            access_list: list = []
-            nonce_key = 0
-            valid_before = b""
-            valid_after = b""
-            fee_token = b""
-            fee_payer_placeholder = bytes([0x00])
-            authorization_list: list = []
+            tx = create_tempo_transaction(
+                to=asset,
+                value=0,
+                data=transfer_data,
+                gas=DEFAULT_GAS_LIMIT,
+                max_fee_per_gas=gas_price,
+                max_priority_fee_per_gas=gas_price,
+                nonce=nonce,
+                nonce_key=0,
+                chain_id=chain_id,
+                _will_have_fee_payer=True,
+            )
 
-            fields_for_signing = [
-                chain_id,
-                gas_price,
-                gas_price,
-                DEFAULT_GAS_LIMIT,
-                calls,
-                access_list,
-                nonce_key,
-                nonce,
-                valid_before,
-                valid_after,
-                b"",
-                fee_payer_placeholder,
-                authorization_list,
-            ]
-
-            encoded_for_signing = rlp.encode(fields_for_signing)
-            signing_hash = keccak(bytes([0x76]) + encoded_for_signing)
-
-            signature = self.account.sign_hash(signing_hash)
-
-            fields_with_sig = [
-                chain_id,
-                gas_price,
-                gas_price,
-                DEFAULT_GAS_LIMIT,
-                calls,
-                access_list,
-                nonce_key,
-                nonce,
-                valid_before,
-                valid_after,
-                fee_token,
-                fee_payer_placeholder,
-                authorization_list,
-                signature,
-            ]
-
-            encoded_tx = rlp.encode(fields_with_sig)
-            raw_tx = "0x76" + encoded_tx.hex()
-
-            return raw_tx
+            tx.sign(self.account.private_key)
+            return "0x" + tx.encode().hex()
 
     def _encode_transfer(self, to: str, amount: int) -> str:
         """Encode a TIP-20 transfer call."""


### PR DESCRIPTION
## Summary

Replace manual RLP encoding in _build_sponsored_transfer with pytempo create_tempo_transaction function. This removes ~50 lines of duplicated transaction building code.

## Changes

- Replace eth-account, eth-utils, rlp dependencies with pytempo in [tempo] extras
- Use create_tempo_transaction() from pytempo for 0x76 transaction building
- Add private_key property to TempoAccount for pytempo sign() method
- Enable direct-references in hatch metadata for git+https dependency

## Benefits

The pytempo library provides:
- Full TempoTransaction RLP encoding
- 2D nonce support for parallel transactions
- Fee payer/sponsorship support
- Keychain precompile utilities (access keys)
- Call batching

## Notes

Currently using git+https reference as tempoxyz/pytempo is not yet published to PyPI under a unique package name (the pytempo name on PyPI is an unrelated project).

Once pytempo is published under a unique name (e.g., tempo-pytempo or tempoxyz-pytempo), the dependency can be updated to use the PyPI version.

## Testing

All 103 tests pass.