### PR TITLE
fix: return 402 for failed receipts per IETF spec

### DIFF
--- a/src/mpay/server/verify.py
+++ b/src/mpay/server/verify.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any
 
 from mpay import Challenge, Credential, Receipt
 from mpay._parsing import ParseError
+from mpay.server.intent import VerificationError
 
 if TYPE_CHECKING:
     from mpay.server.intent import Intent
@@ -83,6 +84,12 @@ async def verify_or_challenge(
         return _create_challenge(method_name, intent.name, request, realm, secret_key)
 
     receipt: Receipt = await intent.verify(credential, request)
+
+    # Per IETF spec, synchronous flows MUST NOT return 200 with a failed receipt.
+    # Convert failed receipts to VerificationError.
+    if receipt.status == "failed":
+        raise VerificationError(f"payment failed: {receipt.reference}")
+
     return (credential, receipt)
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -167,6 +167,50 @@ class TestVerificationError:
                 secret_key="test-secret",
             )
 
+    @pytest.mark.asyncio
+    async def test_raises_error_for_failed_receipt(self) -> None:
+        """Per IETF spec, failed receipts should raise VerificationError."""
+
+        @intent(name="charge")
+        async def failing_receipt_intent(credential: Credential, request: dict) -> Receipt:
+            return Receipt.failed("tx-reverted-123")
+
+        credential = Credential(id="test", payload={})
+        auth_header = credential.to_authorization()
+
+        with pytest.raises(VerificationError, match="payment failed: tx-reverted-123"):
+            await verify_or_challenge(
+                authorization=auth_header,
+                intent=failing_receipt_intent,
+                request={"amount": "1000"},
+                realm="api.example.com",
+                secret_key="test-secret",
+            )
+
+    @pytest.mark.asyncio
+    async def test_returns_receipt_for_success(self) -> None:
+        """Successful receipts should be returned normally."""
+
+        @intent(name="charge")
+        async def success_intent(credential: Credential, request: dict) -> Receipt:
+            return Receipt.success("tx-success-456")
+
+        credential = Credential(id="test", payload={})
+        auth_header = credential.to_authorization()
+
+        result = await verify_or_challenge(
+            authorization=auth_header,
+            intent=success_intent,
+            request={"amount": "1000"},
+            realm="api.example.com",
+            secret_key="test-secret",
+        )
+
+        assert isinstance(result, tuple)
+        cred, receipt = result
+        assert receipt.status == "success"
+        assert receipt.reference == "tx-success-456"
+
 
 class MockRequest:
     """Mock request object for testing."""


### PR DESCRIPTION
## Summary

Per the IETF Payment Auth spec, synchronous flows MUST NOT return 200 with a failed receipt. When the verify function returns a receipt with `status='failed'`, `verify_or_challenge` now raises `VerificationError` instead of returning the `(Credential, Receipt)` tuple.

## Changes

- Added failed receipt status check in `verify_or_challenge` after calling `intent.verify()`
- If receipt status is `'failed'`, raises `VerificationError` with message format: `payment failed: {receipt.reference}`
- Added 2 tests for failed/success receipt handling

## Related

- IETF spec update: https://github.com/tempoxyz/payment-auth-spec/pull/93
- TypeScript mpay fix: https://github.com/wevm/mpay/pull/5
- Rust mpay-rs fix: https://github.com/tempoxyz/mpay-rs/pull/25

## Testing

```bash
make check
```