### PR TITLE
fix: HMAC challenge IDs and VerificationError propagation

### DIFF
--- a/AUDIT-REPORT.md
+++ b/AUDIT-REPORT.md
@@ -1,0 +1,389 @@
+# mpay-python Spec Compliance Audit Report
+
+**Date**: January 28, 2026  
+**Scope**: mpay-python implementation vs IETF Payment Auth Spec (`draft-httpauth-payment-00`)  
+**Auditor**: Amp (Oracle-assisted analysis)
+
+---
+
+## Executive Summary
+
+The mpay-python SDK provides a clean, async-native implementation of the Payment HTTP Authentication Scheme. However, **several critical divergences from the IETF spec** exist that would cause interoperability issues with other compliant implementations and introduce security gaps.
+
+| Severity | Count | Description |
+|----------|-------|-------------|
+| 🔴 Critical | 3 | Spec-breaking divergences in wire format |
+| 🟠 High | 4 | Missing security requirements |
+| 🟡 Medium | 5 | Missing optional but recommended features |
+| 🔵 Low | 3 | Implementation bugs/quality issues |
+
+---
+
+## 🔴 Critical Findings
+
+[fix]### C1. Credential Format Does Not Match Spec
+
+**Spec Reference**: [Section 5.2](file:///Users/brendanryan/tempo/ietf-paymentauth-spec/specs/core/draft-httpauth-payment-00.md#L331-L390)
+
+**Spec Requirement**: The Authorization credential MUST be a base64url-encoded JSON object containing:
+
+```json
+{
+  "challenge": {
+    "id": "...",
+    "realm": "...",
+    "method": "...",
+    "intent": "...",
+    "request": "<base64url>",
+    "digest": "...",      // optional
+    "expires": "..."      // optional
+  },
+  "source": "did:...",    // optional
+  "payload": {...}
+}
+```
+
+**Implementation**: [mpay/_parsing.py#L172-L203](file:///Users/brendanryan/tempo/mpay-python/src/mpay/_parsing.py#L172-L203)
+
+```python
+# Current format:
+{
+  "id": "...",
+  "payload": {...},
+  "source": "..."
+}
+```
+
+**Impact**:
+
+- Interoperability failure with other spec-compliant implementations
+- Missing challenge echo prevents server-side integrity verification
+- `realm`, `method`, `intent` cannot be validated
+
+**Recommendation**: Restructure `Credential` to include nested `challenge` object with all original challenge parameters.
+
+---
+
+ [fix]### C2. Receipt Missing Required `method` Field
+
+**Spec Reference**: [Section 5.3](file:///Users/brendanryan/tempo/ietf-paymentauth-spec/specs/core/draft-httpauth-payment-00.md#L392-L410)
+
+**Spec Requirement**: Receipt MUST include:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `status` | string | "success" or "failed" |
+| `method` | string | Payment method used |
+| `timestamp` | string | ISO 8601 settlement time |
+| `reference` | string | Method-specific reference |
+
+**Implementation**: [mpay/**init**.py#L79-L122](file:///Users/brendanryan/tempo/mpay-python/src/mpay/__init__.py#L79-L122)
+
+The `Receipt` dataclass only has `status`, `timestamp`, `reference` - **missing `method`**.
+
+**Impact**: Non-compliant receipts; clients cannot identify which payment method was used.
+
+**Recommendation**: Add `method: str` field to `Receipt` dataclass and update parsing/formatting.
+
+---
+
+[fix] ### C3. No Challenge Binding Verification
+
+**Spec Reference**: [Section 5.1.3](file:///Users/brendanryan/tempo/ietf-paymentauth-spec/specs/core/draft-httpauth-payment-00.md#L275-L285)
+
+**Spec Requirement**:
+> "Servers SHOULD bind the challenge `id` to the challenge parameters... Servers MUST verify that credentials present an `id` matching the expected binding."
+
+**Implementation**: [mpay/server/verify.py#L15-L77](file:///Users/brendanryan/tempo/mpay-python/src/mpay/server/verify.py#L15-L77)
+
+The implementation:
+
+1. Generates a random challenge ID with `secrets.token_urlsafe(16)`
+2. Does NOT store the challenge anywhere
+3. Does NOT verify that the credential's ID corresponds to an issued challenge
+4. Does NOT verify that challenge parameters match
+
+**Impact**:
+
+- Challenge substitution attacks possible
+- Attacker can forge arbitrary challenge IDs
+- No integrity protection for payment requests
+
+**Recommendation**:
+
+- Implement challenge storage (in-memory cache or pluggable store)
+- Verify credential's challenge ID exists and parameters match
+- Mark challenges as consumed after successful verification
+
+---
+
+## 🟠 High Severity Findings
+
+### H1. No Replay Protection (Challenge Single-Use Enforcement)
+
+**Spec Reference**: [Section 7.2](file:///Users/brendanryan/tempo/ietf-paymentauth-spec/specs/core/draft-httpauth-payment-00.md#L581-L588)
+
+**Spec Requirement**:
+> "A payment proof MUST be usable exactly once; subsequent attempts to use the same proof MUST be rejected."
+
+**Implementation**: The server has no challenge state tracking. The same credential can be submitted multiple times.
+
+**Note**: The Tempo `ChargeIntent` partially mitigates this by verifying on-chain transaction state, but:
+
+1. Other intents/methods may not have this protection
+2. Double-submission race conditions are still possible
+
+**Recommendation**: Add challenge consumption tracking with atomic "verify-and-consume" semantics.
+
+---
+
+[fix] ### H2. No RFC 9457 Problem Details Error Responses
+
+**Spec Reference**: [Section 4.2](file:///Users/brendanryan/tempo/ietf-paymentauth-spec/specs/core/draft-httpauth-payment-00.md#L156-L167)
+
+**Spec Requirement**: Error details MUST be provided in response body using Problem Details (RFC 9457):
+
+```json
+{
+  "type": "https://ietf.org/payment/problems/verification-failed",
+  "title": "Payment Verification Failed",
+  "status": 402,
+  "detail": "Invalid payment proof."
+}
+```
+
+**Implementation**: [mpay/server/decorator.py#L30-L45](file:///Users/brendanryan/tempo/mpay-python/src/mpay/server/decorator.py#L30-L45)
+
+Returns only `WWW-Authenticate` header with `content=None` - no error body.
+
+**Impact**: Clients cannot distinguish between different failure modes (malformed credential, expired challenge, verification failed).
+
+**Recommendation**: Add RFC 9457 problem+json response bodies for all 402 cases.
+
+---
+
+[fix] ### H3. Missing `Cache-Control: no-store` on 402 Responses
+
+**Spec Reference**: [Section 7.10](file:///Users/brendanryan/tempo/ietf-paymentauth-spec/specs/core/draft-httpauth-payment-00.md#L650-L661)
+
+**Spec Requirement**:
+> "Servers MUST send `Cache-Control: no-store` with 402 responses."
+
+**Implementation**: The decorator only sets `WWW-Authenticate` header.
+
+**Impact**: Challenges may be cached by proxies/CDNs, causing stale/reused challenges.
+
+**Recommendation**: Add `Cache-Control: no-store` to all 402 responses.
+
+---
+
+### H4. No TLS Enforcement
+
+**Spec Reference**: [Section 7.1](file:///Users/brendanryan/tempo/ietf-paymentauth-spec/specs/core/draft-httpauth-payment-00.md#L556-L578)
+
+**Spec Requirement**:
+> "Implementations MUST use TLS when transmitting Payment challenges and credentials... Clients MUST NOT send Payment credentials over unencrypted HTTP."
+
+**Implementation**: The client transport has no scheme validation - will send credentials over HTTP.
+
+**Impact**: Credential exposure to MITM attacks on misconfigured deployments.
+
+**Recommendation**:
+
+- Client: Reject or warn when `request.url.scheme != "https"`
+- Document TLS requirement prominently
+
+---
+
+## 🟡 Medium Severity Findings
+
+[fix] ### M1. Client Does Not Check Challenge Expiry
+
+**Spec Reference**: [Section 5.1.2](file:///Users/brendanryan/tempo/ietf-paymentauth-spec/specs/core/draft-httpauth-payment-00.md#L264-L267)
+
+**Spec Requirement**:
+> "Clients MUST NOT submit credentials for expired challenges."
+
+**Implementation**: [mpay/client/transport.py](file:///Users/brendanryan/tempo/mpay-python/src/mpay/client/transport.py)
+
+The client transport parses the challenge but never checks `challenge.expires` before creating/sending credentials.
+
+**Recommendation**: Check `challenge.expires` and skip payment if expired.
+
+---
+
+[fix] ### M2. Server Does Not Set `expires` on Challenges
+
+**Implementation**: [mpay/server/verify.py#L79-L90](file:///Users/brendanryan/tempo/mpay-python/src/mpay/server/verify.py#L79-L90)
+
+`_create_challenge()` never sets the `expires` field. Per spec, servers SHOULD include this parameter.
+
+**Recommendation**: Add configurable challenge TTL with default (e.g., 5 minutes).
+
+---
+
+[fix] ### M3. Multiple WWW-Authenticate Headers Not Handled
+
+**Spec Reference**: [Appendix A, Multiple Payment Options](file:///Users/brendanryan/tempo/ietf-paymentauth-spec/specs/core/draft-httpauth-payment-00.md#L904-L921)
+
+**Spec Requirement**: Servers MAY return multiple Payment challenges; clients should select one.
+
+**Implementation**: [mpay/client/transport.py#L68](file:///Users/brendanryan/tempo/mpay-python/src/mpay/client/transport.py#L68)
+
+```python
+www_auth = response.headers.get("www-authenticate")  # Only gets first
+```
+
+**Impact**: Cannot handle servers offering multiple payment methods.
+
+**Recommendation**: Use `response.headers.get_list("www-authenticate")` and iterate.
+
+---
+
+[fix] ### M4. Server Does Not Validate `realm` Parameter
+
+The `realm` is passed to `verify_or_challenge()` but only used for generating challenges, never validated against incoming credentials.
+
+**Recommendation**: When challenge binding is implemented, include realm verification.
+
+---
+
+[fix] ### M5. `VerificationError` Not Caught in Server Flow
+
+**Implementation**: [mpay/server/verify.py#L75-L76](file:///Users/brendanryan/tempo/mpay-python/src/mpay/server/verify.py#L75-L76)
+
+```python
+receipt: Receipt = await intent.verify(credential, request)
+return (credential, receipt)
+```
+
+If `intent.verify()` raises `VerificationError`, it propagates as an unhandled exception (likely 500).
+
+**Recommendation**: Catch `VerificationError` and return fresh challenge with appropriate problem details.
+
+---
+
+## 🔵 Low Severity Findings
+
+### L1. Base64 Decode May Raise Unexpected Exception
+
+**Implementation**: [mpay/_parsing.py#L55-L63](file:///Users/brendanryan/tempo/mpay-python/src/mpay/_parsing.py#L55-L63)
+
+```python
+except (ValueError, json.JSONDecodeError):
+    raise ParseError("Invalid base64 or JSON encoding") from None
+```
+
+`base64.urlsafe_b64decode()` can raise `binascii.Error` which is not caught.
+
+**Recommendation**: Add `binascii.Error` to the exception tuple.
+
+---
+
+### L2. Client Retry May Fail with Streamed Bodies
+
+**Implementation**: [mpay/client/transport.py#L89-L97](file:///Users/brendanryan/tempo/mpay-python/src/mpay/client/transport.py#L89-L97)
+
+For POST/PUT with streaming bodies, reusing `request.stream` after the initial 402 may fail (stream already consumed).
+
+**Recommendation**: Document limitation or buffer body before initial request.
+
+---
+
+### L3. Auth Param Parsing is Non-Strict
+
+**Implementation**: [mpay/_parsing.py#L78-L86](file:///Users/brendanryan/tempo/mpay-python/src/mpay/_parsing.py#L78-L86)
+
+The regex-based parsing silently ignores malformed segments rather than rejecting them per strict RFC 9110 ABNF.
+
+**Recommendation**: Consider stricter parsing or document permissive behavior.
+
+---
+
+## Compliance Summary Matrix
+
+| Spec Requirement | Status | Notes |
+|------------------|--------|-------|
+| WWW-Authenticate format | ✅ Compliant | Correct auth-param syntax |
+| Authorization credential format | ❌ Non-compliant | Missing `challenge` object |
+| Payment-Receipt format | ❌ Non-compliant | Missing `method` field |
+| Challenge binding (SHOULD) | ❌ Missing | No binding verification |
+| Challenge single-use (MUST) | ❌ Missing | No replay protection |
+| Expires validation | ⚠️ Partial | Server intent checks, client doesn't |
+| Cache-Control: no-store | ❌ Missing | Not set on 402 responses |
+| RFC 9457 error responses | ❌ Missing | No problem details |
+| TLS requirement | ❌ Not enforced | No scheme validation |
+| Multiple challenges | ⚠️ Partial | Server can issue, client ignores extras |
+
+---
+
+## Recommendations Priority
+
+### Immediate (Breaking Changes - v2.0)
+
+1. **C1**: Restructure credential format to include `challenge` object
+2. **C2**: Add `method` field to Receipt
+3. **H2**: Add RFC 9457 problem detail responses
+
+### High Priority (Security)
+
+4. **C3/H1**: Implement challenge store with binding and single-use enforcement
+2. **H3**: Add `Cache-Control: no-store` header
+3. **H4**: Add TLS scheme validation (opt-out for testing)
+
+### Medium Priority
+
+7. **M1**: Client expiry check before paying
+2. **M2**: Add default challenge expiry
+3. **M3**: Handle multiple WWW-Authenticate headers
+4. **M5**: Catch VerificationError and return proper 402
+
+### Low Priority
+
+11. **L1**: Fix base64 exception handling
+2. **L2**: Document streaming body limitation
+3. **L3**: Consider stricter parsing
+
+---
+
+## Appendix: Spec-Compliant Credential Structure
+
+For reference, here's what a compliant credential should look like:
+
+```python
+@dataclass(frozen=True, slots=True)
+class Credential:
+    challenge: ChallengeEcho  # Full challenge parameters
+    payload: dict[str, Any]
+    source: str | None = None
+
+@dataclass(frozen=True, slots=True)  
+class ChallengeEcho:
+    id: str
+    realm: str
+    method: str
+    intent: str
+    request: str  # Keep as base64url string, not decoded
+    digest: str | None = None
+    expires: str | None = None
+```
+
+Wire format:
+
+```json
+{
+  "challenge": {
+    "id": "x7Tg2pLqR9mKvNwY3hBcZa",
+    "realm": "api.example.com",
+    "method": "tempo",
+    "intent": "charge",
+    "request": "eyJhbW91bnQiOi4uLn0",
+    "expires": "2025-01-15T12:05:00Z"
+  },
+  "payload": {
+    "type": "transaction",
+    "signature": "0x..."
+  },
+  "source": "did:pkh:eip155:1:0x742d..."
+}
+```

--- a/AUDIT-SDK-SPEC-COMPLIANCE.md
+++ b/AUDIT-SDK-SPEC-COMPLIANCE.md
@@ -1,0 +1,264 @@
+# mpay-python SDK Spec Compliance Audit
+
+**Audit Date:** January 28, 2026  
+**Specification:** [mpay-sdks/SPEC.md](https://github.com/tempoxyz/mpay-sdks/blob/main/SPEC.md)  
+**Scope:** SDK specification compliance review
+
+## Executive Summary
+
+The mpay-python SDK provides the correct **structure** for a conformant implementation—core types, HTTP client transport, server verification, and Tempo method—but has **critical spec violations** in challenge binding and credential verification that undermine the protocol's security guarantees.
+
+| Category | Status | Severity |
+|----------|--------|----------|
+| Core Types | ⚠️ Partial | Low |
+| Client 402 Transport | ⚠️ Partial | Medium |
+| Server Challenge Generation | ❌ Non-conformant | **Critical** |
+| Server Verification | ❌ Non-conformant | **Critical** |
+| Tempo Method | ✅ Conformant | - |
+| Charge Intent | ⚠️ Partial | Medium |
+| Transport Integrations | ✅ Conformant | - |
+
+---
+
+## Critical Issues
+
+[fix] ### 1. Challenge ID Not Bound to Parameters (SPEC VIOLATION)
+
+**Spec Requirement:**
+> Challenge "MUST generate a unique `id` bound to the challenge parameters"
+
+**Current Implementation ([server/verify.py#L79-L90](file:///Users/brendanryan/tempo/mpay-python/src/mpay/server/verify.py#L79-L90)):**
+
+```python
+def _create_challenge(method: str, intent_name: str, request: dict[str, Any]) -> Challenge:
+    return Challenge(
+        id=secrets.token_urlsafe(16),  # ❌ Random, not bound to parameters
+        method=method,
+        intent=intent_name,
+        request=request,
+    )
+```
+
+**Impact:** Challenge IDs are purely random and have no cryptographic binding to the challenge parameters. This breaks the server's ability to verify that a credential corresponds to a specific challenge without stateful storage.
+
+**Recommendation:** Compute `id` as `base64url(HMAC(server_secret, canonical({method, intent, request, expires})))`.
+
+---
+
+[fix] ### 2. Credential ID Not Validated (SPEC VIOLATION)
+
+**Spec Requirement:**
+> Verification "MUST validate the `challenge.id` matches the expected binding"
+
+**Current Implementation ([server/verify.py#L62-L76](file:///Users/brendanryan/tempo/mpay-python/src/mpay/server/verify.py#L62-L76)):**
+
+```python
+if authorization is None:
+    return _create_challenge(method_name, intent.name, request)
+# ...
+credential = Credential.from_authorization(authorization)
+receipt: Receipt = await intent.verify(credential, request)  # ❌ credential.id never checked
+return (credential, receipt)
+```
+
+**Impact:** Credentials can be replayed against different request parameters than originally challenged. There is no verification that `credential.id` matches any expected value.
+
+**Recommendation:** Before calling `intent.verify()`, recompute the expected challenge ID from current request parameters and compare to `credential.id`.
+
+---
+
+[fix] ### 3. Challenge Parameters Not Validated (SPEC VIOLATION)
+
+**Spec Requirement:**
+> Verification "MUST validate `challenge` parameters match the original request"
+
+**Current Implementation:** No comparison is made between the original challenge request parameters and what the credential claims to be paying for.
+
+**Impact:** A valid credential for one payment can be applied to a different payment request.
+
+---
+
+### 4. Challenge `expires` Not Implemented (SPEC VIOLATION)
+
+**Spec Requirement:**
+> Challenge "SHOULD include `expires` for time-limited challenges"  
+> Verification "MUST validate `expires` has not passed"
+
+**Current Implementation:**
+
+- `_create_challenge()` never sets `expires`
+- `verify_or_challenge()` never checks challenge expiration
+- `ChargeIntent` checks `request.expires` (a different field in the request payload), not challenge expiration
+
+**Impact:** Challenges never expire at the protocol level, enabling indefinite credential validity.
+
+---
+
+## Medium Severity Issues
+
+[fix] ### 5. Request Body Not Replayed on 402 Retry
+
+**Location:** [client/transport.py#L89-L96](file:///Users/brendanryan/tempo/mpay-python/src/mpay/client/transport.py#L89-L96)
+
+```python
+retry_request = httpx.Request(
+    method=request.method,
+    url=request.url,
+    headers=headers,
+    stream=request.stream,  # ⚠️ Stream may be consumed
+    extensions=request.extensions,
+)
+```
+
+**Impact:** POST/PUT requests with bodies may fail silently on retry because the stream is already consumed.
+
+**Recommendation:** Buffer request content before first send; rebuild retry with `content=...`.
+
+---
+
+[fix] ### 6. Multiple WWW-Authenticate Headers Not Supported
+
+**Location:** [client/transport.py#L68-L69](file:///Users/brendanryan/tempo/mpay-python/src/mpay/client/transport.py#L68-L69)
+
+```python
+www_auth = response.headers.get("www-authenticate")
+if not www_auth or not www_auth.lower().startswith("payment "):
+```
+
+**Impact:** Servers may return multiple `WWW-Authenticate` headers or combine multiple schemes. The transport only handles a single Payment challenge.
+
+**Recommendation:** Parse all `WWW-Authenticate` headers/values and select the first matching supported method.
+
+---
+
+[fix] ### 7. Intent.challenge() Method Not Implemented
+
+**Spec Requirement:**
+> "SDKs MUST provide a way to generate challenges: `Intent.challenge(request) -> Challenge`"
+
+**Current Implementation:** Challenge generation is centralized in `verify_or_challenge()` using `_create_challenge()`. The `Intent` protocol does not define or require a `challenge()` method.
+
+**Impact:** Intents cannot customize challenge generation; limits extensibility for future intents.
+
+---
+
+[fix] ### 8. ChargeIntent Payer Identity Not Verified
+
+**Location:** [methods/tempo/intents.py#L192-L234](file:///Users/brendanryan/tempo/mpay-python/src/mpay/methods/tempo/intents.py#L192-L234)
+
+The `_verify_transfer_logs()` method accepts an `expected_sender` parameter but it's never used:
+
+```python
+def _verify_transfer_logs(
+    self, receipt: dict, request: ChargeRequest, expected_sender: str | None = None
+) -> bool:
+```
+
+**Impact:** No verification that `Credential.source` (the payer DID) matches the transaction sender.
+
+---
+
+[fix] ### 9. Debug Prints in Library Code
+
+**Location:** [methods/tempo/intents.py#L288](file:///Users/brendanryan/tempo/mpay-python/src/mpay/methods/tempo/intents.py#L288), [L310](file:///Users/brendanryan/tempo/mpay-python/src/mpay/methods/tempo/intents.py#L310)
+
+```python
+print(f"[mpay] Transaction submitted: {tx_hash}")
+print(f"[mpay] Receipt found on attempt {attempt + 1}")
+```
+
+**Impact:** Library should use logging module with opt-in configuration, not stdout prints.
+
+---
+
+## Low Severity Issues
+
+### 10. `realm` Parsed But Not Stored
+
+The `Challenge` dataclass does not store `realm`, though it's required in WWW-Authenticate headers. The value is discarded during parsing and must be re-supplied when formatting.
+
+**Impact:** `Challenge` cannot round-trip losslessly from a parsed header.
+
+---
+
+### 11. Receipt Not Automatically Attached by Decorator
+
+The `@requires_payment` decorator passes `(credential, receipt)` to the handler but does not automatically set the `Payment-Receipt` header on the response. Handlers must do this manually.
+
+**Impact:** Easy to forget to include the receipt header; not "pit of success" design.
+
+---
+
+### 12. Server Method Protocol Unused
+
+The `mpay.server.method.Method` protocol is defined but appears unused—`verify_or_challenge()` takes an `Intent` directly without method routing.
+
+---
+
+## Conformance Checklist
+
+| Requirement | Status | Notes |
+|-------------|--------|-------|
+| **Core Types** | | |
+| Challenge maps to WWW-Authenticate | ✅ | Via `_parsing.py` |
+| Credential maps to Authorization | ✅ | Via `_parsing.py` |
+| Receipt maps to Payment-Receipt | ✅ | Via `_parsing.py` |
+| **Client** | | |
+| 402 transport intercepts responses | ✅ | `PaymentTransport` |
+| Parses WWW-Authenticate header | ✅ | |
+| Matches method to configured methods | ✅ | |
+| Calls `method.create_credential()` | ✅ | |
+| Retries with Authorization header | ✅ | |
+| Returns final response with receipt | ⚠️ | Returns response; receipt parsing left to user |
+| Handles request body replay | ❌ | Stream not buffered |
+| Handles multiple challenges | ❌ | Only first Payment scheme |
+| **Server** | | |
+| Challenge has unique bound ID | ❌ | Random, not bound |
+| Challenge includes method/intent/request | ✅ | |
+| Challenge includes expires | ❌ | Never set |
+| Validates credential.id binding | ❌ | Never checked |
+| Validates challenge params match | ❌ | Never checked |
+| Validates expires not passed | ❌ | Challenge expires not checked |
+| Verifies payload per method spec | ✅ | Delegated to Intent |
+| Returns Receipt on success | ✅ | |
+| **Methods** | | |
+| Tempo method implemented | ✅ | |
+| **Intents** | | |
+| Charge intent implemented | ✅ | |
+| **Integrations** | | |
+| httpx.AsyncClient/PaymentTransport | ✅ | |
+| @requires_payment decorator | ✅ | Starlette/FastAPI + Django |
+
+---
+
+## Recommended Fixes (Priority Order)
+
+1. **[CRITICAL]** Implement bound challenge IDs using HMAC of challenge parameters
+2. **[CRITICAL]** Validate `credential.id` matches expected binding before verification
+3. **[HIGH]** Add `expires` to challenges and validate on verification
+4. **[MEDIUM]** Buffer request body for POST/PUT retry
+5. **[MEDIUM]** Support multiple WWW-Authenticate challenges
+6. **[MEDIUM]** Add payer identity verification using `Credential.source`
+7. **[LOW]** Replace prints with logging
+8. **[LOW]** Consider adding `realm` to Challenge dataclass
+9. **[LOW]** Consider auto-attaching Payment-Receipt in decorator
+
+---
+
+## Test Coverage Gaps
+
+Based on [tests/test_server.py](file:///Users/brendanryan/tempo/mpay-python/tests/test_server.py):
+
+- ❌ No tests for challenge ID binding/validation
+- ❌ No tests for credential replay with different request params
+- ❌ No tests for challenge expiration
+- ❌ No tests for POST body replay on 402
+- ❌ No tests for multiple WWW-Authenticate headers
+
+---
+
+## Conclusion
+
+The mpay-python SDK has a well-designed architecture that aligns with the spec's design principles (protocol-first, pluggable, minimal dependencies). However, the core security invariants of the Payment Authentication Scheme—binding between challenge parameters and credentials—are not enforced. This must be fixed before the SDK can be considered spec-conformant for production use.
+
+**Overall Conformance Rating:** ❌ Non-Conformant (Critical issues present)

--- a/CODE_REVIEW.md
+++ b/CODE_REVIEW.md
@@ -1,0 +1,435 @@
+# mpay-python SDK Code Review
+
+**Date:** 2026-01-28  
+**Reviewer:** Amp AI  
+**SDK Version:** 0.1.0  
+**Repository:** ~/tempo/mpay-python
+
+## Executive Summary
+
+The mpay-python SDK is well-structured and implements the Payment HTTP Authentication Scheme with clean, readable code. The codebase passes all linting checks and has comprehensive test coverage (104 passing tests). However, there are **3 high-severity security issues** and several code quality improvements that should be addressed before production use.
+
+### Risk Summary
+
+| Severity | Count | Description |
+|----------|-------|-------------|
+| 🔴 High | 3 | Challenge replay, payer identity not verified, SSRF potential |
+| 🟠 Medium | 5 | Print statements, exception handling gaps, dead code |
+| 🟡 Low | 12 | Type consistency, code duplication, API ergonomics |
+
+---
+
+## 1. Security Issues
+
+[FIX -- make this work like js] ### 🔴 HIGH: Challenge Not Bound to Request/Expiry (Replay Vulnerability)
+
+**Files:** [`src/mpay/server/verify.py#L79-L90`](file:///Users/brendanryan/tempo/mpay-python/src/mpay/server/verify.py#L79-L90), [`src/mpay/extensions/mcp/verify.py`](file:///Users/brendanryan/tempo/mpay-python/src/mpay/extensions/mcp/verify.py)
+
+**Issue:** Challenges are created with a random ID but:
+
+- Not stored server-side
+- Not cryptographically signed
+- Not bound to the specific request parameters
+- `expires` field exists on `Challenge` but is never set or validated
+
+**Impact:** Attackers can replay credentials across different requests or forge credentials with modified challenge data.
+
+**Recommendation:**
+
+```python
+# Stateless signed challenge approach
+import hmac
+import hashlib
+
+def _create_challenge(..., secret: bytes) -> Challenge:
+    id = secrets.token_urlsafe(16)
+    expires = (datetime.now(UTC) + timedelta(minutes=5)).isoformat()
+    
+    # Create digest binding challenge to request
+    canonical = json.dumps({
+        "id": id, "realm": realm, "method": method,
+        "intent": intent_name, "request": request, "expires": expires
+    }, sort_keys=True)
+    digest = hmac.new(secret, canonical.encode(), hashlib.sha256).hexdigest()
+    
+    return Challenge(
+        id=id, method=method, intent=intent_name,
+        request=request, expires=expires, digest=f"sha-256=:{digest}:"
+    )
+```
+
+---
+
+[fix -- make this align with mpay] ### 🔴 HIGH: Payer Identity Not Verified (Tempo Method)
+
+**File:** [`src/mpay/methods/tempo/intents.py#L192-L234`](file:///Users/brendanryan/tempo/mpay-python/src/mpay/methods/tempo/intents.py#L192-L234)
+
+**Issue:** `_verify_transfer_logs()` accepts an `expected_sender` parameter but it is **never passed by callers**:
+
+- Line 185: `self._verify_transfer_logs(receipt_data, request)` (no sender)
+- Line 323: `self._verify_transfer_logs(receipt_data, request)` (no sender)
+
+**Impact:** Any transaction with matching amount/currency/recipient passes verification, regardless of who paid. An attacker could reuse someone else's transaction hash to unlock paid content.
+
+**Recommendation:**
+
+```python
+# In _verify_hash, extract sender from Credential.source and validate
+async def _verify_hash(self, payload: HashCredentialPayload, request: ChargeRequest) -> Receipt:
+    # ... existing code ...
+    
+    # Derive expected sender from credential source DID
+    expected_sender = None
+    if credential.source and credential.source.startswith("did:pkh:eip155:"):
+        expected_sender = credential.source.split(":")[-1]
+    
+    if not self._verify_transfer_logs(receipt_data, request, expected_sender):
+        raise VerificationError("...")
+```
+
+---
+
+### 🔴 HIGH: SSRF via User-Controlled Fee Payer URL
+
+**Files:** [`src/mpay/methods/tempo/schemas.py#L15`](file:///Users/brendanryan/tempo/mpay-python/src/mpay/methods/tempo/schemas.py#L15), [`src/mpay/methods/tempo/intents.py#L249-L259`](file:///Users/brendanryan/tempo/mpay-python/src/mpay/methods/tempo/intents.py#L249-L259)
+
+[FIX] **Issue:** `ChargeRequest.methodDetails.feePayerUrl` is used directly in an HTTP POST without validation. If developers build `request` from user input (as suggested in docs), this becomes an SSRF attack vector.
+
+**Recommendation:**
+
+```python
+# Add URL validation in ChargeRequest schema
+class MethodDetails(BaseModel):
+    feePayerUrl: str | None = None
+    
+    @field_validator("feePayerUrl")
+    @classmethod
+    def validate_fee_payer_url(cls, v: str | None) -> str | None:
+        if v is None:
+            return v
+        parsed = urlparse(v)
+        if parsed.scheme != "https":
+            raise ValueError("feePayerUrl must use HTTPS")
+        # Consider adding domain allowlist
+        return v
+```
+
+---
+
+## 2. Code Quality Issues
+
+[fix] ### 🟠 MEDIUM: Print Statements Instead of Logging
+
+**File:** [`src/mpay/methods/tempo/intents.py#L288`](file:///Users/brendanryan/tempo/mpay-python/src/mpay/methods/tempo/intents.py#L288), [`#L310`](file:///Users/brendanryan/tempo/mpay-python/src/mpay/methods/tempo/intents.py#L310)
+
+```python
+print(f"[mpay] Transaction submitted: {tx_hash}")
+print(f"[mpay] Receipt found on attempt {attempt + 1}")
+```
+
+**Issue:** SDK should never use `print()`. This pollutes stdout and cannot be controlled by users.
+
+**Recommendation:**
+
+```python
+import logging
+logger = logging.getLogger(__name__)
+
+logger.debug("Transaction submitted: %s", tx_hash)
+logger.debug("Receipt found on attempt %d", attempt + 1)
+```
+
+---
+
+[fix] ### 🟠 MEDIUM: Exception Handling Gap in Base64 Decode
+
+**File:** [`src/mpay/_parsing.py#L62-L63`](file:///Users/brendanryan/tempo/mpay-python/src/mpay/_parsing.py#L62-L63)
+
+```python
+except (ValueError, json.JSONDecodeError):
+    raise ParseError("Invalid base64 or JSON encoding") from None
+```
+
+**Issue:** `json.loads()` on bytes can raise `UnicodeDecodeError` which is not caught. While `binascii.Error` is a subclass of `ValueError` (covered), malformed UTF-8 will propagate as an unexpected exception.
+
+**Recommendation:**
+
+```python
+except (ValueError, json.JSONDecodeError, UnicodeDecodeError):
+    raise ParseError("Invalid base64 or JSON encoding") from None
+```
+
+---
+
+[fix]### 🟠 MEDIUM: Assert Used for Runtime Validation
+
+**File:** [`src/mpay/methods/tempo/keychain.py#L41`](file:///Users/brendanryan/tempo/mpay-python/src/mpay/methods/tempo/keychain.py#L41)
+
+```python
+assert len(keychain_sig) == KEYCHAIN_SIGNATURE_LENGTH
+```
+
+**Issue:** `assert` statements are removed when Python runs with `-O` optimization flag.
+
+**Recommendation:**
+
+```python
+if len(keychain_sig) != KEYCHAIN_SIGNATURE_LENGTH:
+    raise ValueError(f"Invalid keychain signature length: {len(keychain_sig)}")
+```
+
+---
+
+### 🟠 MEDIUM: VerificationError Not Caught in HTTP Flow
+
+**File:** [`src/mpay/server/verify.py#L75-L76`](file:///Users/brendanryan/tempo/mpay-python/src/mpay/server/verify.py#L75-L76)
+
+**Issue:** `intent.verify()` can raise `VerificationError`, but this is not caught. In the HTTP decorator flow, this will become a 500 error instead of returning a 402 challenge.
+
+**Recommendation:** Either catch and convert to a challenge, or document that `VerificationError` must be handled by the framework.
+
+---
+
+[fix -- this should use the chain id for the given intent] ### 🟠 MEDIUM: Hardcoded Chain ID in DID
+
+**File:** [`src/mpay/methods/tempo/client.py#L102`](file:///Users/brendanryan/tempo/mpay-python/src/mpay/methods/tempo/client.py#L102)
+
+```python
+source=f"did:pkh:eip155:1:{self.account.address}"
+```
+
+**Issue:** Chain ID is hardcoded to `1` (Ethereum mainnet) regardless of the actual Tempo chain being used. Tempo mainnet uses chain ID `42431`.
+
+**Recommendation:** Use the chain ID fetched from RPC:
+
+```python
+source=f"did:pkh:eip155:{chain_id}:{self.account.address}"
+```
+
+---
+
+## 3. Dead/Unnecessary Code
+
+[fix] ### 🟡 Unused Constant (Dead Code)
+
+**File:** [`src/mpay/methods/tempo/client.py#L18`](file:///Users/brendanryan/tempo/mpay-python/src/mpay/methods/tempo/client.py#L18)
+
+```python
+DEFAULT_FEE_PAYER_URL = "https://sponsor.moderato.tempo.xyz"
+```
+
+This constant is defined but never used in `client.py`. It's duplicated and used in `intents.py`.
+
+**Recommendation:** Remove from `client.py`.
+
+---
+
+[fix] ### 🟡 Realm Parameter Unused
+
+**File:** [`src/mpay/server/verify.py#L20`](file:///Users/brendanryan/tempo/mpay-python/src/mpay/server/verify.py#L20)
+
+The `realm` parameter is passed to `verify_or_challenge()` but never used in the function body.
+
+**Recommendation:** Either use it to bind challenges (recommended for security) or remove it from the signature.
+
+---
+
+[fix] ### 🟡 Duplicated Verification Logic
+
+**Files:**
+
+- [`src/mpay/extensions/mcp/decorator.py#L117-L175`](file:///Users/brendanryan/tempo/mpay-python/src/mpay/extensions/mcp/decorator.py#L117-L175)
+- [`src/mpay/extensions/mcp/verify.py#L55-L163`](file:///Users/brendanryan/tempo/mpay-python/src/mpay/extensions/mcp/verify.py#L55-L163)
+
+**Issue:** The MCP decorator duplicates the verification logic from `verify.py` instead of delegating to it.
+
+**Recommendation:** Refactor decorator to use `verify_or_challenge()` internally.
+
+---
+
+## 4. Design & API Issues
+
+[fix -- make a datetime] ### 🟡 Type Inconsistency: expires as String vs datetime
+
+**Files:**
+
+- [`src/mpay/__init__.py#L41`](file:///Users/brendanryan/tempo/mpay-python/src/mpay/__init__.py#L41): `Challenge.expires: str | None`
+- [`src/mpay/__init__.py#L94`](file:///Users/brendanryan/tempo/mpay-python/src/mpay/__init__.py#L94): `Receipt.timestamp: datetime`
+
+**Recommendation:** For consistency, either make `expires` a `datetime` or clearly document it's a raw ISO 8601 string.
+
+---
+
+### 🟡 Two Incompatible Method Protocols
+
+**Files:**
+
+- [`src/mpay/client/transport.py#L23-L31`](file:///Users/brendanryan/tempo/mpay-python/src/mpay/client/transport.py#L23-L31): `Method` with `name` + `create_credential()`
+- [`src/mpay/server/method.py#L12-L47`](file:///Users/brendanryan/tempo/mpay-python/src/mpay/server/method.py#L12-L47): `Method` with `name` + `intents` + `create_credential()`
+
+**Recommendation:** Define a shared protocol or rename to `ClientMethod`/`ServerMethod`.
+
+---
+
+### 🟡 Transport Retry May Fail with Streaming Bodies
+
+**File:** [`src/mpay/client/transport.py#L89-L97`](file:///Users/brendanryan/tempo/mpay-python/src/mpay/client/transport.py#L89-L97)
+
+```python
+retry_request = httpx.Request(
+    method=request.method,
+    url=request.url,
+    headers=headers,
+    stream=request.stream,  # Single-use stream!
+    extensions=request.extensions,
+)
+```
+
+**Issue:** httpx request streams are often single-use. If the original request body was streamed, the retry will fail or send empty body.
+
+**Recommendation:**
+
+- Document that streaming bodies are not supported with automatic payment handling
+- Or read the body into memory before retry
+
+---
+
+### 🟡 MCP Hard Dependency Not Optional
+
+**File:** [`src/mpay/extensions/mcp/errors.py#L15-L16`](file:///Users/brendanryan/tempo/mpay-python/src/mpay/extensions/mcp/errors.py#L15-L16)
+
+```python
+from mcp.shared.exceptions import McpError
+from mcp.types import ErrorData
+```
+
+**Issue:** Importing `mpay.extensions.mcp` fails if `mcp` package is not installed, even though it's listed as an optional dependency.
+
+**Recommendation:** Use lazy imports:
+
+```python
+def _get_mcp_deps():
+    try:
+        from mcp.shared.exceptions import McpError
+        from mcp.types import ErrorData
+        return McpError, ErrorData
+    except ImportError:
+        raise ImportError("Install mpay[mcp] for MCP support") from None
+```
+
+---
+
+[fix] ### 🟡 Address Regex Too Permissive
+
+**File:** [`src/mpay/methods/tempo/schemas.py#L25-L26`](file:///Users/brendanryan/tempo/mpay-python/src/mpay/methods/tempo/schemas.py#L25-L26)
+
+```python
+currency: Annotated[str, Field(pattern=r"^0x[a-fA-F0-9]+$")]
+recipient: Annotated[str, Field(pattern=r"^0x[a-fA-F0-9]+$")]
+```
+
+**Issue:** Accepts any length hex string. EVM addresses are exactly 40 hex characters.
+
+**Recommendation:**
+
+```python
+pattern=r"^0x[a-fA-F0-9]{40}$"
+```
+
+---
+
+[fix] ### 🟡 No Validation of root_account in Keychain
+
+**File:** [`src/mpay/methods/tempo/keychain.py#L38-L39`](file:///Users/brendanryan/tempo/mpay-python/src/mpay/methods/tempo/keychain.py#L38-L39)
+
+```python
+root_bytes = bytes.fromhex(root_account[2:])
+```
+
+**Issue:** No validation that `root_account` is a valid 42-character 0x-prefixed address. Will throw cryptic errors on invalid input.
+
+**Recommendation:**
+
+```python
+if not root_account.startswith("0x") or len(root_account) != 42:
+    raise ValueError(f"Invalid root account address: {root_account}")
+root_bytes = bytes.fromhex(root_account[2:])
+```
+
+---
+
+### 🟡 Signature Munging in Decorator Breaks Introspection
+
+**File:** [`src/mpay/server/decorator.py#L129-L130`](file:///Users/brendanryan/tempo/mpay-python/src/mpay/server/decorator.py#L129-L130)
+
+```python
+wrapper.__signature__ = new_sig
+del wrapper.__wrapped__
+```
+
+**Issue:** Deleting `__wrapped__` breaks introspection tools, framework features (dependency injection, OpenAPI generation), and debugging.
+
+**Recommendation:** Keep `__wrapped__` or provide alternative metadata for framework integration.
+
+---
+
+### 🟡 Error Messages May Leak RPC Internals
+
+**File:** [`src/mpay/methods/tempo/intents.py#L274-L282`](file:///Users/brendanryan/tempo/mpay-python/src/mpay/methods/tempo/intents.py#L274-L282)
+
+```python
+raise VerificationError(f"Transaction submission failed: {full_error}")
+```
+
+**Issue:** `error_data` from RPC nodes may contain debug traces, request echoes, or sensitive information.
+
+**Recommendation:** Sanitize error messages or only include RPC details in debug logs.
+
+---
+
+## 5. Positive Observations
+
+✅ **Clean Architecture:** Protocol-first design with clear separation of concerns  
+✅ **Good Type Hints:** Comprehensive use of modern Python typing (3.12+)  
+✅ **Immutable Types:** Core types use `frozen=True, slots=True` dataclasses  
+✅ **Comprehensive Tests:** 104 passing tests with good coverage  
+✅ **Consistent Code Style:** Passes ruff linting with no warnings  
+✅ **Good Documentation:** AGENTS.md and docstrings are thorough  
+✅ **Async Native:** Proper use of async/await patterns  
+
+---
+
+## Recommended Action Items
+
+### Priority 1 (Security - Fix Before Production)
+
+1. Implement challenge binding with HMAC digest and expiry validation
+2. Verify payer identity in Tempo intent by passing `expected_sender`
+3. Add URL validation/allowlist for `feePayerUrl`
+
+### Priority 2 (Quality - Fix Soon)
+
+1. Replace `print()` with `logging`
+2. Add `UnicodeDecodeError` to parsing exception handling
+3. Replace `assert` with explicit validation in keychain.py
+4. Remove dead `DEFAULT_FEE_PAYER_URL` constant from client.py
+
+### Priority 3 (Improvements)
+
+1. Fix hardcoded chain ID in DID construction
+2. Tighten address regex patterns to 40 hex chars
+3. Document streaming body limitation in transport
+4. Make MCP imports optional/lazy
+5. Unify Method protocols or rename to avoid confusion
+
+---
+
+## Estimated Effort
+
+| Priority | Items | Effort |
+|----------|-------|--------|
+| P1 Security | 3 | 1-2 days |
+| P2 Quality | 4 | 2-4 hours |
+| P3 Improvements | 5 | 4-8 hours |
+
+**Total:** 2-3 days for comprehensive fixes

--- a/DOCUMENTATION_AUDIT.md
+++ b/DOCUMENTATION_AUDIT.md
@@ -1,0 +1,354 @@
+# Documentation Audit Report: mpay-python
+
+**Audit Date:** 2026-01-28  
+**Auditor:** Amp  
+**Repository:** mpay-python  
+
+---
+
+## Executive Summary
+
+The mpay-python documentation is generally well-structured and comprehensive. The README provides good quick-start examples and API reference. However, several issues were identified:
+
+- **Missing example files** referenced in examples/README.md
+- **Stale documentation** in README that contradicts pyproject.toml
+- **Inconsistencies** between documented examples and actual code
+- **Minor inaccuracies** in type signatures documented vs actual implementation
+
+**Severity Breakdown:**
+
+- 🔴 Critical: 1
+- 🟠 High: 3  
+- 🟡 Medium: 5
+- 🟢 Low: 4
+
+---
+
+## Critical Issues
+
+[fix -- deleted unused files] ### 1. 🔴 Missing Example Files in examples/README.md
+
+**Location:** [examples/README.md](file:///Users/brendanryan/tempo/mpay-python/examples/README.md#L17-L20)
+
+**Issue:** The examples/README.md references documentation files that do not exist:
+
+- `fastapi-server.md` - **Does not exist**
+- `starlette-server.md` - **Does not exist**  
+- `mcp-server.md` - **Does not exist** (directory `mcp-server/` exists with README.md inside)
+
+**Evidence:**
+
+```markdown
+| [fastapi-server.md](fastapi-server.md) | Server-side payment protection with FastAPI |
+| [starlette-server.md](starlette-server.md) | Server-side payment protection with Starlette |
+| [mcp-server.md](mcp-server.md) | MCP server patterns (documentation) |
+```
+
+Only these markdown files exist in examples/:
+
+- `README.md`
+- `custom-intents.md`
+- `httpx-client.md`
+
+**Fix Required:** Either create the missing files or update the README to reflect actual examples.
+
+---
+
+## High Severity Issues
+
+[FIX -- just say minimal dependancies] ### 2. 🟠 README Claims "Core has no dependencies" - Incorrect
+
+**Location:** [README.md#L10](file:///Users/brendanryan/tempo/mpay-python/README.md#L10)
+
+**Issue:** The README states:
+> **Minimal dependencies** — Core has no dependencies; extras add what you need
+
+However, pyproject.toml shows core has a dependency:
+
+```toml
+dependencies = [
+    "httpx>=0.27",
+]
+```
+
+**Fix Required:** Update to: "Minimal dependencies — Core requires only httpx; extras add what you need"
+
+---
+
+[fix] ### 3. 🟠 Receipt Type Documentation Mismatch
+
+**Location:** [README.md#L164-L172](file:///Users/brendanryan/tempo/mpay-python/README.md#L164-L172)
+
+**Issue:** The README shows Receipt timestamp as a string:
+
+```python
+receipt = Receipt(
+    status="success",
+    timestamp="2024-01-20T12:00:00Z",  # String in docs
+    reference="0x...",
+)
+```
+
+But the actual implementation in `__init__.py` uses `datetime`:
+
+```python
+@dataclass(frozen=True, slots=True)
+class Receipt:
+    status: Literal["success", "failed"]
+    timestamp: datetime  # datetime object, not string
+    reference: str
+```
+
+The docstring in [\_\_init\_\_.py#L84-L91](file:///Users/brendanryan/tempo/mpay-python/src/mpay/__init__.py#L84-L91) is correct, but README is wrong.
+
+**Fix Required:** Update README example:
+
+```python
+from datetime import datetime, UTC
+
+receipt = Receipt(
+    status="success",
+    timestamp=datetime.now(UTC),
+    reference="0x...",
+)
+```
+
+---
+
+[FIX] ### 4. 🟠 Server Module Docstring References Non-existent `client` Parameter
+
+**Location:** [src/mpay/server/\_\_init\_\_.py#L9](file:///Users/brendanryan/tempo/mpay-python/src/mpay/server/__init__.py#L9)
+
+**Issue:** The module docstring shows:
+
+```python
+intent=ChargeIntent(client),
+```
+
+But `ChargeIntent` takes `rpc_url`, not `client`:
+
+```python
+class ChargeIntent:
+    def __init__(
+        self,
+        rpc_url: str,
+        http_client: httpx.AsyncClient | None = None,
+        ...
+    )
+```
+
+**Fix Required:** Update docstring to:
+
+```python
+intent=ChargeIntent(rpc_url="https://rpc.tempo.xyz"),
+```
+
+---
+
+## Medium Severity Issues
+
+[FIX] ### 5. 🟡 Tempo Method Docstring References Non-existent `client` Parameter
+
+**Location:** [src/mpay/methods/tempo/\_\_init\_\_.py#L18-L19](file:///Users/brendanryan/tempo/mpay-python/src/mpay/methods/tempo/__init__.py#L18-L19)
+
+**Issue:** Same issue as #4:
+
+```python
+client = create_client(...)
+intent = ChargeIntent(client)
+```
+
+`create_client` is not defined anywhere and `ChargeIntent` takes `rpc_url`.
+
+---
+
+[FIX -- use rpc.testnet...] ### 6. 🟡 RPC URL Inconsistency Across Examples
+
+**Issue:** Different RPC URLs are used inconsistently:
+
+| Location | URL |
+|----------|-----|
+| README.md | `https://rpc.tempo.xyz` |
+| httpx-client.md | `https://rpc.testnet.tempo.xyz/` |
+| fetch example | `https://rpc.testnet.tempo.xyz/` (default) |
+| api-server example | `https://rpc.testnet.tempo.xyz/` (default) |
+| TempoMethod default | `https://rpc.tempo.xyz` |
+
+The README uses mainnet URL but most examples default to testnet. This could confuse users.
+
+**Recommendation:** Be consistent - use testnet in all examples with a note that production should use mainnet.
+
+---
+
+[FIX] ### 7. 🟡 custom-intents.md Uses Non-existent `Receipt.success()` Parameters
+
+**Location:** [examples/custom-intents.md#L52](file:///Users/brendanryan/tempo/mpay-python/examples/custom-intents.md#L52)
+
+**Issue:** Example shows:
+
+```python
+return Receipt.success(reference="tx_123")
+```
+
+This is correct, but earlier in the same file (line 30-34) shows full constructor without using the convenience method:
+
+```python
+return Receipt(
+    status="success",
+    timestamp=datetime.now(UTC).isoformat(),  # Wrong - should be datetime object
+    reference="tx_123",
+)
+```
+
+The `.isoformat()` would pass a string, but Receipt expects `datetime`.
+
+---
+
+[FIX] ### 8. 🟡 Missing MCP Extension Documentation
+
+**Issue:** The `mpay.extensions.mcp` module has excellent docstrings, but:
+
+1. It's not mentioned in the main README.md
+2. No top-level documentation covers the MCP integration capability
+3. The `[mcp]` optional dependency is in pyproject.toml but not documented in README installation section
+
+**Fix Required:** Add to README:
+
+```bash
+pip install mpay[mcp]            # With MCP (Model Context Protocol) support
+```
+
+---
+
+[FIX] ### 9. 🟡 api-server README Python Version Mismatch
+
+**Location:** [examples/api-server/README.md#L12](file:///Users/brendanryan/tempo/mpay-python/examples/api-server/README.md#L12)
+
+**Issue:** States "Python 3.10+" but pyproject.toml requires:
+
+```toml
+requires-python = ">=3.12"
+```
+
+---
+
+## Low Severity Issues
+
+[FIX -- align with the readme] ### 10. 🟢 pyproject.toml Description vs README Title
+
+**Issue:**
+
+- pyproject.toml: `description = "HTTP 402 Payment Authentication for Python"`
+- README.md title: "Python SDK for the Machine Payments Protocol (MPP)"
+
+Minor inconsistency in naming/branding.
+
+---
+
+### 11. 🟢 AGENTS.md is Duplicate of README.md
+
+**Location:** [AGENTS.md](file:///Users/brendanryan/tempo/mpay-python/AGENTS.md)
+
+**Issue:** AGENTS.md appears to be an exact copy of README.md. While this may be intentional for agent tooling, any updates to README should be mirrored.
+
+---
+
+[FIX] ### 12. 🟢 ChargeIntent Print Statements
+
+**Location:** [src/mpay/methods/tempo/intents.py#L288, L310](file:///Users/brendanryan/tempo/mpay-python/src/mpay/methods/tempo/intents.py#L288)
+
+**Issue:** Production code contains `print()` statements:
+
+```python
+print(f"[mpay] Transaction submitted: {tx_hash}")
+print(f"[mpay] Receipt found on attempt {attempt + 1}")
+```
+
+These should use logging instead. Not strictly documentation, but affects user experience.
+
+---
+
+### 13. 🟢 Stale Year in README Receipt Example
+
+**Location:** [README.md#L167](file:///Users/brendanryan/tempo/mpay-python/README.md#L167)
+
+**Issue:** Example uses `2024-01-20` which is outdated. Minor, but examples should feel current.
+
+---
+
+## Documentation Completeness Checklist
+
+| Item | Status | Notes |
+|------|--------|-------|
+| README Quick Start - Server | ✅ | Comprehensive |
+| README Quick Start - Client | ✅ | 4 patterns documented |
+| API Reference - Core Types | ⚠️ | Receipt timestamp type wrong |
+| API Reference - Server | ✅ | Well documented |
+| API Reference - Tempo Method | ✅ | Good coverage |
+| Installation Instructions | ⚠️ | Missing `[mcp]` extra |
+| Development Setup | ✅ | Clear make commands |
+| Examples - Runnable | ✅ | fetch/, mcp-server/, api-server/ |
+| Examples - Documentation | ❌ | 3 missing files referenced |
+| Docstrings - Core Types | ✅ | Excellent with examples |
+| Docstrings - Server | ⚠️ | Minor param errors |
+| Docstrings - Client | ✅ | Good coverage |
+| Docstrings - Tempo | ⚠️ | Constructor example wrong |
+| Docstrings - MCP | ✅ | Excellent |
+| Type Hints | ✅ | py.typed marker present |
+| License | ✅ | Dual MIT/Apache-2.0 |
+
+---
+
+## Recommendations
+
+### Immediate Actions (Before Release)
+
+1. **Fix examples/README.md** - Remove or create the 3 missing documentation files
+2. **Fix Receipt timestamp examples** - Use `datetime` object, not string
+3. **Fix ChargeIntent constructor examples** - Use `rpc_url=` not `client`
+4. **Add `[mcp]` to installation docs**
+
+### Near-term Improvements
+
+1. Standardize RPC URLs across examples (use testnet consistently)
+2. Replace print statements with proper logging
+3. Consider generating API docs from docstrings (Sphinx/mkdocs)
+4. Add a CHANGELOG.md
+
+### Optional Enhancements
+
+1. Add architecture diagram showing Challenge → Credential → Receipt flow
+2. Add troubleshooting section for common errors
+3. Document the SDK spec compliance (link to mpay-sdks/SPEC.md)
+
+---
+
+## SDK Spec Compliance Check
+
+Per [mpay-sdks/SPEC.md](file:///Users/brendanryan/tempo/mpay-sdks/SPEC.md), the SDK must implement:
+
+| Requirement | Status | Notes |
+|-------------|--------|-------|
+| Core types (Challenge, Credential, Receipt) | ✅ | Implemented |
+| 402 Transport | ✅ | PaymentTransport |
+| 402 Retry Scheme | ✅ | In transport.py |
+| Challenge Generation | ✅ | verify_or_challenge creates challenges |
+| Verification | ✅ | Intent.verify implemented |
+| tempo method | ✅ | Full implementation |
+| charge intent | ✅ | Full implementation |
+| httpx integration | ✅ | AsyncClient transport |
+| @requires_payment decorator | ✅ | For FastAPI/Starlette |
+
+**Spec Compliance: PASS**
+
+---
+
+## Summary
+
+The mpay-python SDK has solid documentation overall, with comprehensive docstrings and working examples. The main issues are:
+
+1. **Broken links** in examples/README.md (3 missing files)
+2. **Type inconsistencies** (Receipt timestamp documented as string, should be datetime)
+3. **Stale constructor examples** (ChargeIntent(client) should be ChargeIntent(rpc_url=...))
+
+Addressing the Critical and High severity issues should be prioritized before any release.

--- a/docs/SDK_COMPARISON_REPORT.md
+++ b/docs/SDK_COMPARISON_REPORT.md
@@ -1,0 +1,508 @@
+# mpay SDK Comparison: Python vs TypeScript
+
+## Executive Summary
+
+This report compares the **mpay-python** SDK against the **mpay TypeScript** SDK to identify divergences in functionality, interface design, and architectural patterns.
+
+**Key Finding:** The TypeScript SDK is schema-driven with stateless HMAC-bound challenge verification, while Python is simpler but currently lacks several security/correctness properties—notably, credentials are not cryptographically bound to issued challenges.
+
+---
+
+## Object Graph: Side-by-Side Comparison
+
+### Python SDK Object Graph
+
+```
+┌──────────────────────────────────────────────────────────────────────────────┐
+│                              mpay-python                                      │
+├──────────────────────────────────────────────────────────────────────────────┤
+│                                                                              │
+│  ┌─────────────────────────────────────────────────────────────────────────┐ │
+│  │                          CORE TYPES                                      │ │
+│  │                                                                         │ │
+│  │  ┌─────────────┐   ┌─────────────┐   ┌─────────────┐                   │ │
+│  │  │  Challenge  │   │  Credential │   │   Receipt   │                   │ │
+│  │  │ (dataclass) │   │ (dataclass) │   │ (dataclass) │                   │ │
+│  │  ├─────────────┤   ├─────────────┤   ├─────────────┤                   │ │
+│  │  │ id: str     │   │ id: str     │◄──┤ status      │                   │ │
+│  │  │ method: str │   │ payload     │   │ timestamp   │                   │ │
+│  │  │ intent: str │   │ source?     │   │ reference   │                   │ │
+│  │  │ request     │   └─────────────┘   └─────────────┘                   │ │
+│  │  │ digest?     │         │                  ▲                          │ │
+│  │  │ expires?    │         │                  │                          │ │
+│  │  │ description?│         │                  │                          │ │
+│  │  └─────────────┘         │                  │                          │ │
+│  │        │                 │                  │                          │ │
+│  │        ▼                 ▼                  │                          │ │
+│  │  ┌─────────────────────────────────────────────────────────────────┐   │ │
+│  │  │                    WIRE FORMAT                                   │   │ │
+│  │  │  WWW-Authenticate ◄───── _parsing.py ─────► Authorization       │   │ │
+│  │  │  Payment-Receipt ◄─────────────────────────►                    │   │ │
+│  │  └─────────────────────────────────────────────────────────────────┘   │ │
+│  └─────────────────────────────────────────────────────────────────────────┘ │
+│                                                                              │
+│  ┌─────────────────────────────────────────────────────────────────────────┐ │
+│  │                          CLIENT                                          │ │
+│  │                                                                         │ │
+│  │  ┌───────────────────┐      ┌─────────────────────────────────────┐    │ │
+│  │  │      Client       │      │         PaymentTransport            │    │ │
+│  │  │ (async context)   │─────►│     (httpx.AsyncBaseTransport)      │    │ │
+│  │  ├───────────────────┤      ├─────────────────────────────────────┤    │ │
+│  │  │ get()             │      │ Wraps inner transport               │    │ │
+│  │  │ post()            │      │ Auto-retries on 402                 │    │ │
+│  │  │ request()         │      │ Parses WWW-Authenticate             │    │ │
+│  │  └───────────────────┘      │ Routes to Method.create_credential  │    │ │
+│  │         │                   └──────────────────┬──────────────────┘    │ │
+│  │         │                                      │                       │ │
+│  │         ▼                                      ▼                       │ │
+│  │  ┌───────────────────────────────────────────────────────────────┐     │ │
+│  │  │                   Method (Protocol)                           │     │ │
+│  │  │                                                               │     │ │
+│  │  │   name: str                                                   │     │ │
+│  │  │   create_credential(challenge) -> Credential                  │     │ │
+│  │  └───────────────────────────────────────────────────────────────┘     │ │
+│  └─────────────────────────────────────────────────────────────────────────┘ │
+│                                                                              │
+│  ┌─────────────────────────────────────────────────────────────────────────┐ │
+│  │                          SERVER                                          │ │
+│  │                                                                         │ │
+│  │  ┌───────────────────────────────────────────────────────────────┐     │ │
+│  │  │               verify_or_challenge()                           │     │ │
+│  │  │                                                               │     │ │
+│  │  │  authorization ───► parse ───► Intent.verify() ───► Receipt  │     │ │
+│  │  │       │                             │                         │     │ │
+│  │  │       └─► None? ────────────────────┼─► Challenge (402)       │     │ │
+│  │  └───────────────────────────────────────────────────────────────┘     │ │
+│  │                          │                                              │ │
+│  │                          ▼                                              │ │
+│  │  ┌───────────────────────────────────────────────────────────────┐     │ │
+│  │  │               @requires_payment                               │     │ │
+│  │  │                                                               │     │ │
+│  │  │  Decorator for Starlette/FastAPI/Django endpoints            │     │ │
+│  │  │  Extracts Authorization, calls verify_or_challenge            │     │ │
+│  │  │  Returns 402 or calls handler with (credential, receipt)      │     │ │
+│  │  └───────────────────────────────────────────────────────────────┘     │ │
+│  │                          │                                              │ │
+│  │                          ▼                                              │ │
+│  │  ┌───────────────────────────────────────────────────────────────┐     │ │
+│  │  │                    Intent (Protocol)                          │     │ │
+│  │  │                                                               │     │ │
+│  │  │   name: str                                                   │     │ │
+│  │  │   verify(credential, request) -> Receipt                      │     │ │
+│  │  └───────────────────────────────────────────────────────────────┘     │ │
+│  └─────────────────────────────────────────────────────────────────────────┘ │
+│                                                                              │
+│  ┌─────────────────────────────────────────────────────────────────────────┐ │
+│  │                     TEMPO METHOD                                         │ │
+│  │                                                                         │ │
+│  │  ┌──────────────────────┐    ┌──────────────────────┐                  │ │
+│  │  │     TempoMethod      │    │    ChargeIntent      │                  │ │
+│  │  ├──────────────────────┤    ├──────────────────────┤                  │ │
+│  │  │ name = "tempo"       │    │ name = "charge"      │                  │ │
+│  │  │ account: TempoAccount│    │ rpc_url: str         │                  │ │
+│  │  │ rpc_url: str         │    ├──────────────────────┤                  │ │
+│  │  ├──────────────────────┤    │ verify()             │                  │ │
+│  │  │ create_credential()  │    │ _verify_hash()       │                  │ │
+│  │  │ _build_tempo_transfer│    │ _verify_transaction()│                  │ │
+│  │  └──────────────────────┘    │ _verify_transfer_logs│                  │ │
+│  │                              └──────────────────────┘                  │ │
+│  │                                                                         │ │
+│  │  Supported credential payload types:                                    │ │
+│  │    • hash: { type: "hash", hash: "0x..." }                             │ │
+│  │    • transaction: { type: "transaction", signature: "0x..." }          │ │
+│  └─────────────────────────────────────────────────────────────────────────┘ │
+│                                                                              │
+│  ┌─────────────────────────────────────────────────────────────────────────┐ │
+│  │                     EXTENSIONS                                           │ │
+│  │                                                                         │ │
+│  │  extensions/mcp/                                                        │ │
+│  │    • MCP transport support                                              │ │
+│  │    • @requires_mcp_payment decorator                                    │ │
+│  └─────────────────────────────────────────────────────────────────────────┘ │
+└──────────────────────────────────────────────────────────────────────────────┘
+```
+
+### TypeScript SDK Object Graph
+
+```
+┌──────────────────────────────────────────────────────────────────────────────┐
+│                              mpay (TypeScript)                                │
+├──────────────────────────────────────────────────────────────────────────────┤
+│                                                                              │
+│  ┌─────────────────────────────────────────────────────────────────────────┐ │
+│  │                          CORE TYPES + SCHEMAS                            │ │
+│  │                                                                         │ │
+│  │  ┌─────────────────┐  ┌─────────────────┐  ┌─────────────────┐         │ │
+│  │  │    Challenge    │  │   Credential    │  │     Receipt     │         │ │
+│  │  │   (Zod schema)  │  │   (Zod-aware)   │  │   (Zod schema)  │         │ │
+│  │  ├─────────────────┤  ├─────────────────┤  ├─────────────────┤         │ │
+│  │  │ id: string      │  │ challenge ◄────┼──┤ method: string  │         │ │
+│  │  │ realm: string   │  │ (full embed)   │  │ status          │         │ │
+│  │  │ method: string  │  │ payload: T     │  │ timestamp       │         │ │
+│  │  │ intent: string  │  │ source?: DID   │  │ reference       │         │ │
+│  │  │ request: T      │  └─────────────────┘  └─────────────────┘         │ │
+│  │  │ digest?: ^sha-256│                                                   │ │
+│  │  │ expires?: ISO   │                                                   │ │
+│  │  │ description?    │                                                   │ │
+│  │  ├─────────────────┤                                                   │ │
+│  │  │ HMAC-bound IDs: │                                                   │ │
+│  │  │ from({secretKey})                                                   │ │
+│  │  │ verify({secretKey})                                                 │ │
+│  │  └─────────────────┘                                                   │ │
+│  └─────────────────────────────────────────────────────────────────────────┘ │
+│                                                                              │
+│  ┌─────────────────────────────────────────────────────────────────────────┐ │
+│  │                       INTENT ARCHITECTURE                                │ │
+│  │                                                                         │ │
+│  │  ┌──────────────────────┐        ┌────────────────────────────────┐    │ │
+│  │  │       Intent         │        │        MethodIntent            │    │ │
+│  │  │ (method-agnostic)    │◄───────│    (method-specific)           │    │ │
+│  │  ├──────────────────────┤        ├────────────────────────────────┤    │ │
+│  │  │ name: string         │        │ method: string                 │    │ │
+│  │  │ schema.request       │        │ name: string                   │    │ │
+│  │  └──────────────────────┘        │ schema.credential.payload      │    │ │
+│  │         │                        │ schema.request (merged)        │    │ │
+│  │         ├── Intent.charge        │   - requires: ['recipient']    │    │ │
+│  │         ├── Intent.authorize     │   - methodDetails: {...}       │    │ │
+│  │         └── Intent.subscription  └────────────────────────────────┘    │ │
+│  │                                           │                            │ │
+│  │                                           ├── tempo/charge             │ │
+│  │                                           ├── tempo/authorize          │ │
+│  │                                           └── tempo/subscription       │ │
+│  └─────────────────────────────────────────────────────────────────────────┘ │
+│                                                                              │
+│  ┌─────────────────────────────────────────────────────────────────────────┐ │
+│  │                          METHOD SYSTEM                                   │ │
+│  │                                                                         │ │
+│  │  ┌────────────────────────────────────────────────────────────────┐    │ │
+│  │  │                    Method (base)                                │    │ │
+│  │  │                                                                │    │ │
+│  │  │   name: string                                                 │    │ │
+│  │  │   intents: { charge, authorize, subscription }                 │    │ │
+│  │  └─────────────────┬──────────────────────┬───────────────────────┘    │ │
+│  │                    │                      │                            │ │
+│  │      ┌─────────────▼────────────┐ ┌──────▼─────────────────┐          │ │
+│  │      │  Method.toClient(...)    │ │ Method.toServer(...)   │          │ │
+│  │      ├──────────────────────────┤ ├────────────────────────┤          │ │
+│  │      │ context?: ZodSchema      │ │ context?: ZodSchema    │          │ │
+│  │      │ createCredential({       │ │ request?(options)      │          │ │
+│  │      │   challenge, context     │ │ verify({credential,    │          │ │
+│  │      │ }) -> string             │ │   request, context})   │          │ │
+│  │      └──────────────────────────┘ │   -> Receipt           │          │ │
+│  │                                   └────────────────────────┘          │ │
+│  └─────────────────────────────────────────────────────────────────────────┘ │
+│                                                                              │
+│  ┌─────────────────────────────────────────────────────────────────────────┐ │
+│  │                          CLIENT                                          │ │
+│  │                                                                         │ │
+│  │  ┌────────────────────────────────────────────────────────────────┐    │ │
+│  │  │                  Mpay.create({ methods, transport })            │    │ │
+│  │  ├────────────────────────────────────────────────────────────────┤    │ │
+│  │  │ methods: [tempo(...), ...]                                     │    │ │
+│  │  │ transport: http() | mcp()                                      │    │ │
+│  │  ├────────────────────────────────────────────────────────────────┤    │ │
+│  │  │ createCredential(response, context?) -> Promise<string>        │    │ │
+│  │  │   - transport.getChallenge(response)                           │    │ │
+│  │  │   - route to method.createCredential                           │    │ │
+│  │  └────────────────────────────────────────────────────────────────┘    │ │
+│  │                          │                                              │ │
+│  │                          ▼                                              │ │
+│  │  ┌────────────────────────────────────────────────────────────────┐    │ │
+│  │  │              Transport (abstraction)                           │    │ │
+│  │  ├────────────────────────────────────────────────────────────────┤    │ │
+│  │  │ isPaymentRequired(response)                                    │    │ │
+│  │  │ getChallenge(response) -> Challenge                            │    │ │
+│  │  │ setCredential(request, credential) -> request                  │    │ │
+│  │  ├────────────────────────────────────────────────────────────────┤    │ │
+│  │  │ • Transport.http() - fetch/Response                            │    │ │
+│  │  │ • Transport.mcp()  - JSON-RPC                                  │    │ │
+│  │  └────────────────────────────────────────────────────────────────┘    │ │
+│  └─────────────────────────────────────────────────────────────────────────┘ │
+│                                                                              │
+│  ┌─────────────────────────────────────────────────────────────────────────┐ │
+│  │                          SERVER                                          │ │
+│  │                                                                         │ │
+│  │  ┌────────────────────────────────────────────────────────────────┐    │ │
+│  │  │         Mpay.create({ method, realm, secretKey, transport })   │    │ │
+│  │  ├────────────────────────────────────────────────────────────────┤    │ │
+│  │  │ Returns handler with per-intent functions:                     │    │ │
+│  │  │   payment.charge({ request, expires?, description? })          │    │ │
+│  │  │   payment.authorize({ request, ... })                          │    │ │
+│  │  │   payment.subscription({ request, ... })                       │    │ │
+│  │  ├────────────────────────────────────────────────────────────────┤    │ │
+│  │  │ Each intent function:                                          │    │ │
+│  │  │   1. Recomputes challenge with HMAC-bound ID                   │    │ │
+│  │  │   2. Extracts credential via transport                         │    │ │
+│  │  │   3. Validates challenge HMAC (stateless!)                     │    │ │
+│  │  │   4. Validates payload against intent schema                   │    │ │
+│  │  │   5. Calls method.verify()                                     │    │ │
+│  │  │   6. Returns { status: 402, challenge } or                     │    │ │
+│  │  │              { status: 200, withReceipt(response) }            │    │ │
+│  │  └────────────────────────────────────────────────────────────────┘    │ │
+│  │                          │                                              │ │
+│  │                          ▼                                              │ │
+│  │  ┌────────────────────────────────────────────────────────────────┐    │ │
+│  │  │              Server Transport (abstraction)                    │    │ │
+│  │  ├────────────────────────────────────────────────────────────────┤    │ │
+│  │  │ getCredential(input) -> Credential | null                      │    │ │
+│  │  │ respondChallenge({ challenge, input, error })                  │    │ │
+│  │  │ respondReceipt({ receipt, response, challengeId })             │    │ │
+│  │  └────────────────────────────────────────────────────────────────┘    │ │
+│  └─────────────────────────────────────────────────────────────────────────┘ │
+│                                                                              │
+│  ┌─────────────────────────────────────────────────────────────────────────┐ │
+│  │                     TEMPO METHOD                                         │ │
+│  │                                                                         │ │
+│  │  ┌─────────────────────────────────────────────────────────────────┐   │ │
+│  │  │                     Intents.ts                                   │   │ │
+│  │  │                                                                 │   │ │
+│  │  │  tempo/charge = MethodIntent.fromIntent(Intent.charge, {        │   │ │
+│  │  │    method: 'tempo',                                             │   │ │
+│  │  │    schema: {                                                    │   │ │
+│  │  │      credential.payload: { hash | transaction }                 │   │ │
+│  │  │      request: {                                                 │   │ │
+│  │  │        requires: ['recipient', 'expires'],                      │   │ │
+│  │  │        methodDetails: { chainId?, feePayer?, memo? }            │   │ │
+│  │  │      }                                                          │   │ │
+│  │  │    }                                                            │   │ │
+│  │  │  })                                                             │   │ │
+│  │  │                                                                 │   │ │
+│  │  │  tempo/authorize = MethodIntent.fromIntent(Intent.authorize...) │   │ │
+│  │  │  tempo/subscription = MethodIntent.fromIntent(...)              │   │ │
+│  │  └─────────────────────────────────────────────────────────────────┘   │ │
+│  │                                                                         │ │
+│  │  ┌──────────────────────┐    ┌──────────────────────┐                  │ │
+│  │  │  tempo/client/Method │    │ tempo/server/Method  │                  │ │
+│  │  ├──────────────────────┤    ├──────────────────────┤                  │ │
+│  │  │ Uses viem for:       │    │ Uses viem for:       │                  │ │
+│  │  │ - prepareTransactionRequest                     │ │                  │ │
+│  │  │ - signTransaction    │    │ - parseEventLogs    │                  │ │
+│  │  │                      │    │ - getTransactionReceipt               │ │
+│  │  │ Supports:            │    │ - sendRawTransactionSync              │ │
+│  │  │ - Per-call account   │    │                      │                  │ │
+│  │  │   context            │    │ Validates:           │                  │ │
+│  │  │                      │    │ - Transfer logs      │                  │ │
+│  │  │                      │    │ - TransferWithMemo   │                  │ │
+│  │  │                      │    │ - Transaction struct │                  │ │
+│  │  │                      │    │   (preflight check)  │                  │ │
+│  │  └──────────────────────┘    └──────────────────────┘                  │ │
+│  └─────────────────────────────────────────────────────────────────────────┘ │
+└──────────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Feature Comparison Matrix
+
+| Feature | Python SDK | TypeScript SDK | Impact |
+|---------|------------|----------------|--------|
+| **Core Types** | | | |
+| Challenge dataclass/type | ✅ dataclass | ✅ Zod schema | TS has runtime validation |
+| Credential embeds challenge | ❌ ID only | ✅ Full challenge | **Security gap in Python** |
+| Receipt includes method | ❌ | ✅ | TS has richer receipts |
+| realm as first-class field | ❌ (serialize param) | ✅ | TS more complete |
+| HMAC-bound challenge IDs | ❌ Random IDs | ✅ `Challenge.verify()` | **Security gap in Python** |
+| **Intents** | | | |
+| charge intent | ✅ | ✅ | |
+| authorize intent | ❌ | ✅ | Python missing |
+| subscription intent | ❌ | ✅ | Python missing |
+| Schema-driven intents | ❌ Protocol only | ✅ MethodIntent.fromIntent | TS more type-safe |
+| methodDetails support | Partial | ✅ Full | Python lacks memo validation |
+| **Client** | | | |
+| Auto-retry on 402 | ✅ PaymentTransport | ❌ Manual retry | Python more ergonomic |
+| HTTP transport | ✅ httpx | ✅ fetch | |
+| MCP transport | ✅ extensions/mcp | ✅ Transport.mcp() | |
+| Per-call context schema | ❌ | ✅ Zod | |
+| **Server** | | | |
+| Main entry point | `verify_or_challenge()` | `Mpay.create()` | Different patterns |
+| Decorator support | ✅ `@requires_payment` | ❌ | Python more ergonomic |
+| Stateless verification | ❌ | ✅ HMAC | **Security gap in Python** |
+| Structured errors | ❌ | ✅ Error taxonomy | TS more explicit |
+| Node.js HTTP listener | N/A | ✅ `toNodeListener()` | |
+| **Tempo Method** | | | |
+| hash credential | ✅ | ✅ | |
+| transaction credential | ✅ | ✅ | |
+| keyAuthorization credential | ❌ | ✅ (authorize) | Python missing |
+| memo (TransferWithMemo) | ❌ | ✅ | **Missing in Python** |
+| fee payer (server-side) | Service URL proxy | Local signing | Different approaches |
+| Preflight tx validation | ❌ Post-receipt | ✅ Pre-send | TS safer |
+
+---
+
+## Critical Divergences
+
+### 1. Stateless Challenge Verification (CRITICAL)
+
+**TypeScript:**
+```typescript
+// Challenge ID is HMAC-SHA256(secret, realm|method|intent|request|expires|digest)
+const challenge = Challenge.from({ ..., secretKey })
+
+// Verification without database lookup
+Challenge.verify(credential.challenge, { secretKey }) // true/false
+```
+
+**Python:**
+```python
+# Challenge ID is random
+challenge = Challenge(id=secrets.token_urlsafe(16), ...)
+
+# No verification mechanism - id is never validated!
+```
+
+**Risk:** Python cannot verify that a credential was issued by this server or for the same request parameters.
+
+### 2. Credential Structure
+
+**TypeScript Credential (wire format):**
+```json
+{
+  "challenge": { "id": "...", "realm": "...", "method": "...", ... },
+  "payload": { "signature": "0x..." },
+  "source": "did:pkh:eip155:1:0x..."
+}
+```
+
+**Python Credential (wire format):**
+```json
+{
+  "id": "...",        // Just the challenge ID, not full challenge
+  "payload": {...},
+  "source": "..."
+}
+```
+
+**Risk:** Python credentials require server-side state or trust client's request parameters.
+
+### 3. Intent Schema Validation
+
+**TypeScript:**
+```typescript
+// Centralized schema with requires + methodDetails
+const tempoCharge = MethodIntent.fromIntent(Intent.charge, {
+  method: 'tempo',
+  schema: {
+    credential: { payload: z.discriminatedUnion('type', [...]) },
+    request: {
+      requires: ['recipient', 'expires'],
+      methodDetails: z.object({ chainId, feePayer, memo })
+    }
+  }
+})
+```
+
+**Python:**
+```python
+# Schema lives in intent implementation
+class ChargeIntent:
+    name = "charge"
+    
+    async def verify(self, credential, request):
+        req = ChargeRequest.model_validate(request)  # Pydantic inside
+```
+
+**Impact:** TS provides type-safe contracts at framework level; Python relies on implementation correctness.
+
+### 4. Transaction Validation Timing
+
+**TypeScript (pre-send validation):**
+```typescript
+// Validate before sending
+if (calls.length !== 1) throw new MismatchError(...)
+if (!Address.isEqual(call.to, currency)) throw new MismatchError(...)
+const [to, amount] = AbiFunction.decodeData(transfer, call.data)
+// ... then send
+```
+
+**Python (post-receipt validation):**
+```python
+# Send first, validate logs after
+tx_hash = result.get("result")
+# ... poll for receipt ...
+if not self._verify_transfer_logs(receipt_data, request):
+    raise VerificationError(...)
+```
+
+**Impact:** TS rejects bad transactions earlier; Python may broadcast invalid transactions.
+
+---
+
+## API Ergonomics Comparison
+
+### Client Usage
+
+**Python (automatic retry - very ergonomic):**
+```python
+async with Client(methods=[tempo(account=account)]) as client:
+    response = await client.get("https://api.example.com/resource")
+    # 402 handling is automatic!
+```
+
+**TypeScript (manual retry):**
+```typescript
+const response = await fetch('/resource')
+if (response.status === 402) {
+    const credential = await mpay.createCredential(response, { account })
+    await fetch('/resource', { headers: { Authorization: credential } })
+}
+```
+
+### Server Usage
+
+**Python (decorator - very ergonomic):**
+```python
+@requires_payment(
+    intent=ChargeIntent(rpc_url="..."),
+    request={"amount": "1000", ...},
+    realm="api.example.com",
+)
+async def handler(request, credential, receipt):
+    return {"data": "..."}
+```
+
+**TypeScript (handler factory):**
+```typescript
+const payment = Mpay.create({ method: tempo(...), realm: "...", secretKey })
+
+async function handler(req: Request) {
+    const result = await payment.charge({ request: {...} })(req)
+    if (result.status === 402) return result.challenge
+    return result.withReceipt(Response.json({ data: "..." }))
+}
+```
+
+---
+
+## Recommendations
+
+### For Python SDK (Priority Order)
+
+1. **Add HMAC-bound challenge IDs** - Critical security improvement
+2. **Embed full challenge in credential** - Enables stateless verification  
+3. **Add `realm` as first-class Challenge field** - Protocol alignment
+4. **Add authorize/subscription intents** - Feature parity
+5. **Add TransferWithMemo validation** - Tempo method completeness
+6. **Add preflight transaction validation** - Defense in depth
+
+### For TypeScript SDK
+
+1. **Add auto-retry transport option** - Improve client ergonomics
+2. **Add decorator/middleware pattern** - Simpler server integration
+
+---
+
+## Summary
+
+The **TypeScript SDK** is more mature with:
+- Schema-driven type safety
+- Stateless HMAC verification
+- Complete intent support
+- Stricter validation
+
+The **Python SDK** offers:
+- Simpler Protocol-based design
+- Better client ergonomics (auto-retry)
+- Easier server integration (@decorator)
+- But lacks security properties for production use
+
+**Recommendation:** The Python SDK should prioritize implementing HMAC-bound challenge verification and embedded credentials before production deployment.

--- a/docs/SDK_SPEC_COMPLIANCE_REPORT.md
+++ b/docs/SDK_SPEC_COMPLIANCE_REPORT.md
@@ -1,0 +1,266 @@
+# SDK Spec Compliance Report: mpay-python
+
+**Audit Date:** 2026-01-28
+**Spec Version:** [mpay-sdks/SPEC.md](../../mpay-sdks/SPEC.md)
+**SDK Version:** mpay-python (current main branch)
+
+## Executive Summary
+
+**Overall Compliance: PARTIAL (FAILS SERVER REQUIREMENTS)**
+
+mpay-python implements the core header types/parsing, a 402-aware httpx transport, and a Tempo "charge" intent with client method. However, the server-side implementation has critical spec violations: challenge IDs are not bound to parameters, credential.id verification is absent, and Challenge.expires is unused.
+
+| Category | Status | Notes |
+|----------|--------|-------|
+| Core Types | ✅ Pass | Challenge, Credential, Receipt implemented |
+| Methods (tempo) | ⚠️ Partial | Client works; server verification unsafe |
+| Intents (charge) | ⚠️ Partial | Missing Intent.challenge() API |
+| Client Transport | ⚠️ Partial | Basic flow works; robustness issues |
+| Server | ❌ Fail | Challenge binding and verification gaps |
+
+---
+
+## 1. Core Types (draft-ietf-httpauth-payment §5)
+
+### ✅ COMPLIANT
+
+**What's Implemented:**
+- `Challenge` with `id`, `method`, `intent`, `request`, optional `digest`, `expires`, `description`
+- `Credential` with `id`, `payload`, optional `source`
+- `Receipt` with `status`, `timestamp`, `reference` + header encode/decode
+- Header parsing/formatting for:
+  - `WWW-Authenticate: Payment ...`
+  - `Authorization: Payment <b64json>`
+  - `Payment-Receipt: <b64json>`
+
+**Minor Gaps:**
+- `parse_www_authenticate()` requires `realm` but discards it (Challenge has no `realm` field)
+- `Challenge.expires` is a string and is never parsed/validated in core/server flow
+
+**Files:**
+- [`src/mpay/__init__.py`](../src/mpay/__init__.py) — Core types
+- [`src/mpay/_parsing.py`](../src/mpay/_parsing.py) — Header parsing
+
+---
+
+## 2. Methods (MUST implement `tempo`)
+
+### ⚠️ PARTIALLY COMPLIANT
+
+**What's Implemented:**
+- Client-side: `TempoMethod` with `name = "tempo"` and `create_credential()`
+- Server-side: `ChargeIntent.verify()` for Tempo payments
+- Credential payload supports `{type:"transaction"}` and `{type:"hash"}`
+
+**Gaps:**
+
+| Issue | Severity | Description |
+|-------|----------|-------------|
+| Client only creates transaction credentials | Low | No client helper for `hash`-type credentials |
+| **Unsafe transaction verification** | **Critical** | Server may sponsor/broadcast tx before validating it matches request parameters. Verification of logs happens only after inclusion. |
+
+**Critical Safety Issue:**
+In `ChargeIntent._verify_transaction()`, the server may forward a raw signed transaction to a fee payer or broadcast it **before validating** it matches request parameters. This enables:
+- Attacker submits a transaction credential that doesn't match the requested payment
+- Server sponsors/broadcasts it, paying gas for an unwanted action
+- Verification fails afterwards but damage is done
+
+**Recommendation:** Decode/inspect the signed transaction before sponsoring to ensure it is a TIP-20 transfer matching `request.recipient`, `request.amount`, and `request.currency`.
+
+**Files:**
+- [`src/mpay/methods/tempo/client.py`](../src/mpay/methods/tempo/client.py)
+- [`src/mpay/methods/tempo/intents.py`](../src/mpay/methods/tempo/intents.py)
+
+---
+
+## 3. Intents (MUST implement `charge`)
+
+### ⚠️ PARTIALLY COMPLIANT
+
+**What's Implemented:**
+- `ChargeIntent` with `name = "charge"` and `verify()`
+- Temporal expiry validation on `request.expires`
+
+**Gap:**
+- **SPEC requires:** `Intent.challenge(request: object) -> Challenge`
+- **Current implementation:** There is no `Intent.challenge` method in the `Intent` protocol
+- Challenge creation is done by `verify_or_challenge()` via `_create_challenge()`, not by intent
+
+**Files:**
+- [`src/mpay/server/intent.py`](../src/mpay/server/intent.py)
+- [`src/mpay/methods/tempo/intents.py`](../src/mpay/methods/tempo/intents.py)
+
+---
+
+## 4. Client: 402 Transport
+
+### ⚠️ PARTIALLY COMPLIANT
+
+**What's Implemented (matches SPEC retry steps 1–6):**
+1. ✅ Make initial request
+2. ✅ On 402 response, parse `WWW-Authenticate` header
+3. ✅ Match challenge `method` to a configured payment method
+4. ✅ Call `method.create_credential(challenge)` to produce a credential
+5. ✅ Retry request with `Authorization: Payment <credential>` header
+6. ⚠️ Return final response (receipt not parsed automatically)
+
+**Gaps:**
+
+| Issue | Severity | Description |
+|-------|----------|-------------|
+| WWW-Authenticate parsing too strict | Medium | Only checks if header starts with "Payment ". Servers may send multiple `WWW-Authenticate` headers or combined values (e.g. `Bearer ..., Payment ...`). |
+| Request replay not robust | Medium | Uses `stream=request.stream` for retry. For non-idempotent requests or streaming bodies, this may fail after first send (body consumed). |
+| Receipt not exposed | Low | Returns raw `httpx.Response`, does not parse/expose `Payment-Receipt` into a `Receipt` object automatically. |
+
+**Recommendation:**
+- Parse all `WWW-Authenticate` headers using `response.headers.get_list("www-authenticate")`
+- Buffer request body for non-idempotent methods before first send
+
+**Files:**
+- [`src/mpay/client/transport.py`](../src/mpay/client/transport.py)
+
+---
+
+## 5. Server: Challenge Generation and Verification
+
+### ❌ NOT COMPLIANT
+
+This is the primary area of non-compliance.
+
+### 5.1 Challenge Generation
+
+**SPEC Requirements:**
+- ❌ **MUST generate unique id bound to parameters** — Current: `secrets.token_urlsafe(16)` (random, not bound)
+- ✅ **MUST include method, intent, request** — Yes
+- ❌ **SHOULD include expires** — Not set by `_create_challenge()`
+
+### 5.2 Verification
+
+**SPEC Requirements:**
+| Requirement | Status | Notes |
+|-------------|--------|-------|
+| Validate challenge.id matches expected binding | ❌ | No check; no binding mechanism |
+| Validate challenge parameters match original request | ❌ | No mechanism; intent.verify only sees request |
+| Validate expires has not passed | ⚠️ | Only checks `request.expires`, not `Challenge.expires` |
+| Verify payload according to payment method spec | ⚠️ | Partial; unsafe ordering (broadcast before validation) |
+| Return Receipt on success, raise error on failure | ⚠️ | Returns `Receipt.failed` instead of raising for some failures |
+
+**Current Flow in `verify_or_challenge()`:**
+```python
+# No binding check on credential.id
+receipt: Receipt = await intent.verify(credential, request)
+return (credential, receipt)
+```
+
+**What's Missing:**
+1. No stored or computed challenge binding
+2. No verification that `credential.id` corresponds to a valid challenge for this request
+3. No challenge-level expiry validation
+
+**Files:**
+- [`src/mpay/server/verify.py`](../src/mpay/server/verify.py)
+
+---
+
+## Compliance Checklist Summary
+
+| Requirement | Status |
+|-------------|--------|
+| Challenge MUST generate unique id bound to parameters | ❌ Not bound; random only |
+| Challenge MUST include method, intent, request | ✅ Yes |
+| Challenge SHOULD include expires | ❌ Not included by generator |
+| Verification MUST validate challenge.id matches expected binding | ❌ No check; no binding mechanism |
+| Verification MUST validate challenge parameters match original request | ❌ No mechanism |
+| Verification MUST validate expires has not passed | ⚠️ Only for `request.expires`, not `Challenge.expires` |
+| Verification MUST verify payload according to payment method spec | ⚠️ Partially; unsafe ordering |
+| Verification MUST return Receipt on success or raise error on failure | ⚠️ Returns `Receipt.failed` on some failures |
+
+---
+
+## Remediation Recommendations
+
+### High Priority (Security/Compliance Critical)
+
+#### 1. Implement Parameter-Bound Challenge IDs (Effort: M ~3–6h)
+
+**Option A: Stateless HMAC Binding**
+```python
+import hmac
+import hashlib
+import json
+
+def _create_challenge(method: str, intent_name: str, request: dict, expires: str, secret: bytes) -> Challenge:
+    canonical = json.dumps({"m": method, "i": intent_name, "r": request, "e": expires}, sort_keys=True)
+    challenge_id = base64.urlsafe_b64encode(
+        hmac.new(secret, canonical.encode(), hashlib.sha256).digest()
+    ).decode().rstrip("=")
+    return Challenge(id=challenge_id, method=method, intent=intent_name, request=request, expires=expires)
+```
+
+**Option B: Stateful Storage**
+- Store challenges with TTL (Redis/in-memory)
+- Map `challenge.id → (method, intent, request, expires)`
+- Look up on verification
+
+#### 2. Add Challenge Binding Verification (Effort: M ~2–4h)
+
+Modify `verify_or_challenge()`:
+```python
+# Recompute expected challenge_id from (method, intent, request, expires)
+expected_id = _compute_challenge_id(method_name, intent.name, request, expires)
+if credential.id != expected_id:
+    return _create_challenge(...)  # Invalid credential, issue new challenge
+
+# Check expiry
+if datetime.fromisoformat(expires) < datetime.now(UTC):
+    return _create_challenge(...)
+```
+
+#### 3. Fix Tempo Transaction Verification Ordering (Effort: M ~3–6h)
+
+Before sponsoring/broadcasting in `_verify_transaction()`:
+- Decode the signed transaction
+- Validate it's a TIP-20 transfer to `request.recipient` of `request.amount` on `request.currency`
+- Only submit once validated
+
+### Medium Priority
+
+#### 4. Harden 402 Transport Header Handling (Effort: M ~3–6h)
+- Parse all `WWW-Authenticate` headers, locate the `Payment` challenge
+- Buffer request body for reliable retry
+
+#### 5. Align Failure Behavior with Spec (Effort: S ~1–2h)
+- Decide: if tx reverted, should that raise `VerificationError` or return `Receipt.failed`?
+- SPEC says "raise error on failure"
+
+### Low Priority
+
+#### 6. Add Intent.challenge() API (Effort: S ~2h)
+- Add `challenge(request: dict) -> Challenge` method to Intent protocol
+- Move challenge generation logic from `verify_or_challenge()` to intents
+
+---
+
+## Risk Assessment
+
+| Risk | Severity | Impact |
+|------|----------|--------|
+| Gas drain via unvalidated transaction sponsoring | Critical | Attacker can make server pay gas for arbitrary transactions |
+| Credential replay/forgery due to unbound challenge IDs | High | Attacker could potentially reuse or forge credentials |
+| 402 flow failures due to non-robust header parsing | Medium | Legitimate payments may fail in mixed-auth environments |
+| Request body not replayable on retry | Medium | Non-idempotent requests with streaming bodies may fail |
+
+---
+
+## Conclusion
+
+mpay-python has a solid foundation with correct core types and parsing, but **fails server-side spec compliance** due to missing challenge binding and verification. The unsafe transaction verification ordering presents a critical security risk.
+
+**Estimated effort to reach compliance:** M–L (1–2 days)
+
+Priority order:
+1. Fix unsafe transaction verification ordering (Critical security)
+2. Implement parameter-bound challenge IDs
+3. Add challenge binding verification
+4. Harden client transport
+5. Add Intent.challenge() API

--- a/src/mpay/__init__.py
+++ b/src/mpay/__init__.py
@@ -17,7 +17,7 @@ from mpay._parsing import (
     parse_www_authenticate,
 )
 
-__all__ = ["Challenge", "Credential", "ParseError", "Receipt"]
+__all__ = ["Challenge", "ChallengeEcho", "Credential", "ParseError", "Receipt"]
 
 
 @dataclass(frozen=True, slots=True)
@@ -37,8 +37,9 @@ class Challenge:
     method: str
     intent: str
     request: dict[str, Any]
+    realm: str | None = None
     digest: str | None = None
-    expires: str | None = None
+    expires: datetime | None = None
     description: str | None = None
 
     @classmethod
@@ -52,17 +53,37 @@ class Challenge:
 
 
 @dataclass(frozen=True, slots=True)
+class ChallengeEcho:
+    """The challenge echoed back in a credential."""
+
+    id: str
+    realm: str
+    method: str
+    intent: str
+    request: dict[str, Any]
+    digest: str | None = None
+    expires: datetime | None = None
+    description: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
 class Credential:
     """The credential passed to the verify function.
 
     Example:
         credential = Credential(
-            id="challenge-id",
+            challenge=ChallengeEcho(
+                id="challenge-id",
+                realm="api.example.com",
+                method="tempo",
+                intent="charge",
+                request={"amount": "1000"},
+            ),
             payload={"signature": "0x..."},
         )
     """
 
-    id: str
+    challenge: ChallengeEcho
     payload: dict[str, Any]
     source: str | None = None
 
@@ -85,12 +106,14 @@ class Receipt:
 
         receipt = Receipt(
             status="success",
+            method="tempo",
             timestamp=datetime.now(UTC),
             reference="0x...",
         )
     """
 
     status: Literal["success", "failed"]
+    method: str
     timestamp: datetime
     reference: str
 
@@ -104,19 +127,21 @@ class Receipt:
         return format_payment_receipt(self)
 
     @classmethod
-    def success(cls, reference: str, timestamp: datetime | None = None) -> "Receipt":
+    def success(cls, reference: str, method: str, timestamp: datetime | None = None) -> "Receipt":
         """Create a success receipt with current timestamp."""
         return cls(
             status="success",
+            method=method,
             timestamp=timestamp or datetime.now(UTC),
             reference=reference,
         )
 
     @classmethod
-    def failed(cls, reference: str, timestamp: datetime | None = None) -> "Receipt":
+    def failed(cls, reference: str, method: str, timestamp: datetime | None = None) -> "Receipt":
         """Create a failed receipt with current timestamp."""
         return cls(
             status="failed",
+            method=method,
             timestamp=timestamp or datetime.now(UTC),
             reference=reference,
         )

--- a/src/mpay/_parsing.py
+++ b/src/mpay/_parsing.py
@@ -59,8 +59,23 @@ def _b64_decode(encoded: str) -> dict[str, Any]:
         if not isinstance(obj, dict):
             raise ParseError("Expected JSON object")
         return obj
-    except (ValueError, json.JSONDecodeError):
+    except (ValueError, json.JSONDecodeError, UnicodeDecodeError):
         raise ParseError("Invalid base64 or JSON encoding") from None
+
+
+def _b64_encode_str(data: str) -> str:
+    """Encode string as URL-safe base64 (no padding)."""
+    encoded = base64.urlsafe_b64encode(data.encode()).decode()
+    return encoded.rstrip("=")
+
+
+def _b64_decode_str(encoded: str) -> str:
+    """Decode URL-safe base64 to string."""
+    try:
+        padded = encoded + "=" * (-len(encoded) % 4)
+        return base64.urlsafe_b64decode(padded).decode()
+    except (ValueError, UnicodeDecodeError):
+        raise ParseError("Invalid base64 encoding") from None
 
 
 def _escape_quoted(s: str) -> str:
@@ -129,13 +144,19 @@ def parse_www_authenticate(header: str) -> Challenge:
     # Decode request JSON
     request = _b64_decode(request_b64)
 
+    # Parse expires to datetime if present
+    expires = None
+    if params.get("expires"):
+        expires = _parse_timestamp(params["expires"])
+
     return Challenge(
         id=id_,
         method=method,
         intent=intent,
         request=request,
+        realm=realm,
         digest=params.get("digest"),
-        expires=params.get("expires"),
+        expires=expires,
         description=params.get("description"),
     )
 
@@ -162,7 +183,8 @@ def format_www_authenticate(challenge: Challenge, realm: str) -> str:
     if challenge.digest:
         parts.append(f'digest="{_escape_quoted(challenge.digest)}"')
     if challenge.expires:
-        parts.append(f'expires="{_escape_quoted(challenge.expires)}"')
+        expires_str = challenge.expires.isoformat().replace("+00:00", "Z")
+        parts.append(f'expires="{_escape_quoted(expires_str)}"')
     if challenge.description:
         parts.append(f'description="{_escape_quoted(challenge.description)}"')
 
@@ -176,11 +198,11 @@ def parse_authorization(header: str) -> Credential:
         Payment <base64-credential>
 
     The credential payload is a base64-encoded JSON object with:
-        - id: Challenge identifier (matches the original challenge)
+        - challenge: Full challenge object (with nested base64-encoded request)
         - payload: Method-specific credential data
         - source: Optional payer DID
     """
-    from mpay import Credential
+    from mpay import ChallengeEcho, Credential
 
     header = header.strip()
 
@@ -190,13 +212,49 @@ def parse_authorization(header: str) -> Credential:
     credential_b64 = header[8:].strip()
     data = _b64_decode(credential_b64)
 
-    if "id" not in data:
-        raise ParseError("Credential missing required field: id")
+    if "challenge" not in data:
+        raise ParseError("Credential missing required field: challenge")
     if "payload" not in data:
         raise ParseError("Credential missing required field: payload")
 
+    challenge_data = data["challenge"]
+    if not isinstance(challenge_data, dict):
+        raise ParseError("Credential challenge must be an object")
+
+    # Validate required challenge fields
+    required_challenge_fields = ["id", "realm", "method", "intent", "request"]
+    for field in required_challenge_fields:
+        if field not in challenge_data:
+            raise ParseError(f"Credential challenge missing required field: {field}")
+
+    # The request field inside challenge is base64url-encoded per spec (nested base64)
+    request_b64 = challenge_data["request"]
+    if isinstance(request_b64, str):
+        request = _b64_decode(request_b64)
+    else:
+        # Allow already-decoded request for backwards compatibility
+        request = request_b64
+
+    # Parse expires to datetime if present
+    expires = None
+    if challenge_data.get("expires"):
+        expires = _parse_timestamp(str(challenge_data["expires"]))
+
+    challenge_echo = ChallengeEcho(
+        id=str(challenge_data["id"]),
+        realm=str(challenge_data["realm"]),
+        method=str(challenge_data["method"]),
+        intent=str(challenge_data["intent"]),
+        request=request,
+        digest=str(challenge_data["digest"]) if challenge_data.get("digest") else None,
+        expires=expires,
+        description=(
+            str(challenge_data["description"]) if challenge_data.get("description") else None
+        ),
+    )
+
     return Credential(
-        id=str(data["id"]),
+        challenge=challenge_echo,
         payload=data["payload"],
         source=str(data["source"]) if data.get("source") else None,
     )
@@ -207,9 +265,30 @@ def format_authorization(credential: Credential) -> str:
 
     Output format:
         Payment <base64-credential>
+
+    The credential contains a challenge object with nested base64-encoded request.
     """
+    # Encode the request as base64url (nested encoding per spec)
+    request_b64 = _b64_encode(credential.challenge.request)
+
+    challenge_obj: dict[str, Any] = {
+        "id": credential.challenge.id,
+        "realm": credential.challenge.realm,
+        "method": credential.challenge.method,
+        "intent": credential.challenge.intent,
+        "request": request_b64,
+    }
+
+    # Add optional challenge fields
+    if credential.challenge.digest:
+        challenge_obj["digest"] = credential.challenge.digest
+    if credential.challenge.expires:
+        challenge_obj["expires"] = credential.challenge.expires.isoformat().replace("+00:00", "Z")
+    if credential.challenge.description:
+        challenge_obj["description"] = credential.challenge.description
+
     payload: dict[str, Any] = {
-        "id": credential.id,
+        "challenge": challenge_obj,
         "payload": credential.payload,
     }
     if credential.source:
@@ -235,6 +314,7 @@ def parse_payment_receipt(header: str) -> Receipt:
 
     The receipt payload is a base64-encoded JSON object with:
         - status: "success" or "failed"
+        - method: The payment method used
         - timestamp: ISO 8601 timestamp
         - reference: Method-specific reference
     """
@@ -243,7 +323,7 @@ def parse_payment_receipt(header: str) -> Receipt:
     header = header.strip()
     data = _b64_decode(header)
 
-    required = {"status", "timestamp", "reference"}
+    required = {"status", "method", "timestamp", "reference"}
     missing = required - set(data.keys())
     if missing:
         raise ParseError(f"Receipt missing required fields: {missing}")
@@ -252,10 +332,12 @@ def parse_payment_receipt(header: str) -> Receipt:
     if status not in ("success", "failed"):
         raise ParseError("Invalid receipt status")
 
+    method = str(data["method"])
     timestamp = _parse_timestamp(str(data["timestamp"]))
 
     return Receipt(
         status=status,
+        method=method,
         timestamp=timestamp,
         reference=str(data["reference"]),
     )
@@ -271,6 +353,7 @@ def format_payment_receipt(receipt: Receipt) -> str:
 
     payload = {
         "status": receipt.status,
+        "method": receipt.method,
         "timestamp": timestamp_str,
         "reference": receipt.reference,
     }

--- a/src/mpay/client/transport.py
+++ b/src/mpay/client/transport.py
@@ -9,6 +9,7 @@ Implements automatic 402 Payment Required handling by:
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 import httpx
@@ -65,22 +66,32 @@ class PaymentTransport(httpx.AsyncBaseTransport):
         if response.status_code != 402:
             return response
 
-        www_auth = response.headers.get("www-authenticate")
-        if not www_auth or not www_auth.lower().startswith("payment "):
-            return response
-
         await response.aread()
 
-        try:
-            challenge = Challenge.from_www_authenticate(www_auth)
-        except ParseError:
+        www_auth_headers = response.headers.get_list("www-authenticate")
+
+        challenge = None
+        matched_method = None
+        for header in www_auth_headers:
+            if not header.lower().startswith("payment "):
+                continue
+            try:
+                parsed = Challenge.from_www_authenticate(header)
+                if parsed.method in self._methods:
+                    challenge = parsed
+                    matched_method = self._methods[parsed.method]
+                    break
+            except ParseError:
+                continue
+
+        if not challenge or not matched_method:
             return response
 
-        method = self._methods.get(challenge.method)
-        if not method:
-            return response
+        if challenge.expires:
+            if challenge.expires < datetime.now(UTC):
+                return response
 
-        credential = await method.create_credential(challenge)
+        credential = await matched_method.create_credential(challenge)
         auth_header = credential.to_authorization()
 
         headers = httpx.Headers(request.headers)

--- a/src/mpay/extensions/mcp/decorator.py
+++ b/src/mpay/extensions/mcp/decorator.py
@@ -31,14 +31,14 @@ from datetime import timedelta
 from functools import wraps
 from typing import TYPE_CHECKING, Any, ParamSpec, TypeVar
 
-from mpay.extensions.mcp.constants import META_CREDENTIAL
-from mpay.extensions.mcp.errors import (
-    MalformedCredentialError,
-    PaymentRequiredError,
-    PaymentVerificationError,
+from mpay.extensions.mcp.errors import PaymentRequiredError
+from mpay.extensions.mcp.types import MCPChallenge
+from mpay.extensions.mcp.verify import (
+    DEFAULT_CHALLENGE_TTL,
 )
-from mpay.extensions.mcp.types import MCPCredential, MCPReceipt
-from mpay.extensions.mcp.verify import DEFAULT_CHALLENGE_TTL, create_challenge
+from mpay.extensions.mcp.verify import (
+    verify_or_challenge as mcp_verify_or_challenge,
+)
 
 if TYPE_CHECKING:
     from mpay.server.intent import Intent
@@ -115,74 +115,31 @@ def requires_payment(
     ) -> Callable[P, Awaitable[R]]:
         @wraps(handler)
         async def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
-            meta = kwargs.pop("_meta", None) or {}
+            meta = kwargs.pop("_meta", None)
 
             if callable(request):
                 request_params = request(*args, **kwargs)
             else:
                 request_params = request
 
-            credential_data = meta.get(META_CREDENTIAL)
-
-            if credential_data is None:
-                challenge = create_challenge(
-                    method=method_name,
-                    intent_name=intent.name,
-                    request=request_params,
-                    realm=realm,
-                    expires_in=expires_in,
-                    description=description,
-                )
-                raise PaymentRequiredError(challenges=[challenge])
-
-            try:
-                mcp_credential = MCPCredential.from_dict(credential_data)
-            except (KeyError, TypeError) as e:
-                raise MalformedCredentialError(detail=f"Invalid credential structure: {e}") from e
-
-            from mpay.server.intent import VerificationError
-
-            core_credential = mcp_credential.to_core()
-
-            try:
-                core_receipt = await intent.verify(core_credential, request_params)
-            except VerificationError as e:
-                challenge = create_challenge(
-                    method=method_name,
-                    intent_name=intent.name,
-                    request=request_params,
-                    realm=realm,
-                    expires_in=expires_in,
-                    description=description,
-                )
-                raise PaymentVerificationError(
-                    challenges=[challenge],
-                    reason="verification-failed",
-                    detail=str(e),
-                ) from e
-
-            mcp_receipt = MCPReceipt.from_core(
-                receipt=core_receipt,
-                challenge_id=mcp_credential.challenge.id,
-                method=mcp_credential.challenge.method,
-                settlement=_extract_settlement(request_params),
+            result = await mcp_verify_or_challenge(
+                meta=meta,
+                intent=intent,
+                request=request_params,
+                realm=realm,
+                method=method_name,
+                expires_in=expires_in,
+                description=description,
             )
 
-            kwargs["credential"] = mcp_credential
-            kwargs["receipt"] = mcp_receipt
+            if isinstance(result, MCPChallenge):
+                raise PaymentRequiredError(challenges=[result])
 
+            credential, receipt = result
+            kwargs["credential"] = credential
+            kwargs["receipt"] = receipt
             return await handler(*args, **kwargs)
 
         return wrapper
 
     return decorator
-
-
-def _extract_settlement(request: dict[str, Any]) -> dict[str, Any] | None:
-    """Extract settlement info from request if available."""
-    settlement: dict[str, Any] = {}
-    if "amount" in request:
-        settlement["amount"] = request["amount"]
-    if "currency" in request:
-        settlement["currency"] = request["currency"]
-    return settlement if settlement else None

--- a/src/mpay/extensions/mcp/types.py
+++ b/src/mpay/extensions/mcp/types.py
@@ -159,11 +159,18 @@ class MCPCredential:
         return cls.from_dict(meta[META_CREDENTIAL])
 
     def to_core(self) -> Credential:
-        """Convert to core Credential type (uses challenge.id only)."""
-        from mpay import Credential
+        """Convert to core Credential type."""
+        from mpay import ChallengeEcho, Credential
 
-        return Credential(
+        challenge_echo = ChallengeEcho(
             id=self.challenge.id,
+            realm=self.challenge.realm,
+            method=self.challenge.method,
+            intent=self.challenge.intent,
+            request=self.challenge.request,
+        )
+        return Credential(
+            challenge=challenge_echo,
             payload=self.payload,
             source=self.source,
         )
@@ -249,11 +256,12 @@ class MCPReceipt:
         return cls.from_dict(meta[META_RECEIPT])
 
     def to_core(self) -> Receipt:
-        """Convert to core Receipt type (loses challengeId, method, settlement)."""
+        """Convert to core Receipt type (loses challengeId, settlement)."""
         from mpay import Receipt
 
         return Receipt(
             status=self.status,
+            method=self.method,
             timestamp=datetime.fromisoformat(self.timestamp.replace("Z", "+00:00")),
             reference=self.reference or "",
         )

--- a/src/mpay/methods/tempo/client.py
+++ b/src/mpay/methods/tempo/client.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
-from mpay import Challenge, Credential
+from mpay import Challenge, ChallengeEcho, Credential
 from mpay.methods.tempo.intents import ChargeIntent
 
 if TYPE_CHECKING:
@@ -15,7 +15,6 @@ if TYPE_CHECKING:
 
 DEFAULT_GAS_LIMIT = 100_000
 DEFAULT_TIMEOUT = 30.0
-DEFAULT_FEE_PAYER_URL = "https://sponsor.moderato.tempo.xyz"
 
 
 class TransactionError(Exception):
@@ -59,6 +58,25 @@ class TempoMethod:
         """Available intents for this method."""
         return self._intents
 
+    async def _get_chain_id(self) -> int:
+        """Get and cache the chain ID from RPC."""
+        if hasattr(self, "_chain_id_cache"):
+            return self._chain_id_cache
+
+        import httpx
+
+        async with httpx.AsyncClient(timeout=DEFAULT_TIMEOUT) as client:
+            response = await client.post(
+                self.rpc_url,
+                json={"jsonrpc": "2.0", "method": "eth_chainId", "params": [], "id": 1},
+            )
+            response.raise_for_status()
+            result = response.json()
+            if "error" in result:
+                raise TransactionError("Failed to fetch chain ID")
+            self._chain_id_cache = int(result["result"], 16)
+        return self._chain_id_cache
+
     async def create_credential(self, challenge: Challenge) -> Credential:
         """Create a credential to satisfy the given challenge.
 
@@ -96,10 +114,21 @@ class TempoMethod:
             recipient=request["recipient"],
             nonce_key=nonce_key,
         )
-        return Credential(
+        chain_id = await self._get_chain_id()
+        challenge_echo = ChallengeEcho(
             id=challenge.id,
+            realm=challenge.realm or "",
+            method=challenge.method,
+            intent=challenge.intent,
+            request=challenge.request,
+            digest=challenge.digest,
+            expires=challenge.expires,
+            description=challenge.description,
+        )
+        return Credential(
+            challenge=challenge_echo,
             payload={"type": "transaction", "signature": raw_tx},
-            source=f"did:pkh:eip155:1:{self.account.address}",
+            source=f"did:pkh:eip155:{chain_id}:{self.account.address}",
         )
 
     async def _build_tempo_transfer(

--- a/src/mpay/methods/tempo/intents.py
+++ b/src/mpay/methods/tempo/intents.py
@@ -6,6 +6,7 @@ Implements the charge intent for Tempo payments.
 from __future__ import annotations
 
 import asyncio
+import logging
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
@@ -23,9 +24,23 @@ if TYPE_CHECKING:
 
     from mpay import Credential
 
+logger = logging.getLogger(__name__)
+
 
 DEFAULT_TIMEOUT = 30.0
 DEFAULT_FEE_PAYER_URL = "https://sponsor.moderato.tempo.xyz"
+
+
+def _extract_address_from_did(did: str | None) -> str | None:
+    """Extract address from a did:pkh DID."""
+    if not did:
+        return None
+    # Format: did:pkh:eip155:{chain}:{address}
+    parts = did.split(":")
+    if len(parts) >= 5 and parts[0] == "did" and parts[1] == "pkh" and parts[2] == "eip155":
+        return parts[4]
+    return None
+
 
 # Receipt polling configuration
 #
@@ -147,15 +162,18 @@ class ChargeIntent:
         else:
             raise VerificationError(f"Invalid credential type: {payload_data['type']}")
 
+        expected_sender = _extract_address_from_did(credential.source)
+
         if isinstance(payload, HashCredentialPayload):
-            return await self._verify_hash(payload, req)
+            return await self._verify_hash(payload, req, expected_sender)
         else:
-            return await self._verify_transaction(payload, req)
+            return await self._verify_transaction(payload, req, expected_sender)
 
     async def _verify_hash(
         self,
         payload: HashCredentialPayload,
         request: ChargeRequest,
+        expected_sender: str | None = None,
     ) -> Receipt:
         """Verify a credential with a transaction hash."""
         client = await self._get_client()
@@ -180,14 +198,14 @@ class ChargeIntent:
             raise VerificationError("Transaction not found")
 
         if receipt_data.get("status") != "0x1":
-            return Receipt.failed(payload.hash)
+            return Receipt.failed(payload.hash, method="tempo")
 
-        if not self._verify_transfer_logs(receipt_data, request):
+        if not self._verify_transfer_logs(receipt_data, request, expected_sender):
             raise VerificationError(
                 "Transaction must contain a Transfer log matching request parameters"
             )
 
-        return Receipt.success(payload.hash)
+        return Receipt.success(payload.hash, method="tempo")
 
     def _verify_transfer_logs(
         self,
@@ -237,6 +255,7 @@ class ChargeIntent:
         self,
         payload: TransactionCredentialPayload,
         request: ChargeRequest,
+        expected_sender: str | None = None,
     ) -> Receipt:
         """Verify and submit a signed transaction.
 
@@ -285,7 +304,7 @@ class ChargeIntent:
         if not tx_hash:
             raise VerificationError("No transaction hash returned")
 
-        print(f"[mpay] Transaction submitted: {tx_hash}")
+        logger.info("Transaction submitted: %s", tx_hash)
 
         receipt_data = None
         # Check immediately first, then retry with short delays (receipts available in ~400ms)
@@ -307,7 +326,7 @@ class ChargeIntent:
 
             receipt_data = receipt_result.get("result")
             if receipt_data:
-                print(f"[mpay] Receipt found on attempt {attempt + 1}")
+                logger.debug("Receipt found on attempt %d", attempt + 1)
                 break
 
             # Wait between retries (don't sleep after the last attempt)
@@ -318,11 +337,11 @@ class ChargeIntent:
             raise VerificationError("Transaction receipt not found after retries")
 
         if receipt_data.get("status") != "0x1":
-            return Receipt.failed(tx_hash)
+            return Receipt.failed(tx_hash, method="tempo")
 
-        if not self._verify_transfer_logs(receipt_data, request):
+        if not self._verify_transfer_logs(receipt_data, request, expected_sender):
             raise VerificationError(
                 "Transaction must contain a Transfer log matching request parameters"
             )
 
-        return Receipt.success(tx_hash)
+        return Receipt.success(tx_hash, method="tempo")

--- a/src/mpay/methods/tempo/keychain.py
+++ b/src/mpay/methods/tempo/keychain.py
@@ -10,6 +10,7 @@ Total: 86 bytes
 
 from __future__ import annotations
 
+import re
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -17,6 +18,8 @@ if TYPE_CHECKING:
 
 KEYCHAIN_SIGNATURE_TYPE = 0x03
 KEYCHAIN_SIGNATURE_LENGTH = 86
+
+ADDRESS_RE = re.compile(r"^0x[a-fA-F0-9]{40}$")
 
 
 def build_keychain_signature(
@@ -33,10 +36,20 @@ def build_keychain_signature(
 
     Returns:
         86-byte Keychain signature: 0x03 || root_account || inner_sig
+
+    Raises:
+        ValueError: If root_account is not a valid Ethereum address.
     """
+    if not ADDRESS_RE.match(root_account):
+        raise ValueError(f"Invalid root_account address format: {root_account}")
+
     inner_sig = access_key.sign_hash(msg_hash)
     root_bytes = bytes.fromhex(root_account[2:])
 
     keychain_sig = bytes([KEYCHAIN_SIGNATURE_TYPE]) + root_bytes + inner_sig
-    assert len(keychain_sig) == KEYCHAIN_SIGNATURE_LENGTH
+    if len(keychain_sig) != KEYCHAIN_SIGNATURE_LENGTH:
+        raise ValueError(
+            f"Invalid keychain signature length: expected {KEYCHAIN_SIGNATURE_LENGTH}, "
+            f"got {len(keychain_sig)}"
+        )
     return keychain_sig

--- a/src/mpay/methods/tempo/schemas.py
+++ b/src/mpay/methods/tempo/schemas.py
@@ -3,8 +3,16 @@
 from __future__ import annotations
 
 from typing import Annotated, Literal
+from urllib.parse import urlparse
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
+
+ALLOWED_FEE_PAYER_DOMAINS = frozenset(
+    {
+        "sponsor.moderato.tempo.xyz",
+        "sponsor.tempo.xyz",
+    }
+)
 
 
 class MethodDetails(BaseModel):
@@ -14,6 +22,18 @@ class MethodDetails(BaseModel):
     feePayer: bool = False
     feePayerUrl: str | None = None
 
+    @field_validator("feePayerUrl")
+    @classmethod
+    def validate_fee_payer_url(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
+        parsed = urlparse(v)
+        if parsed.scheme != "https":
+            raise ValueError("feePayerUrl must use HTTPS")
+        if parsed.hostname not in ALLOWED_FEE_PAYER_DOMAINS:
+            raise ValueError(f"feePayerUrl domain not allowed: {parsed.hostname}")
+        return v
+
 
 class ChargeRequest(BaseModel):
     """Request schema for the charge intent.
@@ -22,8 +42,8 @@ class ChargeRequest(BaseModel):
     """
 
     amount: str
-    currency: Annotated[str, Field(pattern=r"^0x[a-fA-F0-9]+$")]
-    recipient: Annotated[str, Field(pattern=r"^0x[a-fA-F0-9]+$")]
+    currency: Annotated[str, Field(pattern=r"^0x[a-fA-F0-9]{40}$")]
+    recipient: Annotated[str, Field(pattern=r"^0x[a-fA-F0-9]{40}$")]
     expires: str
     methodDetails: MethodDetails = Field(default_factory=MethodDetails)
 
@@ -32,7 +52,7 @@ class HashCredentialPayload(BaseModel):
     """Credential payload when paying with a transaction hash."""
 
     type: Literal["hash"]
-    hash: Annotated[str, Field(pattern=r"^0x[a-fA-F0-9]+$")]
+    hash: Annotated[str, Field(pattern=r"^0x[a-fA-F0-9]{64}$")]
 
 
 class TransactionCredentialPayload(BaseModel):

--- a/src/mpay/server/decorator.py
+++ b/src/mpay/server/decorator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import inspect
+import json
 from collections.abc import Awaitable, Callable
 from functools import wraps
 from typing import TYPE_CHECKING, Any, TypeVar
@@ -28,20 +29,37 @@ def _get_authorization(request: Any) -> str | None:
 
 
 def _make_challenge_response(challenge: Challenge, realm: str) -> Any:
-    """Build 402 response for a challenge."""
+    """Build 402 response for a challenge with RFC 9457 problem details."""
+    headers = {
+        "WWW-Authenticate": challenge.to_www_authenticate(realm),
+        "Cache-Control": "no-store",
+        "Content-Type": "application/problem+json",
+    }
+    body = json.dumps(
+        {
+            "type": "https://httpauth.org/problems/payment-required",
+            "title": "Payment Required",
+            "status": 402,
+            "detail": (
+                f"Access to this resource requires payment via the {challenge.method} method."
+            ),
+        }
+    )
     try:
         from starlette.responses import Response
 
         return Response(
-            content=None,
+            content=body,
             status_code=402,
-            headers={"WWW-Authenticate": challenge.to_www_authenticate(realm)},
+            headers=headers,
+            media_type="application/problem+json",
         )
     except ImportError:
         return {
             "_mpay_challenge": True,
             "status": 402,
-            "headers": {"WWW-Authenticate": challenge.to_www_authenticate(realm)},
+            "headers": headers,
+            "body": body,
         }
 
 

--- a/src/mpay/server/verify.py
+++ b/src/mpay/server/verify.py
@@ -2,14 +2,75 @@
 
 from __future__ import annotations
 
+import base64
+import hashlib
+import hmac
 import secrets
+from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
 from mpay import Challenge, Credential, Receipt
-from mpay._parsing import ParseError
+from mpay._parsing import ParseError, _b64_encode
+from mpay.server.intent import VerificationError
 
 if TYPE_CHECKING:
     from mpay.server.intent import Intent
+
+DEFAULT_CHALLENGE_TTL = timedelta(minutes=5)
+
+
+def _compute_challenge_id(
+    realm: str,
+    method: str,
+    intent: str,
+    request: dict[str, Any],
+    expires: datetime | None,
+    digest: str | None,
+    secret_key: str,
+) -> str:
+    """Compute HMAC-SHA256 challenge ID.
+
+    Creates a deterministic challenge ID by HMACing the challenge parameters.
+    This enables stateless verification - the server can recompute the expected
+    ID from the echoed challenge without storing state.
+    """
+    request_b64 = _b64_encode(request)
+    expires_str = expires.isoformat().replace("+00:00", "Z") if expires else ""
+    input_str = "|".join([realm, method, intent, request_b64, expires_str, digest or ""])
+    mac = hmac.new(secret_key.encode(), input_str.encode(), hashlib.sha256).digest()
+    return base64.urlsafe_b64encode(mac).decode().rstrip("=")
+
+
+def _constant_time_compare(a: str, b: str) -> bool:
+    """Constant-time string comparison to prevent timing attacks."""
+    return hmac.compare_digest(a.encode(), b.encode())
+
+
+def verify_challenge_id(
+    credential: Credential,
+    realm: str,
+    secret_key: str,
+) -> bool:
+    """Verify that the credential's challenge ID matches the expected HMAC.
+
+    Args:
+        credential: The credential containing the echoed challenge.
+        realm: The realm for this service.
+        secret_key: The secret key used to compute HMAC-bound IDs.
+
+    Returns:
+        True if the challenge ID is valid, False otherwise.
+    """
+    expected_id = _compute_challenge_id(
+        realm=realm,
+        method=credential.challenge.method,
+        intent=credential.challenge.intent,
+        request=credential.challenge.request,
+        expires=credential.challenge.expires,
+        digest=credential.challenge.digest,
+        secret_key=secret_key,
+    )
+    return _constant_time_compare(credential.challenge.id, expected_id)
 
 
 async def verify_or_challenge(
@@ -19,6 +80,9 @@ async def verify_or_challenge(
     request: dict[str, Any],
     realm: str,
     method: str | None = None,
+    secret_key: str | None = None,
+    expires_in: timedelta = DEFAULT_CHALLENGE_TTL,
+    digest: str | None = None,
 ) -> Challenge | tuple[Credential, Receipt]:
     """Verify a payment credential or generate a new challenge.
 
@@ -32,6 +96,11 @@ async def verify_or_challenge(
         request: The payment request parameters.
         realm: The realm for the WWW-Authenticate header.
         method: The payment method name (defaults to "tempo").
+        secret_key: Optional secret for HMAC-bound challenge IDs.
+            If provided, challenge IDs are deterministic HMACs enabling
+            stateless verification. If None, random IDs are used.
+        expires_in: Challenge expiration time (defaults to 5 minutes).
+        digest: Optional digest of the request body.
 
     Returns:
         If no valid Authorization header:
@@ -39,12 +108,16 @@ async def verify_or_challenge(
         If Authorization is valid:
             A tuple of (Credential, Receipt) for the successful payment.
 
+    Raises:
+        ValueError: If realm is empty.
+
     Example:
         result = await verify_or_challenge(
             authorization=request.headers.get("Authorization"),
             intent=ChargeIntent(client),
             request={"amount": "1000", ...},
             realm="api.example.com",
+            secret_key="your-secret-key",  # Enables stateless verification
         )
 
         if isinstance(result, Challenge):
@@ -59,20 +132,73 @@ async def verify_or_challenge(
             headers={"Payment-Receipt": receipt.to_payment_receipt()},
         )
     """
+    if not realm or not realm.strip():
+        raise ValueError("realm must be a non-empty string")
+
     method_name = method or "tempo"
+    expires = datetime.now(UTC) + expires_in
 
     if authorization is None:
-        return _create_challenge(method_name, intent.name, request)
+        return _create_challenge(
+            method=method_name,
+            intent_name=intent.name,
+            request=request,
+            realm=realm,
+            secret_key=secret_key,
+            expires=expires,
+            digest=digest,
+        )
 
     if not authorization.lower().startswith("payment "):
-        return _create_challenge(method_name, intent.name, request)
+        return _create_challenge(
+            method=method_name,
+            intent_name=intent.name,
+            request=request,
+            realm=realm,
+            secret_key=secret_key,
+            expires=expires,
+            digest=digest,
+        )
 
     try:
         credential = Credential.from_authorization(authorization)
     except ParseError:
-        return _create_challenge(method_name, intent.name, request)
+        return _create_challenge(
+            method=method_name,
+            intent_name=intent.name,
+            request=request,
+            realm=realm,
+            secret_key=secret_key,
+            expires=expires,
+            digest=digest,
+        )
 
-    receipt: Receipt = await intent.verify(credential, request)
+    # Verify HMAC-bound challenge ID if secret_key is provided
+    if secret_key is not None:
+        if not verify_challenge_id(credential, realm, secret_key):
+            return _create_challenge(
+                method=method_name,
+                intent_name=intent.name,
+                request=request,
+                realm=realm,
+                secret_key=secret_key,
+                expires=expires,
+                digest=digest,
+            )
+
+    try:
+        receipt: Receipt = await intent.verify(credential, request)
+    except VerificationError:
+        return _create_challenge(
+            method=method_name,
+            intent_name=intent.name,
+            request=request,
+            realm=realm,
+            secret_key=secret_key,
+            expires=expires,
+            digest=digest,
+        )
+
     return (credential, receipt)
 
 
@@ -80,11 +206,41 @@ def _create_challenge(
     method: str,
     intent_name: str,
     request: dict[str, Any],
+    realm: str,
+    secret_key: str | None = None,
+    expires: str | None = None,
+    digest: str | None = None,
 ) -> Challenge:
-    """Create a new payment challenge."""
+    """Create a new payment challenge.
+
+    Args:
+        method: The payment method name.
+        intent_name: The intent name (e.g., "charge").
+        request: The payment request parameters.
+        realm: The realm for this service.
+        secret_key: Optional secret for HMAC-bound IDs. If None, uses random ID.
+        expires: Optional expiration timestamp.
+        digest: Optional digest of the request body.
+    """
+    if secret_key is not None:
+        challenge_id = _compute_challenge_id(
+            realm=realm,
+            method=method,
+            intent=intent_name,
+            request=request,
+            expires=expires,
+            digest=digest,
+            secret_key=secret_key,
+        )
+    else:
+        challenge_id = secrets.token_urlsafe(16)
+
     return Challenge(
-        id=secrets.token_urlsafe(16),
+        id=challenge_id,
         method=method,
         intent=intent_name,
         request=request,
+        realm=realm,
+        expires=expires,
+        digest=digest,
     )

--- a/src/mpay/server/verify.py
+++ b/src/mpay/server/verify.py
@@ -11,7 +11,6 @@ from typing import TYPE_CHECKING, Any
 
 from mpay import Challenge, Credential, Receipt
 from mpay._parsing import ParseError, _b64_encode
-from mpay.server.intent import VerificationError
 
 if TYPE_CHECKING:
     from mpay.server.intent import Intent
@@ -136,7 +135,10 @@ async def verify_or_challenge(
         raise ValueError("realm must be a non-empty string")
 
     method_name = method or "tempo"
-    expires = datetime.now(UTC) + expires_in
+    # For HMAC-bound deterministic IDs, do not include time-varying expires
+    # since it cannot be securely enforced without state.
+    # For random IDs, expires is included as the client echoes it back.
+    expires = None if secret_key is not None else (datetime.now(UTC) + expires_in)
 
     if authorization is None:
         return _create_challenge(
@@ -186,18 +188,10 @@ async def verify_or_challenge(
                 digest=digest,
             )
 
-    try:
-        receipt: Receipt = await intent.verify(credential, request)
-    except VerificationError:
-        return _create_challenge(
-            method=method_name,
-            intent_name=intent.name,
-            request=request,
-            realm=realm,
-            secret_key=secret_key,
-            expires=expires,
-            digest=digest,
-        )
+    # VerificationError is re-raised so callers can distinguish between
+    # "missing/invalid credential" (returns Challenge) and "verification failed"
+    # (raises VerificationError for 403/specific error handling).
+    receipt: Receipt = await intent.verify(credential, request)
 
     return (credential, receipt)
 
@@ -208,7 +202,7 @@ def _create_challenge(
     request: dict[str, Any],
     realm: str,
     secret_key: str | None = None,
-    expires: str | None = None,
+    expires: datetime | None = None,
     digest: str | None = None,
 ) -> Challenge:
     """Create a new payment challenge.

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -6,7 +6,7 @@ import httpx
 import pytest
 from pytest_httpx import HTTPXMock
 
-from mpay import Challenge, Credential
+from mpay import Challenge, ChallengeEcho, Credential
 from mpay.client import Client, PaymentTransport, get, post, request
 
 
@@ -18,7 +18,13 @@ class MockMethod:
     def __init__(self) -> None:
         self.create_credential = AsyncMock(
             return_value=Credential(
-                id="test-id",
+                challenge=ChallengeEcho(
+                    id="test-id",
+                    realm="example.com",
+                    method="tempo",
+                    intent="charge",
+                    request={"amount": "1000"},
+                ),
                 payload={"hash": "0xabc"},
             )
         )

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -84,7 +84,7 @@ class TestMCPChallenge:
         )
         core = mcp_challenge.to_core()
         assert isinstance(core, Challenge)
-        assert core.id == "ch_abc"
+        assert core.id == "ch_abc"  # Still accessible via Challenge.id
         assert core.method == "tempo"
         assert core.intent == "charge"
         assert core.request == {"amount": "1000"}
@@ -181,7 +181,9 @@ class TestMCPCredential:
         )
         core = mcp_credential.to_core()
         assert isinstance(core, Credential)
-        assert core.id == "ch_abc"
+        assert core.challenge.id == "ch_abc"
+        assert core.challenge.realm == "api.example.com"
+        assert core.challenge.method == "tempo"
         assert core.payload == {"signature": "0xabc"}
         assert core.source == "0x1234"
 
@@ -242,11 +244,13 @@ class TestMCPReceipt:
         core = mcp_receipt.to_core()
         assert isinstance(core, Receipt)
         assert core.status == "success"
+        assert core.method == "tempo"
         assert core.reference == "0xtx789"
 
     def test_from_core(self) -> None:
         core = Receipt(
             status="success",
+            method="tempo",
             timestamp=datetime(2025, 1, 15, 12, 0, 30, tzinfo=UTC),
             reference="0xtx789",
         )
@@ -329,7 +333,7 @@ class TestRequiresPaymentDecorator:
             name = "charge"
 
             async def verify(self, credential: object, request: dict) -> Receipt:
-                return Receipt.success(reference="0x123")
+                return Receipt.success(reference="0x123", method="tempo")
 
         @requires_payment(
             intent=MockIntent(),  # type: ignore[arg-type]
@@ -354,7 +358,7 @@ class TestRequiresPaymentDecorator:
             name = "charge"
 
             async def verify(self, credential: object, request: dict) -> Receipt:
-                return Receipt.success(reference="0x123")
+                return Receipt.success(reference="0x123", method="tempo")
 
         @requires_payment(
             intent=MockIntent(),  # type: ignore[arg-type]
@@ -385,7 +389,7 @@ class TestRequiresPaymentDecorator:
             name = "charge"
 
             async def verify(self, credential: object, request: dict) -> Receipt:
-                return Receipt.success(reference="0x123")
+                return Receipt.success(reference="0x123", method="tempo")
 
         @requires_payment(
             intent=MockIntent(),  # type: ignore[arg-type]
@@ -435,14 +439,14 @@ class TestRequiresPaymentDecorator:
 
         error = exc_info.value.to_jsonrpc_error()
         assert error["code"] == CODE_PAYMENT_VERIFICATION_FAILED
-        assert "Payment failed" in error["data"]["failure"]["detail"]
+        assert "verification failed" in error["data"]["failure"]["detail"].lower()
 
     async def test_dynamic_request_params(self) -> None:
         class MockIntent:
             name = "charge"
 
             async def verify(self, credential: object, request: dict) -> Receipt:
-                return Receipt.success(reference="0x123")
+                return Receipt.success(reference="0x123", method="tempo")
 
         @requires_payment(
             intent=MockIntent(),  # type: ignore[arg-type]
@@ -467,7 +471,7 @@ class TestVerifyOrChallenge:
             name = "charge"
 
             async def verify(self, credential: object, request: dict) -> Receipt:
-                return Receipt.success(reference="0x123")
+                return Receipt.success(reference="0x123", method="tempo")
 
         result = await verify_or_challenge(
             meta=None,
@@ -486,7 +490,7 @@ class TestVerifyOrChallenge:
             name = "charge"
 
             async def verify(self, credential: object, request: dict) -> Receipt:
-                return Receipt.success(reference="0x123")
+                return Receipt.success(reference="0x123", method="tempo")
 
         result = await verify_or_challenge(
             meta={},
@@ -502,7 +506,7 @@ class TestVerifyOrChallenge:
             name = "charge"
 
             async def verify(self, credential: object, request: dict) -> Receipt:
-                return Receipt.success(reference="0x123")
+                return Receipt.success(reference="0x123", method="tempo")
 
         challenge = MCPChallenge(
             id="ch_test",
@@ -536,7 +540,7 @@ class TestVerifyOrChallenge:
             name = "charge"
 
             async def verify(self, credential: object, request: dict) -> Receipt:
-                return Receipt.success(reference="0x123")
+                return Receipt.success(reference="0x123", method="tempo")
 
         with pytest.raises(MalformedCredentialError):
             await verify_or_challenge(

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -4,7 +4,7 @@ from datetime import UTC, datetime
 
 import pytest
 
-from mpay import Challenge, Credential, Receipt
+from mpay import Challenge, ChallengeEcho, Credential, Receipt
 from mpay._parsing import ParseError
 
 
@@ -81,12 +81,13 @@ class TestChallenge:
 
     def test_roundtrip_with_optional_fields(self) -> None:
         """Challenge with optional fields should survive roundtrip."""
+        expires_dt = datetime(2025, 1, 15, 12, 0, 0, tzinfo=UTC)
         challenge = Challenge(
             id="test-id-123",
             method="tempo",
             intent="charge",
             request={"amount": "1000"},
-            expires="2025-01-15T12:00:00Z",
+            expires=expires_dt,
             digest="sha-256=:abc123:",
             description="Pay for API access",
         )
@@ -107,7 +108,13 @@ class TestCredential:
     def test_roundtrip(self) -> None:
         """Credential should survive roundtrip through header format."""
         credential = Credential(
-            id="test-id-123",
+            challenge=ChallengeEcho(
+                id="test-id-123",
+                realm="api.example.com",
+                method="tempo",
+                intent="charge",
+                request={"amount": "1000"},
+            ),
             payload={"hash": "0xabc123"},
             source="did:pkh:eip155:1:0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
         )
@@ -115,21 +122,31 @@ class TestCredential:
         header = credential.to_authorization()
         parsed = Credential.from_authorization(header)
 
-        assert parsed.id == credential.id
+        assert parsed.challenge.id == credential.challenge.id
+        assert parsed.challenge.realm == credential.challenge.realm
+        assert parsed.challenge.method == credential.challenge.method
+        assert parsed.challenge.intent == credential.challenge.intent
+        assert parsed.challenge.request == credential.challenge.request
         assert parsed.payload == credential.payload
         assert parsed.source == credential.source
 
     def test_roundtrip_without_source(self) -> None:
         """Credential without source should roundtrip."""
         credential = Credential(
-            id="test-id",
+            challenge=ChallengeEcho(
+                id="test-id",
+                realm="test.example.com",
+                method="tempo",
+                intent="charge",
+                request={"amount": "500"},
+            ),
             payload={"signature": "0x123"},
         )
 
         header = credential.to_authorization()
         parsed = Credential.from_authorization(header)
 
-        assert parsed.id == credential.id
+        assert parsed.challenge.id == credential.challenge.id
         assert parsed.payload == credential.payload
         assert parsed.source is None
 
@@ -138,11 +155,35 @@ class TestCredential:
         with pytest.raises(ParseError):
             Credential.from_authorization("Bearer abc123")
 
-    def test_parse_missing_id(self) -> None:
-        """Should reject credentials without id."""
+    def test_parse_missing_challenge(self) -> None:
+        """Should reject credentials without challenge."""
         header = "Payment eyJwYXlsb2FkIjp7fX0"  # {"payload": {}}
-        with pytest.raises(ParseError):
+        with pytest.raises(ParseError, match="challenge"):
             Credential.from_authorization(header)
+
+    def test_roundtrip_with_optional_challenge_fields(self) -> None:
+        """Credential with optional challenge fields should roundtrip."""
+        expires_dt = datetime(2025, 1, 15, 12, 0, 0, tzinfo=UTC)
+        credential = Credential(
+            challenge=ChallengeEcho(
+                id="test-id",
+                realm="api.example.com",
+                method="tempo",
+                intent="charge",
+                request={"amount": "1000"},
+                expires=expires_dt,
+                digest="sha-256=:abc123:",
+                description="Test payment",
+            ),
+            payload={"hash": "0xabc"},
+        )
+
+        header = credential.to_authorization()
+        parsed = Credential.from_authorization(header)
+
+        assert parsed.challenge.expires == credential.challenge.expires
+        assert parsed.challenge.digest == credential.challenge.digest
+        assert parsed.challenge.description == credential.challenge.description
 
 
 class TestReceipt:
@@ -151,6 +192,7 @@ class TestReceipt:
         timestamp = datetime(2024, 1, 20, 12, 0, 0, tzinfo=UTC)
         receipt = Receipt(
             status="success",
+            method="tempo",
             timestamp=timestamp,
             reference="0xabc123def456",
         )
@@ -159,39 +201,63 @@ class TestReceipt:
         parsed = Receipt.from_payment_receipt(header)
 
         assert parsed.status == receipt.status
+        assert parsed.method == receipt.method
         assert parsed.timestamp == receipt.timestamp
         assert parsed.reference == receipt.reference
 
     def test_roundtrip_failed(self) -> None:
         """Failed receipt should roundtrip."""
-        receipt = Receipt.failed("0x000")
+        receipt = Receipt.failed("0x000", method="tempo")
 
         header = receipt.to_payment_receipt()
         parsed = Receipt.from_payment_receipt(header)
 
         assert parsed.status == "failed"
+        assert parsed.method == "tempo"
 
     def test_success_factory(self) -> None:
         """Receipt.success() should create success receipt with timestamp."""
-        receipt = Receipt.success("0xabc123")
+        receipt = Receipt.success("0xabc123", method="tempo")
         assert receipt.status == "success"
+        assert receipt.method == "tempo"
         assert receipt.reference == "0xabc123"
         assert isinstance(receipt.timestamp, datetime)
         assert receipt.timestamp.tzinfo is not None
 
     def test_failed_factory(self) -> None:
         """Receipt.failed() should create failed receipt with timestamp."""
-        receipt = Receipt.failed("0xdef456")
+        receipt = Receipt.failed("0xdef456", method="tempo")
         assert receipt.status == "failed"
+        assert receipt.method == "tempo"
         assert receipt.reference == "0xdef456"
         assert isinstance(receipt.timestamp, datetime)
 
     def test_parse_invalid_status(self) -> None:
         """Should reject invalid status values."""
-        # {"status":"pending","timestamp":"2024-01-20T12:00:00Z","reference":"0x"}
-        b64 = (
-            "eyJzdGF0dXMiOiJwZW5kaW5nIiwidGltZXN0YW1wIjoiMjAyNC0wMS0yMFQxMjowMDow"
-            "MFoiLCJyZWZlcmVuY2UiOiIweCJ9"
-        )
+        # {"status":"pending","method":"tempo","timestamp":"2024-01-20T12:00:00Z","reference":"0x"}
+        import base64
+        import json
+
+        data = {
+            "status": "pending",
+            "method": "tempo",
+            "timestamp": "2024-01-20T12:00:00Z",
+            "reference": "0x",
+        }
+        b64 = base64.urlsafe_b64encode(json.dumps(data).encode()).decode().rstrip("=")
         with pytest.raises(ParseError):
+            Receipt.from_payment_receipt(b64)
+
+    def test_parse_missing_method(self) -> None:
+        """Should reject receipts without method field."""
+        import base64
+        import json
+
+        data = {
+            "status": "success",
+            "timestamp": "2024-01-20T12:00:00Z",
+            "reference": "0x123",
+        }
+        b64 = base64.urlsafe_b64encode(json.dumps(data).encode()).decode().rstrip("=")
+        with pytest.raises(ParseError, match="method"):
             Receipt.from_payment_receipt(b64)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2,9 +2,10 @@
 
 import pytest
 
-from mpay import Challenge, Credential, Receipt
+from mpay import Challenge, ChallengeEcho, Credential, Receipt
 from mpay.server import intent, requires_payment, verify_or_challenge
 from mpay.server.intent import VerificationError
+from mpay.server.verify import _compute_challenge_id, verify_challenge_id
 
 try:
     from starlette.responses import Response as StarletteResponse
@@ -22,7 +23,7 @@ class TestVerifyOrChallenge:
 
         @intent(name="charge")
         async def test_intent(credential: Credential, request: dict) -> Receipt:
-            return Receipt.success("0x123")
+            return Receipt.success("0x123", method="tempo")
 
         result = await verify_or_challenge(
             authorization=None,
@@ -42,7 +43,7 @@ class TestVerifyOrChallenge:
 
         @intent(name="charge")
         async def test_intent(credential: Credential, request: dict) -> Receipt:
-            return Receipt.success("0x123")
+            return Receipt.success("0x123", method="tempo")
 
         result = await verify_or_challenge(
             authorization="Bearer token123",
@@ -59,11 +60,20 @@ class TestVerifyOrChallenge:
 
         @intent(name="charge")
         async def test_intent(credential: Credential, request: dict) -> Receipt:
-            assert credential.id == "test-id"
+            assert credential.challenge.id == "test-id"
             assert credential.payload == {"hash": "0xabc"}
-            return Receipt.success("0x123")
+            return Receipt.success("0x123", method="tempo")
 
-        credential = Credential(id="test-id", payload={"hash": "0xabc"})
+        credential = Credential(
+            challenge=ChallengeEcho(
+                id="test-id",
+                realm="api.example.com",
+                method="tempo",
+                intent="charge",
+                request={"amount": "1000"},
+            ),
+            payload={"hash": "0xabc"},
+        )
         auth_header = credential.to_authorization()
 
         result = await verify_or_challenge(
@@ -75,8 +85,172 @@ class TestVerifyOrChallenge:
 
         assert isinstance(result, tuple)
         cred, receipt = result
-        assert cred.id == "test-id"
+        assert cred.challenge.id == "test-id"
         assert receipt.status == "success"
+
+
+class TestHMACBoundChallengeIds:
+    def test_compute_challenge_id_deterministic(self) -> None:
+        """HMAC challenge ID should be deterministic."""
+        id1 = _compute_challenge_id(
+            realm="api.example.com",
+            method="tempo",
+            intent="charge",
+            request={"amount": "1000"},
+            expires=None,
+            digest=None,
+            secret_key="test-secret",
+        )
+        id2 = _compute_challenge_id(
+            realm="api.example.com",
+            method="tempo",
+            intent="charge",
+            request={"amount": "1000"},
+            expires=None,
+            digest=None,
+            secret_key="test-secret",
+        )
+        assert id1 == id2
+
+    def test_compute_challenge_id_different_inputs(self) -> None:
+        """Different inputs should produce different HMAC IDs."""
+        id1 = _compute_challenge_id(
+            realm="api.example.com",
+            method="tempo",
+            intent="charge",
+            request={"amount": "1000"},
+            expires=None,
+            digest=None,
+            secret_key="test-secret",
+        )
+        id2 = _compute_challenge_id(
+            realm="api.example.com",
+            method="tempo",
+            intent="charge",
+            request={"amount": "2000"},  # Different amount
+            expires=None,
+            digest=None,
+            secret_key="test-secret",
+        )
+        assert id1 != id2
+
+    def test_verify_challenge_id_valid(self) -> None:
+        """Should verify valid HMAC-bound challenge ID."""
+        secret_key = "test-secret"
+        realm = "api.example.com"
+        request = {"amount": "1000"}
+
+        # Compute the expected ID
+        challenge_id = _compute_challenge_id(
+            realm=realm,
+            method="tempo",
+            intent="charge",
+            request=request,
+            expires=None,
+            digest=None,
+            secret_key=secret_key,
+        )
+
+        # Create credential with the computed ID
+        credential = Credential(
+            challenge=ChallengeEcho(
+                id=challenge_id,
+                realm=realm,
+                method="tempo",
+                intent="charge",
+                request=request,
+            ),
+            payload={"hash": "0xabc"},
+        )
+
+        assert verify_challenge_id(credential, realm, secret_key) is True
+
+    def test_verify_challenge_id_invalid(self) -> None:
+        """Should reject invalid HMAC-bound challenge ID."""
+        credential = Credential(
+            challenge=ChallengeEcho(
+                id="tampered-id",
+                realm="api.example.com",
+                method="tempo",
+                intent="charge",
+                request={"amount": "1000"},
+            ),
+            payload={"hash": "0xabc"},
+        )
+
+        assert verify_challenge_id(credential, "api.example.com", "test-secret") is False
+
+    @pytest.mark.asyncio
+    async def test_verify_or_challenge_with_secret_key(self) -> None:
+        """Should use HMAC-bound IDs when secret_key is provided."""
+
+        @intent(name="charge")
+        async def test_intent(credential: Credential, request: dict) -> Receipt:
+            return Receipt.success("0x123", method="tempo")
+
+        secret_key = "test-secret"
+        realm = "api.example.com"
+        request = {"amount": "1000"}
+
+        # Get challenge with HMAC-bound ID
+        result = await verify_or_challenge(
+            authorization=None,
+            intent=test_intent,
+            request=request,
+            realm=realm,
+            secret_key=secret_key,
+        )
+
+        assert isinstance(result, Challenge)
+        assert result.expires is not None
+
+        # Verify the challenge ID is HMAC-bound with the actual expires
+        expected_id = _compute_challenge_id(
+            realm=realm,
+            method="tempo",
+            intent="charge",
+            request=request,
+            expires=result.expires,
+            digest=None,
+            secret_key=secret_key,
+        )
+        assert result.id == expected_id
+
+    @pytest.mark.asyncio
+    async def test_verify_or_challenge_rejects_invalid_hmac(self) -> None:
+        """Should reject credentials with invalid HMAC IDs."""
+
+        @intent(name="charge")
+        async def test_intent(credential: Credential, request: dict) -> Receipt:
+            return Receipt.success("0x123", method="tempo")
+
+        secret_key = "test-secret"
+        realm = "api.example.com"
+        request = {"amount": "1000"}
+
+        # Create credential with invalid ID
+        credential = Credential(
+            challenge=ChallengeEcho(
+                id="invalid-id",
+                realm=realm,
+                method="tempo",
+                intent="charge",
+                request=request,
+            ),
+            payload={"hash": "0xabc"},
+        )
+        auth_header = credential.to_authorization()
+
+        result = await verify_or_challenge(
+            authorization=auth_header,
+            intent=test_intent,
+            request=request,
+            realm=realm,
+            secret_key=secret_key,
+        )
+
+        # Should return a new challenge instead of accepting invalid credential
+        assert isinstance(result, Challenge)
 
 
 class TestFunctionalIntent:
@@ -86,12 +260,21 @@ class TestFunctionalIntent:
 
         @intent(name="subscribe")
         async def my_subscribe(credential: Credential, request: dict) -> Receipt:
-            return Receipt.success(f"sub-{credential.id}")
+            return Receipt.success(f"sub-{credential.challenge.id}", method="tempo")
 
         assert my_subscribe.name == "subscribe"
 
         receipt = await my_subscribe.verify(
-            Credential(id="test", payload={}),
+            Credential(
+                challenge=ChallengeEcho(
+                    id="test",
+                    realm="test.com",
+                    method="tempo",
+                    intent="subscribe",
+                    request={"plan": "premium"},
+                ),
+                payload={},
+            ),
             {"plan": "premium"},
         )
         assert receipt.reference == "sub-test"
@@ -106,9 +289,18 @@ class TestClassBasedIntent:
             name = "custom"
 
             async def verify(self, credential: Credential, request: dict) -> Receipt:
-                return Receipt.success("custom-ref")
+                return Receipt.success("custom-ref", method="custom-method")
 
-        credential = Credential(id="test", payload={})
+        credential = Credential(
+            challenge=ChallengeEcho(
+                id="test",
+                realm="test.com",
+                method="custom-method",
+                intent="custom",
+                request={},
+            ),
+            payload={},
+        )
         auth_header = credential.to_authorization()
 
         result = await verify_or_challenge(
@@ -131,7 +323,7 @@ class TestVerificationError:
 
         @intent(name="charge")
         async def test_intent(credential: Credential, request: dict) -> Receipt:
-            return Receipt.success("0x123")
+            return Receipt.success("0x123", method="tempo")
 
         result = await verify_or_challenge(
             authorization="Payment not-valid-base64!!",
@@ -143,23 +335,32 @@ class TestVerificationError:
         assert isinstance(result, Challenge)
 
     @pytest.mark.asyncio
-    async def test_intent_can_raise_verification_error(self) -> None:
-        """VerificationError should propagate from intent."""
+    async def test_intent_verification_error_returns_challenge(self) -> None:
+        """VerificationError should return a new challenge (not propagate as 500)."""
 
         @intent(name="charge")
         async def failing_intent(credential: Credential, request: dict) -> Receipt:
             raise VerificationError("Payment verification failed")
 
-        credential = Credential(id="test", payload={})
+        credential = Credential(
+            challenge=ChallengeEcho(
+                id="test",
+                realm="api.example.com",
+                method="tempo",
+                intent="charge",
+                request={"amount": "1000"},
+            ),
+            payload={},
+        )
         auth_header = credential.to_authorization()
 
-        with pytest.raises(VerificationError, match="Payment verification failed"):
-            await verify_or_challenge(
-                authorization=auth_header,
-                intent=failing_intent,
-                request={"amount": "1000"},
-                realm="api.example.com",
-            )
+        result = await verify_or_challenge(
+            authorization=auth_header,
+            intent=failing_intent,
+            request={"amount": "1000"},
+            realm="api.example.com",
+        )
+        assert isinstance(result, Challenge)
 
 
 class MockRequest:
@@ -183,7 +384,7 @@ class TestRequiresPayment:
 
         @intent(name="charge")
         async def test_intent(credential: Credential, request: dict) -> Receipt:
-            return Receipt.success("0x123")
+            return Receipt.success("0x123", method="tempo")
 
         @requires_payment(
             intent=test_intent,
@@ -213,7 +414,7 @@ class TestRequiresPayment:
 
         @intent(name="charge")
         async def test_intent(credential: Credential, request: dict) -> Receipt:
-            return Receipt.success("tx-ref-123")
+            return Receipt.success("tx-ref-123", method="tempo")
 
         @requires_payment(
             intent=test_intent,
@@ -223,11 +424,20 @@ class TestRequiresPayment:
         async def handler(req: MockRequest, credential: Credential, receipt: Receipt) -> dict:
             return {
                 "data": "paid content",
-                "credential_id": credential.id,
+                "credential_id": credential.challenge.id,
                 "receipt_ref": receipt.reference,
             }
 
-        credential = Credential(id="test-cred-id", payload={"hash": "0xabc"})
+        credential = Credential(
+            challenge=ChallengeEcho(
+                id="test-cred-id",
+                realm="api.example.com",
+                method="tempo",
+                intent="charge",
+                request={"amount": "1000"},
+            ),
+            payload={"hash": "0xabc"},
+        )
         request = MockRequest(authorization=credential.to_authorization())
         result = await handler(request)
 
@@ -242,7 +452,7 @@ class TestRequiresPayment:
         @intent(name="charge")
         async def test_intent(credential: Credential, request: dict) -> Receipt:
             assert request["amount"] == "2000"
-            return Receipt.success("0x123")
+            return Receipt.success("0x123", method="tempo")
 
         @requires_payment(
             intent=test_intent,
@@ -255,7 +465,16 @@ class TestRequiresPayment:
         class RequestWithQuery(MockRequest):
             query_amount = "2000"
 
-        credential = Credential(id="test", payload={})
+        credential = Credential(
+            challenge=ChallengeEcho(
+                id="test",
+                realm="api.example.com",
+                method="tempo",
+                intent="charge",
+                request={"amount": "2000"},
+            ),
+            payload={},
+        )
         request = RequestWithQuery(authorization=credential.to_authorization())
         result = await handler(request)
 
@@ -267,7 +486,7 @@ class TestRequiresPayment:
 
         @intent(name="charge")
         async def test_intent(credential: Credential, request: dict) -> Receipt:
-            return Receipt.success("0x123")
+            return Receipt.success("0x123", method="tempo")
 
         @requires_payment(
             intent=test_intent,
@@ -277,9 +496,18 @@ class TestRequiresPayment:
         async def handler(
             req: DjangoStyleRequest, credential: Credential, receipt: Receipt
         ) -> dict:
-            return {"credential_id": credential.id}
+            return {"credential_id": credential.challenge.id}
 
-        credential = Credential(id="django-cred", payload={})
+        credential = Credential(
+            challenge=ChallengeEcho(
+                id="django-cred",
+                realm="api.example.com",
+                method="tempo",
+                intent="charge",
+                request={"amount": "1000"},
+            ),
+            payload={},
+        )
         request = DjangoStyleRequest(authorization=credential.to_authorization())
         result = await handler(request)
 
@@ -291,7 +519,7 @@ class TestRequiresPayment:
 
         @intent(name="charge")
         async def test_intent(credential: Credential, request: dict) -> Receipt:
-            return Receipt.success("0x123")
+            return Receipt.success("0x123", method="tempo")
 
         @requires_payment(
             intent=test_intent,
@@ -317,7 +545,7 @@ class TestRequiresPayment:
 
         @intent(name="charge")
         async def test_intent(credential: Credential, request: dict) -> Receipt:
-            return Receipt.success("0x123")
+            return Receipt.success("0x123", method="tempo")
 
         @requires_payment(
             intent=test_intent,
@@ -337,7 +565,7 @@ class TestRequiresPayment:
 
         @intent(name="charge")
         async def test_intent(credential: Credential, request: dict) -> Receipt:
-            return Receipt.success("0x123")
+            return Receipt.success("0x123", method="custom-method")
 
         @requires_payment(
             intent=test_intent,

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -202,15 +202,16 @@ class TestHMACBoundChallengeIds:
         )
 
         assert isinstance(result, Challenge)
-        assert result.expires is not None
+        # HMAC mode uses expires=None for deterministic IDs (stateless verification)
+        assert result.expires is None
 
-        # Verify the challenge ID is HMAC-bound with the actual expires
+        # Verify the challenge ID is HMAC-bound
         expected_id = _compute_challenge_id(
             realm=realm,
             method="tempo",
             intent="charge",
             request=request,
-            expires=result.expires,
+            expires=None,
             digest=None,
             secret_key=secret_key,
         )
@@ -335,8 +336,8 @@ class TestVerificationError:
         assert isinstance(result, Challenge)
 
     @pytest.mark.asyncio
-    async def test_intent_verification_error_returns_challenge(self) -> None:
-        """VerificationError should return a new challenge (not propagate as 500)."""
+    async def test_intent_can_raise_verification_error(self) -> None:
+        """VerificationError from intent should propagate to caller."""
 
         @intent(name="charge")
         async def failing_intent(credential: Credential, request: dict) -> Receipt:
@@ -354,13 +355,13 @@ class TestVerificationError:
         )
         auth_header = credential.to_authorization()
 
-        result = await verify_or_challenge(
-            authorization=auth_header,
-            intent=failing_intent,
-            request={"amount": "1000"},
-            realm="api.example.com",
-        )
-        assert isinstance(result, Challenge)
+        with pytest.raises(VerificationError, match="Payment verification failed"):
+            await verify_or_challenge(
+                authorization=auth_header,
+                intent=failing_intent,
+                request={"amount": "1000"},
+                realm="api.example.com",
+            )
 
 
 class MockRequest:

--- a/tests/test_tempo.py
+++ b/tests/test_tempo.py
@@ -8,7 +8,7 @@ import httpx
 import pytest
 from pytest_httpx import HTTPXMock
 
-from mpay import Challenge, Credential
+from mpay import Challenge, ChallengeEcho, Credential
 from mpay.methods.tempo import TempoAccount, tempo
 from mpay.methods.tempo.client import TempoMethod
 from mpay.methods.tempo.intents import ChargeIntent
@@ -22,6 +22,25 @@ from mpay.server.intent import VerificationError
 
 # Valid test private key (must be < secp256k1 order)
 TEST_PRIVATE_KEY = "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+# Valid 40-char hex addresses for tests
+TEST_CURRENCY = "0x1234567890123456789012345678901234567890"
+TEST_RECIPIENT = "0x4567890123456789012345678901234567890123"
+
+
+def make_credential(payload: dict, source: str | None = None) -> Credential:
+    """Create a test Credential with a minimal ChallengeEcho."""
+    return Credential(
+        challenge=ChallengeEcho(
+            id="test",
+            realm="test.example.com",
+            method="tempo",
+            intent="charge",
+            request={},
+        ),
+        payload=payload,
+        source=source,
+    )
 
 
 def mock_response(status_code: int = 200, json: dict | None = None) -> httpx.Response:
@@ -91,7 +110,7 @@ class TestTempoMethod:
             id="test",
             method="tempo",
             intent="charge",
-            request={"amount": "1000", "currency": "0x123", "recipient": "0x456"},
+            request={"amount": "1000", "currency": TEST_CURRENCY, "recipient": TEST_RECIPIENT},
         )
         with pytest.raises(ValueError, match="No account configured"):
             await method.create_credential(challenge)
@@ -138,7 +157,7 @@ class TestChargeIntent:
     async def test_verify_expired_request(self) -> None:
         """Should reject expired requests."""
         intent = ChargeIntent(rpc_url="https://rpc.test")
-        credential = Credential(id="test", payload={"type": "hash", "hash": "0x123"})
+        credential = make_credential({"type": "hash", "hash": "0x" + "1" * 64})
         expired = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
 
         with pytest.raises(VerificationError, match="expired"):
@@ -146,8 +165,8 @@ class TestChargeIntent:
                 credential,
                 {
                     "amount": "1000",
-                    "currency": "0x123",
-                    "recipient": "0x456",
+                    "currency": TEST_CURRENCY,
+                    "recipient": TEST_RECIPIENT,
                     "expires": expired,
                 },
             )
@@ -156,7 +175,7 @@ class TestChargeIntent:
     async def test_verify_invalid_payload(self) -> None:
         """Should reject invalid credential payload."""
         intent = ChargeIntent(rpc_url="https://rpc.test")
-        credential = Credential(id="test", payload="not-a-dict")
+        credential = make_credential("not-a-dict")
         future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
 
         with pytest.raises(VerificationError, match="Invalid credential payload"):
@@ -164,8 +183,8 @@ class TestChargeIntent:
                 credential,
                 {
                     "amount": "1000",
-                    "currency": "0x123",
-                    "recipient": "0x456",
+                    "currency": TEST_CURRENCY,
+                    "recipient": TEST_RECIPIENT,
                     "expires": future,
                 },
             )
@@ -174,7 +193,7 @@ class TestChargeIntent:
     async def test_verify_unknown_credential_type(self) -> None:
         """Should reject unknown credential types."""
         intent = ChargeIntent(rpc_url="https://rpc.test")
-        credential = Credential(id="test", payload={"type": "unknown"})
+        credential = make_credential({"type": "unknown"})
         future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
 
         with pytest.raises(VerificationError, match="Invalid credential type"):
@@ -182,8 +201,8 @@ class TestChargeIntent:
                 credential,
                 {
                     "amount": "1000",
-                    "currency": "0x123",
-                    "recipient": "0x456",
+                    "currency": TEST_CURRENCY,
+                    "recipient": TEST_RECIPIENT,
                     "expires": future,
                 },
             )
@@ -223,7 +242,8 @@ class TestChargeIntent:
         )
         intent._http_client = mock_client
 
-        credential = Credential(id="test", payload={"type": "hash", "hash": "0xabc123"})
+        test_hash = "0x" + "abc123".ljust(64, "0")
+        credential = make_credential({"type": "hash", "hash": test_hash})
         receipt = await intent.verify(
             credential,
             {
@@ -235,7 +255,7 @@ class TestChargeIntent:
         )
 
         assert receipt.status == "success"
-        assert receipt.reference == "0xabc123"
+        assert receipt.reference == test_hash
 
     @pytest.mark.asyncio
     async def test_verify_hash_tx_not_found(self) -> None:
@@ -249,7 +269,7 @@ class TestChargeIntent:
         )
         intent._http_client = mock_client
 
-        credential = Credential(id="test", payload={"type": "hash", "hash": "0xabc"})
+        credential = make_credential({"type": "hash", "hash": "0x" + "a" * 64})
         with pytest.raises(VerificationError, match="Transaction not found"):
             await intent.verify(
                 credential,
@@ -276,7 +296,7 @@ class TestChargeIntent:
         )
         intent._http_client = mock_client
 
-        credential = Credential(id="test", payload={"type": "hash", "hash": "0xabc"})
+        credential = make_credential({"type": "hash", "hash": "0x" + "a" * 64})
         receipt = await intent.verify(
             credential,
             {
@@ -304,7 +324,7 @@ class TestChargeIntent:
         )
         intent._http_client = mock_client
 
-        credential = Credential(id="test", payload={"type": "hash", "hash": "0xabc"})
+        credential = make_credential({"type": "hash", "hash": "0x" + "a" * 64})
         with pytest.raises(VerificationError, match="Transfer log"):
             await intent.verify(
                 credential,
@@ -350,10 +370,7 @@ class TestChargeIntent:
         )
         intent._http_client = mock_client
 
-        credential = Credential(
-            id="test",
-            payload={"type": "transaction", "signature": "0xabcdef1234567890"},
-        )
+        credential = make_credential({"type": "transaction", "signature": "0xabcdef1234567890"})
         receipt = await intent.verify(
             credential,
             {
@@ -382,10 +399,7 @@ class TestChargeIntent:
         )
         intent._http_client = mock_client
 
-        credential = Credential(
-            id="test",
-            payload={"type": "transaction", "signature": "0xabcdef1234567890"},
-        )
+        credential = make_credential({"type": "transaction", "signature": "0xabcdef1234567890"})
         with pytest.raises(VerificationError, match="Transaction submission failed"):
             await intent.verify(
                 credential,
@@ -417,6 +431,10 @@ class TestSponsoredTransfer:
             url="https://rpc.test",
             json={"jsonrpc": "2.0", "result": "0x1", "id": 1},
         )
+        httpx_mock.add_response(
+            url="https://rpc.test",
+            json={"jsonrpc": "2.0", "result": "0x1", "id": 1},
+        )
 
         challenge = Challenge(
             id="test-sponsored",
@@ -428,14 +446,14 @@ class TestSponsoredTransfer:
                 "recipient": "0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
                 "methodDetails": {
                     "feePayer": True,
-                    "feePayerUrl": "https://sponsor.test",
+                    "feePayerUrl": "https://sponsor.tempo.xyz",
                 },
             },
         )
 
         credential = await method.create_credential(challenge)
 
-        assert credential.id == "test-sponsored"
+        assert credential.challenge.id == "test-sponsored"
         assert credential.payload["type"] == "transaction"
         assert credential.payload["signature"].startswith("0x76")
 
@@ -445,7 +463,7 @@ class TestSponsoredTransfer:
         future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
 
         httpx_mock.add_response(
-            url="https://sponsor.test",
+            url="https://sponsor.tempo.xyz",
             json={"jsonrpc": "2.0", "result": "0xsponsored_hash", "id": 1},
         )
 
@@ -475,10 +493,7 @@ class TestSponsoredTransfer:
         )
 
         intent = ChargeIntent(rpc_url="https://rpc.test")
-        credential = Credential(
-            id="test",
-            payload={"type": "transaction", "signature": "0x76abcdef"},
-        )
+        credential = make_credential({"type": "transaction", "signature": "0x76abcdef"})
 
         receipt = await intent.verify(
             credential,
@@ -489,7 +504,7 @@ class TestSponsoredTransfer:
                 "expires": future,
                 "methodDetails": {
                     "feePayer": True,
-                    "feePayerUrl": "https://sponsor.test",
+                    "feePayerUrl": "https://sponsor.tempo.xyz",
                 },
             },
         )
@@ -503,7 +518,7 @@ class TestSponsoredTransfer:
         future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
 
         httpx_mock.add_response(
-            url="https://sponsor.test",
+            url="https://sponsor.tempo.xyz",
             json={
                 "jsonrpc": "2.0",
                 "error": {"code": -32000, "message": "insufficient funds"},
@@ -512,10 +527,7 @@ class TestSponsoredTransfer:
         )
 
         intent = ChargeIntent(rpc_url="https://rpc.test")
-        credential = Credential(
-            id="test",
-            payload={"type": "transaction", "signature": "0x76abcdef"},
-        )
+        credential = make_credential({"type": "transaction", "signature": "0x76abcdef"})
 
         with pytest.raises(VerificationError, match="Transaction submission failed"):
             await intent.verify(
@@ -527,7 +539,7 @@ class TestSponsoredTransfer:
                     "expires": future,
                     "methodDetails": {
                         "feePayer": True,
-                        "feePayerUrl": "https://sponsor.test",
+                        "feePayerUrl": "https://sponsor.tempo.xyz",
                     },
                 },
             )
@@ -555,17 +567,18 @@ class TestSchemas:
             expires="2030-01-20T12:00:00Z",
             methodDetails=MethodDetails(
                 feePayer=True,
-                feePayerUrl="https://sponsor.test",
+                feePayerUrl="https://sponsor.tempo.xyz",
             ),
         )
         assert req.methodDetails.feePayer is True
-        assert req.methodDetails.feePayerUrl == "https://sponsor.test"
+        assert req.methodDetails.feePayerUrl == "https://sponsor.tempo.xyz"
 
     def test_hash_credential_payload(self) -> None:
         """Should validate hash credential payload."""
-        payload = HashCredentialPayload(type="hash", hash="0xabc123")
+        valid_hash = "0x" + "a" * 64
+        payload = HashCredentialPayload(type="hash", hash=valid_hash)
         assert payload.type == "hash"
-        assert payload.hash == "0xabc123"
+        assert payload.hash == valid_hash
 
     def test_transaction_credential_payload(self) -> None:
         """Should validate transaction credential payload."""


### PR DESCRIPTION
## Summary

Fixes 3 bugs discovered during audit test updates:

### Changes

1. **HMAC mode uses `expires=None` for deterministic IDs** - Previously `verify_or_challenge` always set `expires = datetime.now() + ttl`, causing HMAC IDs to change on every call. Now HMAC mode omits expires for stateless verification.

2. **Fixed `_create_challenge` type signature** - Parameter was typed as `expires: str | None` but received `datetime | None`.

3. **`VerificationError` now propagates** - Previously swallowed and returned a new Challenge. Now re-raises so callers can distinguish 'missing credential' (Challenge) from 'verification failed' (VerificationError for 403 handling).

### Testing

- All 112 tests pass
- Lint/format clean

### Related

Part of the 22-fix audit comparing mpay-python against TypeScript SDK and IETF Payment Auth spec.