### PR TITLE
feat: add HMAC-SHA256 challenge ID generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,29 +16,31 @@ Python SDK for the Machine Payments Protocol (MPP) - an implementation of the ["
 
 ```python
 from mpay import Challenge
-from mpay.server import verify_or_challenge
-from mpay.methods.tempo import ChargeIntent
+from mpay.server import Mpay
+from mpay.methods.tempo import TempoMethod
 
-intent = ChargeIntent(rpc_url="https://rpc.tempo.xyz")
+# Create handler with bound secret_key (matches TypeScript pattern)
+payment = Mpay(
+    method=TempoMethod(rpc_url="https://rpc.tempo.xyz"),
+    realm="api.example.com",
+    secret_key="my-server-secret",
+)
 
 async def handler(request):
-    result = await verify_or_challenge(
+    result = await payment.charge(
         authorization=request.headers.get("Authorization"),
-        intent=intent,
         request={
             "amount": "1000000",
             "currency": "0x20c0000000000000000000000000000000000001",
             "recipient": "0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
             "expires": "2030-01-20T12:00:00Z",
         },
-        realm="api.example.com",
-        secret_key="my-server-secret",  # Enables HMAC-bound challenge IDs
     )
 
     if isinstance(result, Challenge):
         return Response(
             status=402,
-            headers={"WWW-Authenticate": result.to_www_authenticate("api.example.com")},
+            headers={"WWW-Authenticate": result.to_www_authenticate(payment.realm)},
         )
 
     credential, receipt = result

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ from mpay import Challenge
 from mpay.server import Mpay
 from mpay.methods.tempo import TempoMethod
 
-# Create handler with bound secret_key (matches TypeScript pattern)
+# Create handler with bound secret_key
 payment = Mpay(
     method=TempoMethod(rpc_url="https://rpc.tempo.xyz"),
     realm="api.example.com",

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ async def handler(request):
             "expires": "2030-01-20T12:00:00Z",
         },
         realm="api.example.com",
+        secret_key="my-server-secret",  # Enables HMAC-bound challenge IDs
     )
 
     if isinstance(result, Challenge):
@@ -188,6 +189,7 @@ intent = ChargeIntent(rpc_url="https://rpc.tempo.xyz")
     intent=intent,
     request={"amount": "1000", "currency": "0x...", "recipient": "0x..."},
     realm="api.example.com",
+    secret_key="my-server-secret",
 )
 async def get_resource(request: Request, credential: Credential, receipt: Receipt):
     return {"data": "paid content", "payer": credential.source}
@@ -200,6 +202,7 @@ With dynamic request params:
     intent=intent,
     request=lambda req: {"amount": req.query_params.get("price", "1000"), ...},
     realm="api.example.com",
+    secret_key="my-server-secret",
 )
 async def dynamic_pricing(request: Request, credential: Credential, receipt: Receipt):
     return {"data": "..."}
@@ -224,6 +227,7 @@ result = await verify_or_challenge(
     intent=intent,
     request={"amount": "1000", ...},
     realm="api.example.com",
+    secret_key="my-server-secret",
 )
 
 if isinstance(result, Challenge):

--- a/examples/api-server/server.py
+++ b/examples/api-server/server.py
@@ -4,10 +4,11 @@ import os
 from datetime import UTC, datetime, timedelta
 
 from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
 
-from mpay import Credential, Receipt
-from mpay.methods.tempo import ChargeIntent
-from mpay.server import requires_payment
+from mpay import Challenge, Credential, Receipt
+from mpay.methods.tempo import TempoMethod
+from mpay.server import Mpay
 
 app = FastAPI(
     title="Payment-Protected API",
@@ -18,12 +19,18 @@ RPC_URL = os.environ.get("TEMPO_RPC_URL", "https://rpc.testnet.tempo.xyz/")
 DESTINATION = os.environ.get(
     "PAYMENT_DESTINATION", "0x742d35Cc6634c0532925a3b844bC9e7595F8fE00"
 )
+SECRET_KEY = os.environ.get("PAYMENT_SECRET_KEY", "example-server-secret-key")
 ALPHA_USD = "0x20c0000000000000000000000000000000000001"
 
-intent = ChargeIntent(rpc_url=RPC_URL)
+# Create payment handler with bound secret_key
+payment = Mpay(
+    method=TempoMethod(rpc_url=RPC_URL),
+    realm="localhost:8000",
+    secret_key=SECRET_KEY,
+)
 
 
-def get_payment_request(_request=None):
+def get_payment_request():
     """Build payment request with fresh expiration."""
     expires = (datetime.now(UTC) + timedelta(minutes=5)).isoformat()
     if expires.endswith("+00:00"):
@@ -44,9 +51,21 @@ async def free_endpoint():
 
 
 @app.get("/paid")
-@requires_payment(intent=intent, request=get_payment_request, realm="localhost:8000")
-async def paid_endpoint(request: Request, credential: Credential, receipt: Receipt):
+async def paid_endpoint(request: Request):
     """A paid endpoint that requires payment to access."""
+    result = await payment.charge(
+        authorization=request.headers.get("Authorization"),
+        request=get_payment_request(),
+    )
+
+    if isinstance(result, Challenge):
+        return JSONResponse(
+            status_code=402,
+            content={"error": "Payment required"},
+            headers={"WWW-Authenticate": result.to_www_authenticate(payment.realm)},
+        )
+
+    credential, receipt = result
     return {
         "message": "This is paid content!",
         "payer": credential.source,

--- a/src/mpay/__init__.py
+++ b/src/mpay/__init__.py
@@ -3,6 +3,12 @@
 Core types for the Payment HTTP Authentication Scheme.
 """
 
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any, Literal
@@ -17,7 +23,79 @@ from mpay._parsing import (
     parse_www_authenticate,
 )
 
-__all__ = ["Challenge", "Credential", "ParseError", "Receipt"]
+__all__ = ["Challenge", "Credential", "ParseError", "Receipt", "generate_challenge_id"]
+
+
+def _b64url_encode(data: str) -> str:
+    """Encode a string to base64url without padding."""
+    encoded = base64.urlsafe_b64encode(data.encode("utf-8")).decode("ascii")
+    return encoded.rstrip("=")
+
+
+def _b64url_encode_bytes(data: bytes) -> str:
+    """Encode bytes to base64url without padding."""
+    encoded = base64.urlsafe_b64encode(data).decode("ascii")
+    return encoded.rstrip("=")
+
+
+def generate_challenge_id(
+    *,
+    secret_key: str,
+    realm: str,
+    method: str,
+    intent: str,
+    request: dict[str, Any],
+    expires: str | None = None,
+    digest: str | None = None,
+) -> str:
+    """Generate HMAC-SHA256 challenge ID per spec.
+
+    The challenge ID is computed as HMAC-SHA256 over the challenge parameters,
+    cryptographically binding the ID to its contents. This enables stateless
+    verification - the server can verify a challenge was issued by it without
+    storing state.
+
+    HMAC input format: realm|method|intent|request_b64|expires|digest (pipe-delimited)
+    Output: base64url(HMAC-SHA256(secret_key, input))
+
+    Args:
+        secret_key: Server secret for HMAC computation.
+        realm: Server realm (e.g., hostname).
+        method: Payment method name (e.g., "tempo").
+        intent: Intent name (e.g., "charge").
+        request: Payment request parameters.
+        expires: Optional expiration timestamp (ISO 8601).
+        digest: Optional digest of request body.
+
+    Returns:
+        Base64url-encoded HMAC-SHA256 of the challenge parameters.
+
+    Example:
+        challenge_id = generate_challenge_id(
+            secret_key="my-server-secret",
+            realm="api.example.com",
+            method="tempo",
+            intent="charge",
+            request={"amount": "1000000", "currency": "0x...", "recipient": "0x..."},
+        )
+    """
+    request_json = json.dumps(request, separators=(",", ":"), ensure_ascii=False)
+    request_b64 = _b64url_encode(request_json)
+
+    hmac_input = f"{realm}|{method}|{intent}|{request_b64}|{expires or ''}|{digest or ''}"
+
+    mac = hmac.new(
+        secret_key.encode("utf-8"),
+        hmac_input.encode("utf-8"),
+        hashlib.sha256,
+    ).digest()
+
+    return _b64url_encode_bytes(mac)
+
+
+def _constant_time_equal(a: str, b: str) -> bool:
+    """Constant-time string comparison to prevent timing attacks."""
+    return hmac.compare_digest(a.encode("utf-8"), b.encode("utf-8"))
 
 
 @dataclass(frozen=True, slots=True)
@@ -31,6 +109,15 @@ class Challenge:
             intent="charge",
             request={"amount": "1000000", "currency": "0x...", "recipient": "0x..."},
         )
+
+        # Create with HMAC-bound ID (recommended for servers):
+        challenge = Challenge.create(
+            secret_key="my-server-secret",
+            realm="api.example.com",
+            method="tempo",
+            intent="charge",
+            request={"amount": "1000000", ...},
+        )
     """
 
     id: str
@@ -42,13 +129,91 @@ class Challenge:
     description: str | None = None
 
     @classmethod
-    def from_www_authenticate(cls, header: str) -> "Challenge":
+    def create(
+        cls,
+        *,
+        secret_key: str,
+        realm: str,
+        method: str,
+        intent: str,
+        request: dict[str, Any],
+        expires: str | None = None,
+        digest: str | None = None,
+        description: str | None = None,
+    ) -> Challenge:
+        """Create a Challenge with an HMAC-bound ID.
+
+        The challenge ID is computed as HMAC-SHA256 over the challenge parameters,
+        cryptographically binding the ID to its contents. This enables stateless
+        verification - the server can verify a challenge was issued by it without
+        storing state.
+
+        Args:
+            secret_key: Server secret for HMAC computation.
+            realm: Server realm (e.g., hostname).
+            method: Payment method name (e.g., "tempo").
+            intent: Intent name (e.g., "charge").
+            request: Payment request parameters.
+            expires: Optional expiration timestamp (ISO 8601).
+            digest: Optional digest of request body.
+            description: Optional human-readable description.
+
+        Returns:
+            A Challenge with an HMAC-bound ID.
+        """
+        challenge_id = generate_challenge_id(
+            secret_key=secret_key,
+            realm=realm,
+            method=method,
+            intent=intent,
+            request=request,
+            expires=expires,
+            digest=digest,
+        )
+        return cls(
+            id=challenge_id,
+            method=method,
+            intent=intent,
+            request=request,
+            digest=digest,
+            expires=expires,
+            description=description,
+        )
+
+    @classmethod
+    def from_www_authenticate(cls, header: str) -> Challenge:
         """Parse a Challenge from a WWW-Authenticate header value."""
         return parse_www_authenticate(header)
 
     def to_www_authenticate(self, realm: str) -> str:
         """Serialize to a WWW-Authenticate header value."""
         return format_www_authenticate(self, realm)
+
+    def verify(self, secret_key: str, realm: str) -> bool:
+        """Verify the challenge ID matches the expected HMAC.
+
+        Recomputes the HMAC from the challenge parameters and compares
+        to the stored ID. This allows stateless verification - if the
+        IDs match, the server knows it issued this challenge with these
+        exact parameters.
+
+        Args:
+            secret_key: Server secret used to generate the original ID.
+            realm: Server realm used to generate the original ID.
+
+        Returns:
+            True if the ID is valid, False otherwise.
+        """
+        expected_id = generate_challenge_id(
+            secret_key=secret_key,
+            realm=realm,
+            method=self.method,
+            intent=self.intent,
+            request=self.request,
+            expires=self.expires,
+            digest=self.digest,
+        )
+        return _constant_time_equal(self.id, expected_id)
 
 
 @dataclass(frozen=True, slots=True)
@@ -67,7 +232,7 @@ class Credential:
     source: str | None = None
 
     @classmethod
-    def from_authorization(cls, header: str) -> "Credential":
+    def from_authorization(cls, header: str) -> Credential:
         """Parse a Credential from an Authorization header value."""
         return parse_authorization(header)
 
@@ -95,7 +260,7 @@ class Receipt:
     reference: str
 
     @classmethod
-    def from_payment_receipt(cls, header: str) -> "Receipt":
+    def from_payment_receipt(cls, header: str) -> Receipt:
         """Parse a Receipt from a Payment-Receipt header value."""
         return parse_payment_receipt(header)
 
@@ -104,7 +269,7 @@ class Receipt:
         return format_payment_receipt(self)
 
     @classmethod
-    def success(cls, reference: str, timestamp: datetime | None = None) -> "Receipt":
+    def success(cls, reference: str, timestamp: datetime | None = None) -> Receipt:
         """Create a success receipt with current timestamp."""
         return cls(
             status="success",
@@ -113,7 +278,7 @@ class Receipt:
         )
 
     @classmethod
-    def failed(cls, reference: str, timestamp: datetime | None = None) -> "Receipt":
+    def failed(cls, reference: str, timestamp: datetime | None = None) -> Receipt:
         """Create a failed receipt with current timestamp."""
         return cls(
             status="failed",

--- a/src/mpay/server/__init__.py
+++ b/src/mpay/server/__init__.py
@@ -20,11 +20,13 @@ Example:
 from mpay.server.decorator import requires_payment
 from mpay.server.intent import Intent, VerificationError, intent
 from mpay.server.method import Method
+from mpay.server.mpay import Mpay
 from mpay.server.verify import verify_or_challenge
 
 __all__ = [
     "Intent",
     "Method",
+    "Mpay",
     "VerificationError",
     "intent",
     "requires_payment",

--- a/src/mpay/server/decorator.py
+++ b/src/mpay/server/decorator.py
@@ -50,6 +50,7 @@ def requires_payment(
     intent: Intent,
     request: RequestParamsType,
     realm: str,
+    secret_key: str,
     method: str | None = None,
 ) -> Callable[
     [Callable[[Any, Credential, Receipt], Awaitable[R]]],
@@ -68,6 +69,8 @@ def requires_payment(
         request: Payment request params - either a static dict or a callable
             that takes the request and returns the params.
         realm: The realm for the WWW-Authenticate header.
+        secret_key: Server secret for HMAC-bound challenge IDs. Required.
+            Enables stateless challenge verification.
         method: The payment method name (defaults to "tempo").
 
     Example:
@@ -76,6 +79,7 @@ def requires_payment(
             intent=ChargeIntent(rpc_url="..."),
             request={"amount": "1000", "currency": "0x...", "recipient": "0x..."},
             realm="api.example.com",
+            secret_key="my-server-secret",  # Enables HMAC-bound IDs
         )
         async def get_resource(request: Request, credential: Credential, receipt: Receipt):
             return {"data": "paid content", "payer": credential.source}
@@ -85,6 +89,7 @@ def requires_payment(
             intent=ChargeIntent(rpc_url="..."),
             request=lambda req: {"amount": req.query_params.get("price"), ...},
             realm="api.example.com",
+            secret_key="my-server-secret",
         )
         async def dynamic_pricing(request: Request, credential: Credential, receipt: Receipt):
             return {"data": "..."}
@@ -117,6 +122,7 @@ def requires_payment(
                 intent=intent,
                 request=request_params,
                 realm=realm,
+                secret_key=secret_key,
                 method=method,
             )
 

--- a/src/mpay/server/mpay.py
+++ b/src/mpay/server/mpay.py
@@ -15,7 +15,7 @@ class Mpay:
     """Server-side payment handler.
     
     Binds a payment method with realm and secret_key for stateless
-    challenge verification. Matches TypeScript's Mpay.create() pattern.
+    challenge verification.
     
     Example:
         from mpay.server import Mpay

--- a/src/mpay/server/mpay.py
+++ b/src/mpay/server/mpay.py
@@ -13,33 +13,34 @@ if TYPE_CHECKING:
 
 class Mpay:
     """Server-side payment handler.
-    
+
     Binds a payment method with realm and secret_key for stateless
     challenge verification.
-    
+
     Example:
         from mpay.server import Mpay
         from mpay.methods.tempo import TempoMethod
-        
+
         payment = Mpay(
             method=TempoMethod(rpc_url="https://rpc.tempo.xyz"),
             realm="api.example.com",
             secret_key="my-server-secret",
         )
-        
+
         # In request handler:
         result = await payment.charge(
             authorization=request.headers.get("Authorization"),
             request={"amount": "1000", "currency": "0x...", "recipient": "0x..."},
         )
-        
+
         if isinstance(result, Challenge):
-            return Response(status=402, headers={"WWW-Authenticate": result.to_www_authenticate(payment.realm)})
-        
+            headers = {"WWW-Authenticate": result.to_www_authenticate(payment.realm)}
+            return Response(status=402, headers=headers)
+
         credential, receipt = result
-        return Response({"data": "..."}, headers={"Payment-Receipt": receipt.to_payment_receipt()})
+        return Response({"data": "..."}, headers={"Payment-Receipt": ...})
     """
-    
+
     def __init__(
         self,
         method: Method,
@@ -47,7 +48,7 @@ class Mpay:
         secret_key: str,
     ) -> None:
         """Initialize the payment handler.
-        
+
         Args:
             method: Payment method (e.g., TempoMethod).
             realm: Server realm for WWW-Authenticate header.
@@ -57,31 +58,31 @@ class Mpay:
         self.method = method
         self.realm = realm
         self.secret_key = secret_key
-    
+
     async def charge(
         self,
         authorization: str | None,
         request: dict[str, Any],
     ) -> Challenge | tuple[Credential, Receipt]:
         """Handle a charge intent.
-        
+
         If no valid Authorization header is provided, returns a Challenge
         that should be sent as a 402 response.
-        
+
         If a valid credential is provided, verifies it and returns
         the (Credential, Receipt) tuple.
-        
+
         Args:
             authorization: The Authorization header value (or None).
             request: Payment request parameters (amount, currency, recipient, etc.).
-        
+
         Returns:
             Challenge if payment required, or (Credential, Receipt) if verified.
         """
         intent = self.method.intents.get("charge")
         if intent is None:
             raise ValueError(f"Method {self.method.name} does not support charge intent")
-        
+
         return await verify_or_challenge(
             authorization=authorization,
             intent=intent,
@@ -90,25 +91,25 @@ class Mpay:
             secret_key=self.secret_key,
             method=self.method.name,
         )
-    
+
     async def authorize(
         self,
         authorization: str | None,
         request: dict[str, Any],
     ) -> Challenge | tuple[Credential, Receipt]:
         """Handle an authorize intent.
-        
+
         Args:
             authorization: The Authorization header value (or None).
             request: Authorization request parameters.
-        
+
         Returns:
             Challenge if payment required, or (Credential, Receipt) if verified.
         """
         intent = self.method.intents.get("authorize")
         if intent is None:
             raise ValueError(f"Method {self.method.name} does not support authorize intent")
-        
+
         return await verify_or_challenge(
             authorization=authorization,
             intent=intent,

--- a/src/mpay/server/mpay.py
+++ b/src/mpay/server/mpay.py
@@ -1,0 +1,119 @@
+"""Payment handler that binds method, realm, and secret_key."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from mpay import Challenge, Credential, Receipt
+from mpay.server.verify import verify_or_challenge
+
+if TYPE_CHECKING:
+    from mpay.server.method import Method
+
+
+class Mpay:
+    """Server-side payment handler.
+    
+    Binds a payment method with realm and secret_key for stateless
+    challenge verification. Matches TypeScript's Mpay.create() pattern.
+    
+    Example:
+        from mpay.server import Mpay
+        from mpay.methods.tempo import TempoMethod
+        
+        payment = Mpay(
+            method=TempoMethod(rpc_url="https://rpc.tempo.xyz"),
+            realm="api.example.com",
+            secret_key="my-server-secret",
+        )
+        
+        # In request handler:
+        result = await payment.charge(
+            authorization=request.headers.get("Authorization"),
+            request={"amount": "1000", "currency": "0x...", "recipient": "0x..."},
+        )
+        
+        if isinstance(result, Challenge):
+            return Response(status=402, headers={"WWW-Authenticate": result.to_www_authenticate(payment.realm)})
+        
+        credential, receipt = result
+        return Response({"data": "..."}, headers={"Payment-Receipt": receipt.to_payment_receipt()})
+    """
+    
+    def __init__(
+        self,
+        method: Method,
+        realm: str,
+        secret_key: str,
+    ) -> None:
+        """Initialize the payment handler.
+        
+        Args:
+            method: Payment method (e.g., TempoMethod).
+            realm: Server realm for WWW-Authenticate header.
+            secret_key: Server secret for HMAC-bound challenge IDs.
+                Enables stateless challenge verification.
+        """
+        self.method = method
+        self.realm = realm
+        self.secret_key = secret_key
+    
+    async def charge(
+        self,
+        authorization: str | None,
+        request: dict[str, Any],
+    ) -> Challenge | tuple[Credential, Receipt]:
+        """Handle a charge intent.
+        
+        If no valid Authorization header is provided, returns a Challenge
+        that should be sent as a 402 response.
+        
+        If a valid credential is provided, verifies it and returns
+        the (Credential, Receipt) tuple.
+        
+        Args:
+            authorization: The Authorization header value (or None).
+            request: Payment request parameters (amount, currency, recipient, etc.).
+        
+        Returns:
+            Challenge if payment required, or (Credential, Receipt) if verified.
+        """
+        intent = self.method.intents.get("charge")
+        if intent is None:
+            raise ValueError(f"Method {self.method.name} does not support charge intent")
+        
+        return await verify_or_challenge(
+            authorization=authorization,
+            intent=intent,
+            request=request,
+            realm=self.realm,
+            secret_key=self.secret_key,
+            method=self.method.name,
+        )
+    
+    async def authorize(
+        self,
+        authorization: str | None,
+        request: dict[str, Any],
+    ) -> Challenge | tuple[Credential, Receipt]:
+        """Handle an authorize intent.
+        
+        Args:
+            authorization: The Authorization header value (or None).
+            request: Authorization request parameters.
+        
+        Returns:
+            Challenge if payment required, or (Credential, Receipt) if verified.
+        """
+        intent = self.method.intents.get("authorize")
+        if intent is None:
+            raise ValueError(f"Method {self.method.name} does not support authorize intent")
+        
+        return await verify_or_challenge(
+            authorization=authorization,
+            intent=intent,
+            request=request,
+            realm=self.realm,
+            secret_key=self.secret_key,
+            method=self.method.name,
+        )

--- a/src/mpay/server/verify.py
+++ b/src/mpay/server/verify.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import secrets
 from typing import TYPE_CHECKING, Any
 
 from mpay import Challenge, Credential, Receipt
@@ -18,6 +17,7 @@ async def verify_or_challenge(
     intent: Intent,
     request: dict[str, Any],
     realm: str,
+    secret_key: str,
     method: str | None = None,
 ) -> Challenge | tuple[Credential, Receipt]:
     """Verify a payment credential or generate a new challenge.
@@ -26,11 +26,20 @@ async def verify_or_challenge(
     It checks for an Authorization header, verifies the credential if present,
     or generates a new challenge if not.
 
+    When `secret_key` is provided, the challenge ID is computed as HMAC-SHA256
+    over the challenge parameters (realm|method|intent|request|expires|digest),
+    cryptographically binding the ID to its contents. This enables stateless
+    verification - the server can verify a challenge was issued by it without
+    storing state.
+
     Args:
         authorization: The Authorization header value (or None if missing).
         intent: The payment intent to verify against.
         request: The payment request parameters.
         realm: The realm for the WWW-Authenticate header.
+        secret_key: Server secret for HMAC-bound challenge IDs. Required.
+            Enables stateless challenge verification by computing challenge IDs
+            as HMAC-SHA256 over the challenge parameters.
         method: The payment method name (defaults to "tempo").
 
     Returns:
@@ -45,6 +54,7 @@ async def verify_or_challenge(
             intent=ChargeIntent(client),
             request={"amount": "1000", ...},
             realm="api.example.com",
+            secret_key="my-server-secret",  # Enables HMAC-bound IDs
         )
 
         if isinstance(result, Challenge):
@@ -62,15 +72,15 @@ async def verify_or_challenge(
     method_name = method or "tempo"
 
     if authorization is None:
-        return _create_challenge(method_name, intent.name, request)
+        return _create_challenge(method_name, intent.name, request, realm, secret_key)
 
     if not authorization.lower().startswith("payment "):
-        return _create_challenge(method_name, intent.name, request)
+        return _create_challenge(method_name, intent.name, request, realm, secret_key)
 
     try:
         credential = Credential.from_authorization(authorization)
     except ParseError:
-        return _create_challenge(method_name, intent.name, request)
+        return _create_challenge(method_name, intent.name, request, realm, secret_key)
 
     receipt: Receipt = await intent.verify(credential, request)
     return (credential, receipt)
@@ -80,10 +90,13 @@ def _create_challenge(
     method: str,
     intent_name: str,
     request: dict[str, Any],
+    realm: str,
+    secret_key: str,
 ) -> Challenge:
-    """Create a new payment challenge."""
-    return Challenge(
-        id=secrets.token_urlsafe(16),
+    """Create a new payment challenge with HMAC-bound ID."""
+    return Challenge.create(
+        secret_key=secret_key,
+        realm=realm,
         method=method,
         intent=intent_name,
         request=request,

--- a/tests/test_challenge_id.py
+++ b/tests/test_challenge_id.py
@@ -1,0 +1,256 @@
+"""Tests for HMAC-SHA256 challenge ID generation.
+
+These tests use the cross-SDK conformance test vectors to ensure
+Python SDK produces identical challenge IDs to TypeScript and Rust SDKs.
+"""
+
+from mpay import Challenge, generate_challenge_id
+
+
+class TestGenerateChallengeId:
+    """Test HMAC-SHA256 challenge ID generation with conformance vectors."""
+
+    def test_basic_charge(self) -> None:
+        """Basic charge challenge ID generation."""
+        result = generate_challenge_id(
+            secret_key="test-secret-key-12345",
+            realm="api.example.com",
+            method="tempo",
+            intent="charge",
+            request={
+                "amount": "1000000",
+                "currency": "0x20c0000000000000000000000000000000000001",
+                "recipient": "0x1234567890abcdef1234567890abcdef12345678",
+            },
+        )
+        assert result == "4Y_7cCtNrnPq0ujXFLOPsk4DRMctIFYxijKxrY5uob0"
+
+    def test_with_expires(self) -> None:
+        """Challenge ID with expires field included in HMAC."""
+        result = generate_challenge_id(
+            secret_key="test-secret-key-12345",
+            realm="api.example.com",
+            method="tempo",
+            intent="charge",
+            request={
+                "amount": "5000000",
+                "currency": "0x20c0000000000000000000000000000000000001",
+                "recipient": "0xabcdef1234567890abcdef1234567890abcdef12",
+            },
+            expires="2026-01-29T12:00:00Z",
+        )
+        assert result == "02h24ab0XjVsKFwbyhz8HU9FacoT-21zV4FokI2U4YI"
+
+    def test_with_digest(self) -> None:
+        """Challenge ID with digest field included in HMAC."""
+        result = generate_challenge_id(
+            secret_key="my-server-secret",
+            realm="payments.example.org",
+            method="tempo",
+            intent="charge",
+            request={
+                "amount": "250000",
+                "currency": "USD",
+                "recipient": "0x9999999999999999999999999999999999999999",
+            },
+            digest="sha-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=",
+        )
+        assert result == "EAX2sqwdeg8Km8LIKRBFhM5xDQvEgIlbTif9FKBsOiU"
+
+    def test_full_challenge(self) -> None:
+        """Challenge ID with all optional fields."""
+        result = generate_challenge_id(
+            secret_key="production-secret-abc123",
+            realm="api.tempo.xyz",
+            method="tempo",
+            intent="charge",
+            request={
+                "amount": "10000000",
+                "currency": "0x20c0000000000000000000000000000000000001",
+                "recipient": "0x742d35Cc6634C0532925a3b844Bc9e7595f1B0F2",
+                "description": "API access fee",
+                "externalId": "order-12345",
+            },
+            expires="2026-02-01T00:00:00Z",
+            digest="sha-256=abc123def456",
+        )
+        assert result == "9uqa-bDFwDBiMIgJF-hytstRW_YgjpBUDCo5_SMSqG4"
+
+    def test_different_secret_different_id(self) -> None:
+        """Same parameters with different secret produces different ID."""
+        result = generate_challenge_id(
+            secret_key="different-secret-key",
+            realm="api.example.com",
+            method="tempo",
+            intent="charge",
+            request={
+                "amount": "1000000",
+                "currency": "0x20c0000000000000000000000000000000000001",
+                "recipient": "0x1234567890abcdef1234567890abcdef12345678",
+            },
+        )
+        assert result == "GaC7Gn_Fbbq98Tw-Eb7z4FadriU7GzNrAyC7ZcY3VRI"
+
+    def test_empty_request(self) -> None:
+        """Challenge ID with empty request object."""
+        result = generate_challenge_id(
+            secret_key="test-key",
+            realm="test.example.com",
+            method="tempo",
+            intent="authorize",
+            request={},
+        )
+        assert result == "jUTqTVe3kCv5rVizv1XBCs9qKCLg4AZLwBUnk4N3MR8"
+
+    def test_unicode_in_description(self) -> None:
+        """Request with unicode characters."""
+        result = generate_challenge_id(
+            secret_key="unicode-test-key",
+            realm="api.example.com",
+            method="tempo",
+            intent="charge",
+            request={
+                "amount": "100",
+                "currency": "EUR",
+                "recipient": "0x1111111111111111111111111111111111111111",
+                "description": "Payment for café ☕",
+            },
+        )
+        assert result == "76lyru2p7i7Xw6fGTJtWzd9c7Z6mt33LIW7968Mlkz8"
+
+    def test_nested_method_details(self) -> None:
+        """Request with nested methodDetails object."""
+        result = generate_challenge_id(
+            secret_key="nested-test-key",
+            realm="api.tempo.xyz",
+            method="tempo",
+            intent="charge",
+            request={
+                "amount": "5000000",
+                "currency": "0x20c0000000000000000000000000000000000001",
+                "recipient": "0x2222222222222222222222222222222222222222",
+                "methodDetails": {"chainId": 42431, "feePayer": True},
+            },
+        )
+        assert result == "dyItTtUU31Gp2ckWrYXoeB2wZtS1OTVpXw81D_blwuk"
+
+
+class TestChallengeCreate:
+    """Test Challenge.create() factory method."""
+
+    def test_creates_challenge_with_hmac_id(self) -> None:
+        """Challenge.create() should use HMAC-bound ID."""
+        challenge = Challenge.create(
+            secret_key="test-secret-key-12345",
+            realm="api.example.com",
+            method="tempo",
+            intent="charge",
+            request={
+                "amount": "1000000",
+                "currency": "0x20c0000000000000000000000000000000000001",
+                "recipient": "0x1234567890abcdef1234567890abcdef12345678",
+            },
+        )
+        assert challenge.id == "4Y_7cCtNrnPq0ujXFLOPsk4DRMctIFYxijKxrY5uob0"
+        assert challenge.method == "tempo"
+        assert challenge.intent == "charge"
+
+    def test_create_with_optional_fields(self) -> None:
+        """Challenge.create() should handle optional fields."""
+        challenge = Challenge.create(
+            secret_key="test-secret-key-12345",
+            realm="api.example.com",
+            method="tempo",
+            intent="charge",
+            request={
+                "amount": "5000000",
+                "currency": "0x20c0000000000000000000000000000000000001",
+                "recipient": "0xabcdef1234567890abcdef1234567890abcdef12",
+            },
+            expires="2026-01-29T12:00:00Z",
+            description="Test payment",
+        )
+        assert challenge.id == "02h24ab0XjVsKFwbyhz8HU9FacoT-21zV4FokI2U4YI"
+        assert challenge.expires == "2026-01-29T12:00:00Z"
+        assert challenge.description == "Test payment"
+
+
+class TestChallengeVerify:
+    """Test Challenge.verify() method."""
+
+    def test_verify_valid_challenge(self) -> None:
+        """Challenge.verify() should return True for valid HMAC."""
+        challenge = Challenge.create(
+            secret_key="test-secret-key-12345",
+            realm="api.example.com",
+            method="tempo",
+            intent="charge",
+            request={
+                "amount": "1000000",
+                "currency": "0x20c0000000000000000000000000000000000001",
+                "recipient": "0x1234567890abcdef1234567890abcdef12345678",
+            },
+        )
+        assert challenge.verify("test-secret-key-12345", "api.example.com")
+
+    def test_verify_invalid_secret(self) -> None:
+        """Challenge.verify() should return False for wrong secret."""
+        challenge = Challenge.create(
+            secret_key="test-secret-key-12345",
+            realm="api.example.com",
+            method="tempo",
+            intent="charge",
+            request={"amount": "1000000"},
+        )
+        assert not challenge.verify("wrong-secret", "api.example.com")
+
+    def test_verify_invalid_realm(self) -> None:
+        """Challenge.verify() should return False for wrong realm."""
+        challenge = Challenge.create(
+            secret_key="test-secret-key-12345",
+            realm="api.example.com",
+            method="tempo",
+            intent="charge",
+            request={"amount": "1000000"},
+        )
+        assert not challenge.verify("test-secret-key-12345", "wrong.realm.com")
+
+    def test_verify_tampered_challenge(self) -> None:
+        """Challenge.verify() should return False if challenge was tampered."""
+        original = Challenge.create(
+            secret_key="test-secret-key-12345",
+            realm="api.example.com",
+            method="tempo",
+            intent="charge",
+            request={"amount": "1000000"},
+        )
+        # Simulate tampering by creating a new challenge with modified request
+        tampered = Challenge(
+            id=original.id,  # Keep original ID
+            method=original.method,
+            intent=original.intent,
+            request={"amount": "9999999"},  # Tampered amount
+        )
+        assert not tampered.verify("test-secret-key-12345", "api.example.com")
+
+    def test_verify_with_expires(self) -> None:
+        """Challenge.verify() should include expires in HMAC."""
+        challenge = Challenge.create(
+            secret_key="test-secret-key-12345",
+            realm="api.example.com",
+            method="tempo",
+            intent="charge",
+            request={"amount": "5000000"},
+            expires="2026-01-29T12:00:00Z",
+        )
+        assert challenge.verify("test-secret-key-12345", "api.example.com")
+
+        # Tampering expires should fail
+        tampered = Challenge(
+            id=challenge.id,
+            method=challenge.method,
+            intent=challenge.intent,
+            request=challenge.request,
+            expires="2099-12-31T23:59:59Z",  # Tampered
+        )
+        assert not tampered.verify("test-secret-key-12345", "api.example.com")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -29,6 +29,7 @@ class TestVerifyOrChallenge:
             intent=test_intent,
             request={"amount": "1000"},
             realm="api.example.com",
+            secret_key="test-secret",
         )
 
         assert isinstance(result, Challenge)
@@ -49,6 +50,7 @@ class TestVerifyOrChallenge:
             intent=test_intent,
             request={"amount": "1000"},
             realm="api.example.com",
+            secret_key="test-secret",
         )
 
         assert isinstance(result, Challenge)
@@ -71,6 +73,7 @@ class TestVerifyOrChallenge:
             intent=test_intent,
             request={"amount": "1000"},
             realm="api.example.com",
+            secret_key="test-secret",
         )
 
         assert isinstance(result, tuple)
@@ -116,6 +119,7 @@ class TestClassBasedIntent:
             intent=MyIntent(),
             request={},
             realm="test",
+            secret_key="test-secret",
             method="custom-method",
         )
 
@@ -138,6 +142,7 @@ class TestVerificationError:
             intent=test_intent,
             request={"amount": "1000"},
             realm="api.example.com",
+            secret_key="test-secret",
         )
 
         assert isinstance(result, Challenge)
@@ -159,6 +164,7 @@ class TestVerificationError:
                 intent=failing_intent,
                 request={"amount": "1000"},
                 realm="api.example.com",
+                secret_key="test-secret",
             )
 
 
@@ -189,6 +195,7 @@ class TestRequiresPayment:
             intent=test_intent,
             request={"amount": "1000"},
             realm="api.example.com",
+            secret_key="test-secret",
         )
         async def handler(req: MockRequest, credential: Credential, receipt: Receipt) -> dict:
             return {"data": "paid content"}
@@ -219,6 +226,7 @@ class TestRequiresPayment:
             intent=test_intent,
             request={"amount": "1000"},
             realm="api.example.com",
+            secret_key="test-secret",
         )
         async def handler(req: MockRequest, credential: Credential, receipt: Receipt) -> dict:
             return {
@@ -248,6 +256,7 @@ class TestRequiresPayment:
             intent=test_intent,
             request=lambda req: {"amount": req.query_amount},
             realm="api.example.com",
+            secret_key="test-secret",
         )
         async def handler(req: MockRequest, credential: Credential, receipt: Receipt) -> dict:
             return {"data": "paid"}
@@ -273,6 +282,7 @@ class TestRequiresPayment:
             intent=test_intent,
             request={"amount": "1000"},
             realm="api.example.com",
+            secret_key="test-secret",
         )
         async def handler(
             req: DjangoStyleRequest, credential: Credential, receipt: Receipt
@@ -297,6 +307,7 @@ class TestRequiresPayment:
             intent=test_intent,
             request={"amount": "1000"},
             realm="api.example.com",
+            secret_key="test-secret",
         )
         async def handler(req: MockRequest, credential: Credential, receipt: Receipt) -> dict:
             return {"data": "paid"}
@@ -323,6 +334,7 @@ class TestRequiresPayment:
             intent=test_intent,
             request={"amount": "1000"},
             realm="api.example.com",
+            secret_key="test-secret",
         )
         async def my_handler(req: MockRequest, credential: Credential, receipt: Receipt) -> dict:
             """My handler docstring."""
@@ -343,6 +355,7 @@ class TestRequiresPayment:
             intent=test_intent,
             request={"amount": "1000"},
             realm="api.example.com",
+            secret_key="test-secret",
             method="custom-method",
         )
         async def handler(req: MockRequest, credential: Credential, receipt: Receipt) -> dict:


### PR DESCRIPTION
Add support for HMAC-bound challenge IDs matching the TypeScript SDK.

## Changes

- Add `generate_challenge_id()` function for HMAC-SHA256 ID computation
- Add `Challenge.create()` factory method with `secret_key` parameter
- Add `Challenge.verify()` method for stateless challenge verification
- Add optional `secret_key` parameter to `verify_or_challenge()` and `@requires_payment` decorator
- Add cross-SDK compatibility tests using conformance test vectors from `mpay-sdks`

## API

### Challenge.create()
```python
challenge = Challenge.create(
    secret_key="my-server-secret",
    realm="api.example.com",
    method="tempo",
    intent="charge",
    request={"amount": "1000000", "currency": "0x...", "recipient": "0x..."},
)
```

### Challenge.verify()
```python
is_valid = challenge.verify(secret_key="my-server-secret", realm="api.example.com")
```

### verify_or_challenge() with secret_key
```python
result = await verify_or_challenge(
    authorization=request.headers.get("Authorization"),
    intent=intent,
    request={...},
    realm="api.example.com",
    secret_key="my-server-secret",  # Enables HMAC-bound IDs
)
```

## Algorithm

HMAC input format: `realm|method|intent|request_b64|expires|digest` (pipe-delimited)
Output: `base64url(HMAC-SHA256(secret_key, input))`

When `secret_key` is omitted, falls back to random IDs (`secrets.token_urlsafe(16)`).

## Cross-SDK Compatibility

All 8 conformance test cases pass, matching TypeScript and Rust SDK outputs.

Related: https://github.com/tempoxyz/mpay-rs/pull/23