### PR TITLE
spec: remove failed receipt state, return 402 for failures

### DIFF
--- a/src/mpay/__init__.py
+++ b/src/mpay/__init__.py
@@ -313,7 +313,7 @@ class Receipt:
         )
     """
 
-    status: Literal["success", "failed"]
+    status: Literal["success"]
     timestamp: datetime
     reference: str
 
@@ -331,15 +331,6 @@ class Receipt:
         """Create a success receipt with current timestamp."""
         return cls(
             status="success",
-            timestamp=timestamp or datetime.now(UTC),
-            reference=reference,
-        )
-
-    @classmethod
-    def failed(cls, reference: str, timestamp: datetime | None = None) -> Receipt:
-        """Create a failed receipt with current timestamp."""
-        return cls(
-            status="failed",
             timestamp=timestamp or datetime.now(UTC),
             reference=reference,
         )

--- a/src/mpay/_parsing.py
+++ b/src/mpay/_parsing.py
@@ -281,7 +281,7 @@ def parse_payment_receipt(header: str) -> Receipt:
         raise ParseError(f"Receipt missing required fields: {missing}")
 
     status = data["status"]
-    if status not in ("success", "failed"):
+    if status != "success":
         raise ParseError("Invalid receipt status")
 
     timestamp = _parse_timestamp(str(data["timestamp"]))

--- a/src/mpay/extensions/mcp/types.py
+++ b/src/mpay/extensions/mcp/types.py
@@ -214,7 +214,7 @@ class MCPReceipt:
         )
     """
 
-    status: Literal["success", "failed"]
+    status: Literal["success"]
     challenge_id: str
     method: str
     timestamp: str

--- a/src/mpay/methods/tempo/intents.py
+++ b/src/mpay/methods/tempo/intents.py
@@ -188,7 +188,7 @@ class ChargeIntent:
             raise VerificationError("Transaction not found")
 
         if receipt_data.get("status") != "0x1":
-            return Receipt.failed(payload.hash)
+            raise VerificationError("Transaction reverted")
 
         if not self._verify_transfer_logs(receipt_data, request):
             raise VerificationError(
@@ -340,7 +340,7 @@ class ChargeIntent:
             raise VerificationError("Transaction receipt not found after retries")
 
         if receipt_data.get("status") != "0x1":
-            return Receipt.failed(tx_hash)
+            raise VerificationError("Transaction reverted")
 
         if not self._verify_transfer_logs(receipt_data, request):
             raise VerificationError(

--- a/src/mpay/server/verify.py
+++ b/src/mpay/server/verify.py
@@ -85,11 +85,6 @@ async def verify_or_challenge(
 
     receipt: Receipt = await intent.verify(credential, request)
 
-    # Per IETF spec, synchronous flows MUST NOT return 200 with a failed receipt.
-    # Convert failed receipts to VerificationError.
-    if receipt.status == "failed":
-        raise VerificationError(f"payment failed: {receipt.reference}")
-
     return (credential, receipt)
 
 

--- a/src/mpay/server/verify.py
+++ b/src/mpay/server/verify.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING, Any
 
 from mpay import Challenge, Credential, Receipt
 from mpay._parsing import ParseError
-from mpay.server.intent import VerificationError
 
 if TYPE_CHECKING:
     from mpay.server.intent import Intent

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -163,15 +163,6 @@ class TestReceipt:
         assert parsed.timestamp == receipt.timestamp
         assert parsed.reference == receipt.reference
 
-    def test_roundtrip_failed(self) -> None:
-        """Failed receipt should roundtrip."""
-        receipt = Receipt.failed("0x000")
-
-        header = receipt.to_payment_receipt()
-        parsed = Receipt.from_payment_receipt(header)
-
-        assert parsed.status == "failed"
-
     def test_success_factory(self) -> None:
         """Receipt.success() should create success receipt with timestamp."""
         receipt = Receipt.success("0xabc123")
@@ -179,13 +170,6 @@ class TestReceipt:
         assert receipt.reference == "0xabc123"
         assert isinstance(receipt.timestamp, datetime)
         assert receipt.timestamp.tzinfo is not None
-
-    def test_failed_factory(self) -> None:
-        """Receipt.failed() should create failed receipt with timestamp."""
-        receipt = Receipt.failed("0xdef456")
-        assert receipt.status == "failed"
-        assert receipt.reference == "0xdef456"
-        assert isinstance(receipt.timestamp, datetime)
 
     def test_parse_invalid_status(self) -> None:
         """Should reject invalid status values."""

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -169,26 +169,6 @@ class TestVerificationError:
             )
 
     @pytest.mark.asyncio
-    async def test_raises_error_for_failed_receipt(self) -> None:
-        """Per IETF spec, failed receipts should raise VerificationError."""
-
-        @intent(name="charge")
-        async def failing_receipt_intent(credential: Credential, request: dict) -> Receipt:
-            return Receipt.failed("tx-reverted-123")
-
-        credential = make_credential(payload={}, challenge_id="test")
-        auth_header = credential.to_authorization()
-
-        with pytest.raises(VerificationError, match="payment failed: tx-reverted-123"):
-            await verify_or_challenge(
-                authorization=auth_header,
-                intent=failing_receipt_intent,
-                request={"amount": "1000"},
-                realm="api.example.com",
-                secret_key="test-secret",
-            )
-
-    @pytest.mark.asyncio
     async def test_returns_receipt_for_success(self) -> None:
         """Successful receipts should be returned normally."""
 

--- a/tests/test_tempo.py
+++ b/tests/test_tempo.py
@@ -264,7 +264,7 @@ class TestChargeIntent:
 
     @pytest.mark.asyncio
     async def test_verify_hash_tx_failed(self) -> None:
-        """Should return failed receipt for failed transaction."""
+        """Should raise VerificationError for failed transaction."""
         future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
         intent = ChargeIntent(rpc_url="https://rpc.test")
 
@@ -278,17 +278,16 @@ class TestChargeIntent:
         intent._http_client = mock_client
 
         credential = make_credential(payload={"type": "hash", "hash": "0xabc"})
-        receipt = await intent.verify(
-            credential,
-            {
-                "amount": "1000",
-                "currency": "0x1234567890123456789012345678901234567890",
-                "recipient": "0x4567890123456789012345678901234567890123",
-                "expires": future,
-            },
-        )
-
-        assert receipt.status == "failed"
+        with pytest.raises(VerificationError, match="Transaction reverted"):
+            await intent.verify(
+                credential,
+                {
+                    "amount": "1000",
+                    "currency": "0x1234567890123456789012345678901234567890",
+                    "recipient": "0x4567890123456789012345678901234567890123",
+                    "expires": future,
+                },
+            )
 
     @pytest.mark.asyncio
     async def test_verify_hash_no_matching_logs(self) -> None:


### PR DESCRIPTION
Per spec change in https://github.com/tempoxyz/payment-auth-spec/pull/101

## Changes
- Change `Receipt.status` from `Literal['success', 'failed']` to `Literal['success']`
- Remove `Receipt.failed()` classmethod
- Remove the `receipt.status == 'failed'` check in verify handler
- Change tempo intents to `raise VerificationError('Transaction reverted')` instead of `return Receipt.failed()`
- Update parsing validation to only accept 'success' status
- Remove related tests

Receipts can now only have `success` status. Transaction failures now return 402 directly via `VerificationError`.