### PR TITLE
fix: update credential format to match new spec with ChallengeEcho

### DIFF
--- a/src/mpay/__init__.py
+++ b/src/mpay/__init__.py
@@ -23,7 +23,14 @@ from mpay._parsing import (
     parse_www_authenticate,
 )
 
-__all__ = ["Challenge", "Credential", "ParseError", "Receipt", "generate_challenge_id"]
+__all__ = [
+    "Challenge",
+    "ChallengeEcho",
+    "Credential",
+    "ParseError",
+    "Receipt",
+    "generate_challenge_id",
+]
 
 
 def _b64url_encode(data: str) -> str:
@@ -124,6 +131,8 @@ class Challenge:
     method: str
     intent: str
     request: dict[str, Any]
+    realm: str = ""
+    request_b64: str = ""
     digest: str | None = None
     expires: str | None = None
     description: str | None = None
@@ -215,19 +224,68 @@ class Challenge:
         )
         return _constant_time_equal(self.id, expected_id)
 
+    def to_echo(self) -> ChallengeEcho:
+        """Create a ChallengeEcho for use in credentials.
+
+        Returns:
+            A ChallengeEcho with the challenge parameters.
+        """
+        return ChallengeEcho(
+            id=self.id,
+            realm=self.realm,
+            method=self.method,
+            intent=self.intent,
+            request=self.request_b64,
+            expires=self.expires,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ChallengeEcho:
+    """Challenge echo in credential (echoes server challenge parameters).
+
+    This is included in the credential to bind the payment to the original challenge.
+    The `request` field is the raw base64url string (not re-encoded).
+
+    Example:
+        echo = ChallengeEcho(
+            id="challenge-id",
+            realm="api.example.com",
+            method="tempo",
+            intent="charge",
+            request="eyJhbW91bnQiOiIxMDAwIn0",
+        )
+    """
+
+    id: str
+    realm: str
+    method: str
+    intent: str
+    request: str
+    expires: str | None = None
+
 
 @dataclass(frozen=True, slots=True)
 class Credential:
     """The credential passed to the verify function.
 
+    Contains the challenge echo and the payment proof.
+
     Example:
-        credential = Credential(
+        echo = ChallengeEcho(
             id="challenge-id",
-            payload={"signature": "0x..."},
+            realm="api.example.com",
+            method="tempo",
+            intent="charge",
+            request="eyJhbW91bnQiOiIxMDAwIn0",
+        )
+        credential = Credential(
+            challenge=echo,
+            payload={"type": "transaction", "signature": "0x..."},
         )
     """
 
-    id: str
+    challenge: ChallengeEcho
     payload: dict[str, Any]
     source: str | None = None
 

--- a/src/mpay/_parsing.py
+++ b/src/mpay/_parsing.py
@@ -134,6 +134,8 @@ def parse_www_authenticate(header: str) -> Challenge:
         method=method,
         intent=intent,
         request=request,
+        realm=realm,
+        request_b64=request_b64,
         digest=params.get("digest"),
         expires=params.get("expires"),
         description=params.get("description"),
@@ -176,11 +178,11 @@ def parse_authorization(header: str) -> Credential:
         Payment <base64-credential>
 
     The credential payload is a base64-encoded JSON object with:
-        - id: Challenge identifier (matches the original challenge)
+        - challenge: ChallengeEcho object containing id, realm, method, intent, request
         - payload: Method-specific credential data
         - source: Optional payer DID
     """
-    from mpay import Credential
+    from mpay import ChallengeEcho, Credential
 
     header = header.strip()
 
@@ -190,13 +192,28 @@ def parse_authorization(header: str) -> Credential:
     credential_b64 = header[8:].strip()
     data = _b64_decode(credential_b64)
 
-    if "id" not in data:
-        raise ParseError("Credential missing required field: id")
+    if "challenge" not in data:
+        raise ParseError("Credential missing required field: challenge")
     if "payload" not in data:
         raise ParseError("Credential missing required field: payload")
 
+    challenge_data = data["challenge"]
+    if not isinstance(challenge_data, dict):
+        raise ParseError("Credential challenge must be an object")
+    if "id" not in challenge_data:
+        raise ParseError("Credential challenge missing required field: id")
+
+    echo = ChallengeEcho(
+        id=str(challenge_data["id"]),
+        realm=str(challenge_data.get("realm", "")),
+        method=str(challenge_data.get("method", "")),
+        intent=str(challenge_data.get("intent", "")),
+        request=str(challenge_data.get("request", "")),
+        expires=str(challenge_data["expires"]) if challenge_data.get("expires") else None,
+    )
+
     return Credential(
-        id=str(data["id"]),
+        challenge=echo,
         payload=data["payload"],
         source=str(data["source"]) if data.get("source") else None,
     )
@@ -207,9 +224,24 @@ def format_authorization(credential: Credential) -> str:
 
     Output format:
         Payment <base64-credential>
+
+    The credential is a JSON object with:
+        - challenge: ChallengeEcho with id, realm, method, intent, request, expires
+        - payload: Method-specific credential data
+        - source: Optional payer DID
     """
+    challenge_dict: dict[str, Any] = {
+        "id": credential.challenge.id,
+        "realm": credential.challenge.realm,
+        "method": credential.challenge.method,
+        "intent": credential.challenge.intent,
+        "request": credential.challenge.request,
+    }
+    if credential.challenge.expires:
+        challenge_dict["expires"] = credential.challenge.expires
+
     payload: dict[str, Any] = {
-        "id": credential.id,
+        "challenge": challenge_dict,
         "payload": credential.payload,
     }
     if credential.source:

--- a/src/mpay/extensions/mcp/types.py
+++ b/src/mpay/extensions/mcp/types.py
@@ -159,11 +159,25 @@ class MCPCredential:
         return cls.from_dict(meta[META_CREDENTIAL])
 
     def to_core(self) -> Credential:
-        """Convert to core Credential type (uses challenge.id only)."""
-        from mpay import Credential
+        """Convert to core Credential type."""
+        import base64
+        import json
 
-        return Credential(
+        from mpay import ChallengeEcho, Credential
+
+        request_json = json.dumps(self.challenge.request, separators=(",", ":"))
+        request_b64 = base64.urlsafe_b64encode(request_json.encode()).decode().rstrip("=")
+
+        echo = ChallengeEcho(
             id=self.challenge.id,
+            realm=self.challenge.realm,
+            method=self.challenge.method,
+            intent=self.challenge.intent,
+            request=request_b64,
+            expires=self.challenge.expires,
+        )
+        return Credential(
+            challenge=echo,
             payload=self.payload,
             source=self.source,
         )

--- a/src/mpay/methods/tempo/client.py
+++ b/src/mpay/methods/tempo/client.py
@@ -100,8 +100,10 @@ class TempoMethod:
             nonce_key=nonce_key,
             memo=memo,
         )
+
+        chain_id = await self._get_chain_id()
         return Credential(
-            id=challenge.id,
+            challenge=challenge.to_echo(),
             payload={"type": "transaction", "signature": raw_tx},
             source=f"did:pkh:eip155:{chain_id}:{self.account.address}",
         )
@@ -217,6 +219,21 @@ class TempoMethod:
         memo_clean = memo[2:] if memo.startswith("0x") else memo
         memo_padded = memo_clean.lower().zfill(64)
         return f"0x{selector}{to_padded}{amount_padded}{memo_padded}"
+
+    async def _get_chain_id(self) -> int:
+        """Fetch the chain ID from the RPC endpoint."""
+        import httpx
+
+        async with httpx.AsyncClient(timeout=DEFAULT_TIMEOUT) as client:
+            chain_resp = await client.post(
+                self.rpc_url,
+                json={"jsonrpc": "2.0", "method": "eth_chainId", "params": [], "id": 1},
+            )
+            chain_resp.raise_for_status()
+            chain_result = chain_resp.json()
+            if "error" in chain_result:
+                raise TransactionError("Failed to fetch chain ID")
+            return int(chain_result["result"], 16)
 
 
 def tempo(

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,27 @@
 """mpay test suite."""
+
+from typing import Any
+
+from mpay import ChallengeEcho, Credential
+
+
+def make_credential(
+    payload: dict[str, Any],
+    challenge_id: str = "test",
+    realm: str = "test.example.com",
+    method: str = "tempo",
+    intent: str = "charge",
+    request: str = "e30",
+    source: str | None = None,
+    expires: str | None = None,
+) -> Credential:
+    """Create a Credential with a ChallengeEcho for testing."""
+    echo = ChallengeEcho(
+        id=challenge_id,
+        realm=realm,
+        method=method,
+        intent=intent,
+        request=request,
+        expires=expires,
+    )
+    return Credential(challenge=echo, payload=payload, source=source)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -6,8 +6,9 @@ import httpx
 import pytest
 from pytest_httpx import HTTPXMock
 
-from mpay import Challenge, Credential
+from mpay import Challenge
 from mpay.client import Client, PaymentTransport, get, post, request
+from tests import make_credential
 
 
 class MockMethod:
@@ -17,9 +18,9 @@ class MockMethod:
 
     def __init__(self) -> None:
         self.create_credential = AsyncMock(
-            return_value=Credential(
-                id="test-id",
+            return_value=make_credential(
                 payload={"hash": "0xabc"},
+                challenge_id="test-id",
             )
         )
 

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -181,7 +181,10 @@ class TestMCPCredential:
         )
         core = mcp_credential.to_core()
         assert isinstance(core, Credential)
-        assert core.id == "ch_abc"
+        assert core.challenge.id == "ch_abc"
+        assert core.challenge.realm == "api.example.com"
+        assert core.challenge.method == "tempo"
+        assert core.challenge.intent == "charge"
         assert core.payload == {"signature": "0xabc"}
         assert core.source == "0x1234"
 

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -6,6 +6,7 @@ import pytest
 
 from mpay import Challenge, Credential, Receipt
 from mpay._parsing import ParseError
+from tests import make_credential
 
 
 class TestChallenge:
@@ -106,8 +107,8 @@ class TestChallenge:
 class TestCredential:
     def test_roundtrip(self) -> None:
         """Credential should survive roundtrip through header format."""
-        credential = Credential(
-            id="test-id-123",
+        credential = make_credential(
+            challenge_id="test-id-123",
             payload={"hash": "0xabc123"},
             source="did:pkh:eip155:1:0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
         )
@@ -115,21 +116,21 @@ class TestCredential:
         header = credential.to_authorization()
         parsed = Credential.from_authorization(header)
 
-        assert parsed.id == credential.id
+        assert parsed.challenge.id == credential.challenge.id
         assert parsed.payload == credential.payload
         assert parsed.source == credential.source
 
     def test_roundtrip_without_source(self) -> None:
         """Credential without source should roundtrip."""
-        credential = Credential(
-            id="test-id",
+        credential = make_credential(
+            challenge_id="test-id",
             payload={"signature": "0x123"},
         )
 
         header = credential.to_authorization()
         parsed = Credential.from_authorization(header)
 
-        assert parsed.id == credential.id
+        assert parsed.challenge.id == credential.challenge.id
         assert parsed.payload == credential.payload
         assert parsed.source is None
 
@@ -139,7 +140,7 @@ class TestCredential:
             Credential.from_authorization("Bearer abc123")
 
     def test_parse_missing_id(self) -> None:
-        """Should reject credentials without id."""
+        """Should reject credentials without challenge."""
         header = "Payment eyJwYXlsb2FkIjp7fX0"  # {"payload": {}}
         with pytest.raises(ParseError):
             Credential.from_authorization(header)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -5,6 +5,7 @@ import pytest
 from mpay import Challenge, Credential, Receipt
 from mpay.server import intent, requires_payment, verify_or_challenge
 from mpay.server.intent import VerificationError
+from tests import make_credential
 
 try:
     from starlette.responses import Response as StarletteResponse
@@ -61,11 +62,11 @@ class TestVerifyOrChallenge:
 
         @intent(name="charge")
         async def test_intent(credential: Credential, request: dict) -> Receipt:
-            assert credential.id == "test-id"
+            assert credential.challenge.id == "test-id"
             assert credential.payload == {"hash": "0xabc"}
             return Receipt.success("0x123")
 
-        credential = Credential(id="test-id", payload={"hash": "0xabc"})
+        credential = make_credential(payload={"hash": "0xabc"}, challenge_id="test-id")
         auth_header = credential.to_authorization()
 
         result = await verify_or_challenge(
@@ -78,7 +79,7 @@ class TestVerifyOrChallenge:
 
         assert isinstance(result, tuple)
         cred, receipt = result
-        assert cred.id == "test-id"
+        assert cred.challenge.id == "test-id"
         assert receipt.status == "success"
 
 
@@ -89,12 +90,12 @@ class TestFunctionalIntent:
 
         @intent(name="subscribe")
         async def my_subscribe(credential: Credential, request: dict) -> Receipt:
-            return Receipt.success(f"sub-{credential.id}")
+            return Receipt.success(f"sub-{credential.challenge.id}")
 
         assert my_subscribe.name == "subscribe"
 
         receipt = await my_subscribe.verify(
-            Credential(id="test", payload={}),
+            make_credential(payload={}, challenge_id="test"),
             {"plan": "premium"},
         )
         assert receipt.reference == "sub-test"
@@ -111,7 +112,7 @@ class TestClassBasedIntent:
             async def verify(self, credential: Credential, request: dict) -> Receipt:
                 return Receipt.success("custom-ref")
 
-        credential = Credential(id="test", payload={})
+        credential = make_credential(payload={}, challenge_id="test")
         auth_header = credential.to_authorization()
 
         result = await verify_or_challenge(
@@ -155,7 +156,7 @@ class TestVerificationError:
         async def failing_intent(credential: Credential, request: dict) -> Receipt:
             raise VerificationError("Payment verification failed")
 
-        credential = Credential(id="test", payload={})
+        credential = make_credential(payload={}, challenge_id="test")
         auth_header = credential.to_authorization()
 
         with pytest.raises(VerificationError, match="Payment verification failed"):
@@ -175,7 +176,7 @@ class TestVerificationError:
         async def failing_receipt_intent(credential: Credential, request: dict) -> Receipt:
             return Receipt.failed("tx-reverted-123")
 
-        credential = Credential(id="test", payload={})
+        credential = make_credential(payload={}, challenge_id="test")
         auth_header = credential.to_authorization()
 
         with pytest.raises(VerificationError, match="payment failed: tx-reverted-123"):
@@ -195,7 +196,7 @@ class TestVerificationError:
         async def success_intent(credential: Credential, request: dict) -> Receipt:
             return Receipt.success("tx-success-456")
 
-        credential = Credential(id="test", payload={})
+        credential = make_credential(payload={}, challenge_id="test")
         auth_header = credential.to_authorization()
 
         result = await verify_or_challenge(
@@ -275,11 +276,11 @@ class TestRequiresPayment:
         async def handler(req: MockRequest, credential: Credential, receipt: Receipt) -> dict:
             return {
                 "data": "paid content",
-                "credential_id": credential.id,
+                "credential_id": credential.challenge.id,
                 "receipt_ref": receipt.reference,
             }
 
-        credential = Credential(id="test-cred-id", payload={"hash": "0xabc"})
+        credential = make_credential(payload={"hash": "0xabc"}, challenge_id="test-cred-id")
         request = MockRequest(authorization=credential.to_authorization())
         result = await handler(request)
 
@@ -308,7 +309,7 @@ class TestRequiresPayment:
         class RequestWithQuery(MockRequest):
             query_amount = "2000"
 
-        credential = Credential(id="test", payload={})
+        credential = make_credential(payload={}, challenge_id="test")
         request = RequestWithQuery(authorization=credential.to_authorization())
         result = await handler(request)
 
@@ -331,9 +332,9 @@ class TestRequiresPayment:
         async def handler(
             req: DjangoStyleRequest, credential: Credential, receipt: Receipt
         ) -> dict:
-            return {"credential_id": credential.id}
+            return {"credential_id": credential.challenge.id}
 
-        credential = Credential(id="django-cred", payload={})
+        credential = make_credential(payload={}, challenge_id="django-cred")
         request = DjangoStyleRequest(authorization=credential.to_authorization())
         result = await handler(request)
 

--- a/tests/test_tempo.py
+++ b/tests/test_tempo.py
@@ -8,7 +8,7 @@ import httpx
 import pytest
 from pytest_httpx import HTTPXMock
 
-from mpay import Challenge, Credential
+from mpay import Challenge
 from mpay.methods.tempo import TempoAccount, tempo
 from mpay.methods.tempo.client import TempoMethod
 from mpay.methods.tempo.intents import ChargeIntent
@@ -19,6 +19,7 @@ from mpay.methods.tempo.schemas import (
     TransactionCredentialPayload,
 )
 from mpay.server.intent import VerificationError
+from tests import make_credential
 
 # Valid test private key (must be < secp256k1 order)
 TEST_PRIVATE_KEY = "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
@@ -138,7 +139,7 @@ class TestChargeIntent:
     async def test_verify_expired_request(self) -> None:
         """Should reject expired requests."""
         intent = ChargeIntent(rpc_url="https://rpc.test")
-        credential = Credential(id="test", payload={"type": "hash", "hash": "0x123"})
+        credential = make_credential(payload={"type": "hash", "hash": "0x123"})
         expired = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
 
         with pytest.raises(VerificationError, match="expired"):
@@ -156,7 +157,7 @@ class TestChargeIntent:
     async def test_verify_invalid_payload(self) -> None:
         """Should reject invalid credential payload."""
         intent = ChargeIntent(rpc_url="https://rpc.test")
-        credential = Credential(id="test", payload="not-a-dict")
+        credential = make_credential(payload="not-a-dict")
         future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
 
         with pytest.raises(VerificationError, match="Invalid credential payload"):
@@ -174,7 +175,7 @@ class TestChargeIntent:
     async def test_verify_unknown_credential_type(self) -> None:
         """Should reject unknown credential types."""
         intent = ChargeIntent(rpc_url="https://rpc.test")
-        credential = Credential(id="test", payload={"type": "unknown"})
+        credential = make_credential(payload={"type": "unknown"})
         future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
 
         with pytest.raises(VerificationError, match="Invalid credential type"):
@@ -223,7 +224,7 @@ class TestChargeIntent:
         )
         intent._http_client = mock_client
 
-        credential = Credential(id="test", payload={"type": "hash", "hash": "0xabc123"})
+        credential = make_credential(payload={"type": "hash", "hash": "0xabc123"})
         receipt = await intent.verify(
             credential,
             {
@@ -249,7 +250,7 @@ class TestChargeIntent:
         )
         intent._http_client = mock_client
 
-        credential = Credential(id="test", payload={"type": "hash", "hash": "0xabc"})
+        credential = make_credential(payload={"type": "hash", "hash": "0xabc"})
         with pytest.raises(VerificationError, match="Transaction not found"):
             await intent.verify(
                 credential,
@@ -276,7 +277,7 @@ class TestChargeIntent:
         )
         intent._http_client = mock_client
 
-        credential = Credential(id="test", payload={"type": "hash", "hash": "0xabc"})
+        credential = make_credential(payload={"type": "hash", "hash": "0xabc"})
         receipt = await intent.verify(
             credential,
             {
@@ -304,7 +305,7 @@ class TestChargeIntent:
         )
         intent._http_client = mock_client
 
-        credential = Credential(id="test", payload={"type": "hash", "hash": "0xabc"})
+        credential = make_credential(payload={"type": "hash", "hash": "0xabc"})
         with pytest.raises(VerificationError, match="Transfer log"):
             await intent.verify(
                 credential,
@@ -350,8 +351,7 @@ class TestChargeIntent:
         )
         intent._http_client = mock_client
 
-        credential = Credential(
-            id="test",
+        credential = make_credential(
             payload={"type": "transaction", "signature": "0xabcdef1234567890"},
         )
         receipt = await intent.verify(
@@ -382,8 +382,7 @@ class TestChargeIntent:
         )
         intent._http_client = mock_client
 
-        credential = Credential(
-            id="test",
+        credential = make_credential(
             payload={"type": "transaction", "signature": "0xabcdef1234567890"},
         )
         with pytest.raises(VerificationError, match="Transaction submission failed"):
@@ -417,6 +416,10 @@ class TestSponsoredTransfer:
             url="https://rpc.test",
             json={"jsonrpc": "2.0", "result": "0x1", "id": 1},
         )
+        httpx_mock.add_response(
+            url="https://rpc.test",
+            json={"jsonrpc": "2.0", "result": "0x1", "id": 1},
+        )
 
         challenge = Challenge(
             id="test-sponsored",
@@ -431,11 +434,13 @@ class TestSponsoredTransfer:
                     "feePayerUrl": "https://sponsor.test",
                 },
             },
+            realm="test.example.com",
+            request_b64="e30",
         )
 
         credential = await method.create_credential(challenge)
 
-        assert credential.id == "test-sponsored"
+        assert credential.challenge.id == "test-sponsored"
         assert credential.payload["type"] == "transaction"
         assert credential.payload["signature"].startswith("0x76")
 
@@ -475,8 +480,7 @@ class TestSponsoredTransfer:
         )
 
         intent = ChargeIntent(rpc_url="https://rpc.test")
-        credential = Credential(
-            id="test",
+        credential = make_credential(
             payload={"type": "transaction", "signature": "0x76abcdef"},
         )
 
@@ -512,8 +516,7 @@ class TestSponsoredTransfer:
         )
 
         intent = ChargeIntent(rpc_url="https://rpc.test")
-        credential = Credential(
-            id="test",
+        credential = make_credential(
             payload={"type": "transaction", "signature": "0x76abcdef"},
         )
 


### PR DESCRIPTION
## Summary

The credential format has been updated to match the mpay-rs SDK and server expectations. The new format includes a full `challenge` object (ChallengeEcho) instead of just the challenge ID.

## Problem

The Python SDK was sending credentials in an old format:
```json
{"id": "...", "payload": {...}, "source": "..."}
```

But the server and mpay-rs use the new spec format:
```json
{
  "challenge": {"id": "...", "realm": "...", "method": "...", "intent": "...", "request": "..."},
  "payload": {...},
  "source": "..."
}
```

This caused `malformed_credential` errors when using mpay-python against `storage.payments.tempo.xyz`.

## Changes

- Add `ChallengeEcho` dataclass to mirror Rust SDK structure
- Update `Credential` to use `challenge: ChallengeEcho` instead of `id: str`
- Update `format_authorization`/`parse_authorization` for new format
- Update `Challenge` to store `realm` and `request_b64` for echo creation
- Update Tempo client to create credentials with full challenge echo
- Update MCP extension's `MCPCredential.to_core()` for new format
- Update all tests to use new `make_credential()` helper

## Testing

- All 104 tests pass
- Verified working against `storage.payments.tempo.xyz`:
```
Success: 200 hello cloudflare
```