### PR TITLE
fix: client robustness improvements

### DIFF
--- a/src/mpay/client/transport.py
+++ b/src/mpay/client/transport.py
@@ -9,12 +9,16 @@ Implements automatic 402 Payment Required handling by:
 
 from __future__ import annotations
 
+import logging
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 import httpx
 
 from mpay import Challenge, Credential
 from mpay._parsing import ParseError
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -65,22 +69,39 @@ class PaymentTransport(httpx.AsyncBaseTransport):
         if response.status_code != 402:
             return response
 
-        www_auth = response.headers.get("www-authenticate")
-        if not www_auth or not www_auth.lower().startswith("payment "):
-            return response
-
         await response.aread()
 
-        try:
-            challenge = Challenge.from_www_authenticate(www_auth)
-        except ParseError:
+        # Handle multiple WWW-Authenticate headers (per RFC 9110)
+        www_auth_headers = response.headers.get_list("www-authenticate")
+
+        challenge = None
+        matched_method = None
+        for header in www_auth_headers:
+            if not header.lower().startswith("payment "):
+                continue
+            try:
+                parsed = Challenge.from_www_authenticate(header)
+                if parsed.method in self._methods:
+                    challenge = parsed
+                    matched_method = self._methods[parsed.method]
+                    break
+            except ParseError:
+                continue
+
+        if not challenge or not matched_method:
             return response
 
-        method = self._methods.get(challenge.method)
-        if not method:
-            return response
+        # Check expiry before paying (client-side guardrail)
+        if challenge.expires:
+            try:
+                expires_dt = datetime.fromisoformat(challenge.expires.replace("Z", "+00:00"))
+                if expires_dt < datetime.now(UTC):
+                    logger.warning("Challenge expired at %s, not paying", challenge.expires)
+                    return response
+            except ValueError:
+                pass  # If we can't parse, let server validate
 
-        credential = await method.create_credential(challenge)
+        credential = await matched_method.create_credential(challenge)
         auth_header = credential.to_authorization()
 
         headers = httpx.Headers(request.headers)

--- a/src/mpay/extensions/mcp/decorator.py
+++ b/src/mpay/extensions/mcp/decorator.py
@@ -31,14 +31,14 @@ from datetime import timedelta
 from functools import wraps
 from typing import TYPE_CHECKING, Any, ParamSpec, TypeVar
 
-from mpay.extensions.mcp.constants import META_CREDENTIAL
-from mpay.extensions.mcp.errors import (
-    MalformedCredentialError,
-    PaymentRequiredError,
-    PaymentVerificationError,
+from mpay.extensions.mcp.errors import PaymentRequiredError
+from mpay.extensions.mcp.types import MCPChallenge
+from mpay.extensions.mcp.verify import (
+    DEFAULT_CHALLENGE_TTL,
 )
-from mpay.extensions.mcp.types import MCPCredential, MCPReceipt
-from mpay.extensions.mcp.verify import DEFAULT_CHALLENGE_TTL, create_challenge
+from mpay.extensions.mcp.verify import (
+    verify_or_challenge as mcp_verify_or_challenge,
+)
 
 if TYPE_CHECKING:
     from mpay.server.intent import Intent
@@ -115,74 +115,31 @@ def requires_payment(
     ) -> Callable[P, Awaitable[R]]:
         @wraps(handler)
         async def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
-            meta = kwargs.pop("_meta", None) or {}
+            meta = kwargs.pop("_meta", None)
 
             if callable(request):
                 request_params = request(*args, **kwargs)
             else:
                 request_params = request
 
-            credential_data = meta.get(META_CREDENTIAL)
-
-            if credential_data is None:
-                challenge = create_challenge(
-                    method=method_name,
-                    intent_name=intent.name,
-                    request=request_params,
-                    realm=realm,
-                    expires_in=expires_in,
-                    description=description,
-                )
-                raise PaymentRequiredError(challenges=[challenge])
-
-            try:
-                mcp_credential = MCPCredential.from_dict(credential_data)
-            except (KeyError, TypeError) as e:
-                raise MalformedCredentialError(detail=f"Invalid credential structure: {e}") from e
-
-            from mpay.server.intent import VerificationError
-
-            core_credential = mcp_credential.to_core()
-
-            try:
-                core_receipt = await intent.verify(core_credential, request_params)
-            except VerificationError as e:
-                challenge = create_challenge(
-                    method=method_name,
-                    intent_name=intent.name,
-                    request=request_params,
-                    realm=realm,
-                    expires_in=expires_in,
-                    description=description,
-                )
-                raise PaymentVerificationError(
-                    challenges=[challenge],
-                    reason="verification-failed",
-                    detail=str(e),
-                ) from e
-
-            mcp_receipt = MCPReceipt.from_core(
-                receipt=core_receipt,
-                challenge_id=mcp_credential.challenge.id,
-                method=mcp_credential.challenge.method,
-                settlement=_extract_settlement(request_params),
+            result = await mcp_verify_or_challenge(
+                meta=meta,
+                intent=intent,
+                request=request_params,
+                realm=realm,
+                method=method_name,
+                expires_in=expires_in,
+                description=description,
             )
 
-            kwargs["credential"] = mcp_credential
-            kwargs["receipt"] = mcp_receipt
+            if isinstance(result, MCPChallenge):
+                raise PaymentRequiredError(challenges=[result])
 
+            credential, receipt = result
+            kwargs["credential"] = credential
+            kwargs["receipt"] = receipt
             return await handler(*args, **kwargs)
 
         return wrapper
 
     return decorator
-
-
-def _extract_settlement(request: dict[str, Any]) -> dict[str, Any] | None:
-    """Extract settlement info from request if available."""
-    settlement: dict[str, Any] = {}
-    if "amount" in request:
-        settlement["amount"] = request["amount"]
-    if "currency" in request:
-        settlement["currency"] = request["currency"]
-    return settlement if settlement else None

--- a/src/mpay/extensions/mcp/verify.py
+++ b/src/mpay/extensions/mcp/verify.py
@@ -149,7 +149,7 @@ async def verify_or_challenge(
         raise PaymentVerificationError(
             challenges=[challenge],
             reason="verification-failed",
-            detail="Payment verification failed",
+            detail=str(e),
         ) from e
 
     mcp_receipt = MCPReceipt.from_core(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -154,6 +154,68 @@ class TestPaymentTransport:
         transport = PaymentTransport(methods=[], inner=inner)
         await transport.aclose()
 
+    @pytest.mark.asyncio
+    async def test_skips_expired_challenge(self) -> None:
+        """Should return 402 without paying if challenge is expired."""
+        challenge = Challenge(
+            id="test-id",
+            method="tempo",
+            intent="charge",
+            request={"amount": "1000"},
+            expires="2020-01-01T00:00:00Z",  # Expired
+        )
+        www_auth = challenge.to_www_authenticate("example.com")
+
+        inner = MockTransport(
+            [
+                httpx.Response(402, headers={"www-authenticate": www_auth}),
+            ]
+        )
+
+        method = MockMethod()
+        transport = PaymentTransport(methods=[method], inner=inner)
+
+        request = httpx.Request("GET", "https://example.com")
+        response = await transport.handle_async_request(request)
+
+        assert response.status_code == 402
+        assert len(inner.requests) == 1
+        method.create_credential.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_handles_multiple_www_authenticate_headers(self) -> None:
+        """Should find matching method across multiple WWW-Authenticate headers."""
+        tempo_challenge = Challenge(
+            id="test-id",
+            method="tempo",
+            intent="charge",
+            request={"amount": "1000"},
+        )
+        tempo_auth = tempo_challenge.to_www_authenticate("example.com")
+
+        inner = MockTransport(
+            [
+                httpx.Response(
+                    402,
+                    headers=[
+                        ("www-authenticate", "Bearer realm=test"),
+                        ("www-authenticate", tempo_auth),
+                    ],
+                ),
+                httpx.Response(200, content=b'{"data": "ok"}'),
+            ]
+        )
+
+        method = MockMethod()
+        transport = PaymentTransport(methods=[method], inner=inner)
+
+        request = httpx.Request("GET", "https://example.com")
+        response = await transport.handle_async_request(request)
+
+        assert response.status_code == 200
+        assert len(inner.requests) == 2
+        method.create_credential.assert_called_once()
+
 
 class TestClient:
     @pytest.mark.asyncio

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -578,7 +578,7 @@ class TestVerifyOrChallenge:
                 realm="api.example.com",
             )
 
-        assert exc_info.value.detail == "Payment verification failed"
+        assert exc_info.value.detail == "Payment failed"
 
 
 class TestCreateChallenge:


### PR DESCRIPTION
## Summary

Ports valuable non-breaking improvements from the closed PR #7.

## Changes

### Multiple WWW-Authenticate header handling (RFC 9110)
- Servers may return multiple `WWW-Authenticate` headers with different auth schemes
- Client now iterates through all headers to find a matching Payment challenge
- Correctly handles mixed auth schemes (e.g., Bearer + Payment)

### Client-side expiry check
- If challenge has `expires` and it's already passed, skip payment attempt
- UX guardrail to fail fast rather than wasting a transaction
- Logs warning when challenge is expired

### MCP decorator refactor
- Removed duplicated verification logic from `@requires_payment` decorator  
- Now uses shared `verify_or_challenge()` function
- Preserves actual verification error messages in responses

## Testing

- Added `test_skips_expired_challenge` - verifies client doesn't pay expired challenges
- Added `test_handles_multiple_www_authenticate_headers` - verifies multi-header parsing
- All 123 tests pass