### PR TITLE
feat: mpay TypeScript SDK parity

### DIFF
--- a/src/mpay/methods/tempo/_defaults.py
+++ b/src/mpay/methods/tempo/_defaults.py
@@ -1,4 +1,4 @@
-"""Shared defaults for Tempo payment method."""
+"""Shared defaults for Tempo payment method (mainnet)."""
 
 CHAIN_ID = 4217
 RPC_URL = "https://rpc.tempo.xyz"

--- a/src/mpay/methods/tempo/_defaults.py
+++ b/src/mpay/methods/tempo/_defaults.py
@@ -1,0 +1,4 @@
+"""Shared defaults for Tempo payment method."""
+
+CHAIN_ID = 4217
+RPC_URL = "https://rpc.tempo.xyz"

--- a/src/mpay/methods/tempo/client.py
+++ b/src/mpay/methods/tempo/client.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from mpay import Challenge, Credential
+from mpay.methods.tempo._defaults import RPC_URL
 from mpay.methods.tempo.intents import ChargeIntent
 
 if TYPE_CHECKING:
@@ -45,7 +46,7 @@ class TempoMethod:
     name: str = "tempo"
     account: TempoAccount | None = None
     root_account: str | None = None
-    rpc_url: str = "https://rpc.tempo.xyz"
+    rpc_url: str = RPC_URL
     _intents: dict[str, Intent] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
@@ -238,7 +239,7 @@ class TempoMethod:
 
 def tempo(
     account: TempoAccount | None = None,
-    rpc_url: str = "https://rpc.tempo.xyz",
+    rpc_url: str = RPC_URL,
     root_account: str | None = None,
 ) -> TempoMethod:
     """Create a Tempo payment method.

--- a/src/mpay/methods/tempo/intents.py
+++ b/src/mpay/methods/tempo/intents.py
@@ -10,6 +10,7 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
 from mpay import Receipt
+from mpay.methods.tempo._defaults import RPC_URL
 from mpay.methods.tempo.schemas import (
     ChargeRequest,
     CredentialPayload,
@@ -80,7 +81,7 @@ class ChargeIntent:
 
     def __init__(
         self,
-        rpc_url: str,
+        rpc_url: str = RPC_URL,
         http_client: httpx.AsyncClient | None = None,
         timeout: float = DEFAULT_TIMEOUT,
     ) -> None:

--- a/src/mpay/server/__init__.py
+++ b/src/mpay/server/__init__.py
@@ -19,7 +19,7 @@ Example:
 
 from mpay.server.decorator import requires_payment
 from mpay.server.intent import Intent, VerificationError, intent
-from mpay.server.method import Method
+from mpay.server.method import Method, transform_request
 from mpay.server.mpay import Mpay
 from mpay.server.verify import verify_or_challenge
 
@@ -30,5 +30,6 @@ __all__ = [
     "VerificationError",
     "intent",
     "requires_payment",
+    "transform_request",
     "verify_or_challenge",
 ]

--- a/src/mpay/server/method.py
+++ b/src/mpay/server/method.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
     from mpay import Challenge, Credential
@@ -16,6 +16,7 @@ class Method(Protocol):
     A method represents a payment network (e.g., Tempo, Stripe) and provides:
     - Named intents for different payment operations
     - Client-side credential creation
+    - Optional request transformation
 
     Example:
         class StripeMethod:
@@ -45,3 +46,27 @@ class Method(Protocol):
             A credential that satisfies the challenge.
         """
         ...
+
+
+def transform_request(
+    method: Method,
+    request: dict[str, Any],
+    credential: Credential | None,
+) -> dict[str, Any]:
+    """Transform request using method's transform_request if available.
+
+    This hook allows methods to modify the request before challenge creation,
+    with access to the credential (if present) for conditional logic like
+    feePayer sponsorship.
+
+    Args:
+        method: The payment method.
+        request: The original request parameters.
+        credential: The parsed credential, or None if not provided.
+
+    Returns:
+        The transformed request.
+    """
+    if hasattr(method, "transform_request"):
+        return method.transform_request(request, credential)
+    return request

--- a/src/mpay/server/mpay.py
+++ b/src/mpay/server/mpay.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from mpay import Challenge, Credential, Receipt
+from mpay._parsing import ParseError
+from mpay.server.method import transform_request
 from mpay.server.verify import verify_or_challenge
 
 if TYPE_CHECKING:
@@ -46,6 +48,7 @@ class Mpay:
         method: Method,
         realm: str,
         secret_key: str,
+        defaults: dict[str, Any] | None = None,
     ) -> None:
         """Initialize the payment handler.
 
@@ -54,10 +57,12 @@ class Mpay:
             realm: Server realm for WWW-Authenticate header.
             secret_key: Server secret for HMAC-bound challenge IDs.
                 Enables stateless challenge verification.
+            defaults: Default request values merged with per-call request params.
         """
         self.method = method
         self.realm = realm
         self.secret_key = secret_key
+        self.defaults = defaults or {}
 
     async def charge(
         self,
@@ -83,37 +88,21 @@ class Mpay:
         if intent is None:
             raise ValueError(f"Method {self.method.name} does not support charge intent")
 
-        return await verify_or_challenge(
-            authorization=authorization,
-            intent=intent,
-            request=request,
-            realm=self.realm,
-            secret_key=self.secret_key,
-            method=self.method.name,
-        )
+        merged_request = {**self.defaults, **request}
 
-    async def authorize(
-        self,
-        authorization: str | None,
-        request: dict[str, Any],
-    ) -> Challenge | tuple[Credential, Receipt]:
-        """Handle an authorize intent.
+        credential: Credential | None = None
+        if authorization and authorization.lower().startswith("payment "):
+            try:
+                credential = Credential.from_authorization(authorization)
+            except ParseError:
+                pass
 
-        Args:
-            authorization: The Authorization header value (or None).
-            request: Authorization request parameters.
-
-        Returns:
-            Challenge if payment required, or (Credential, Receipt) if verified.
-        """
-        intent = self.method.intents.get("authorize")
-        if intent is None:
-            raise ValueError(f"Method {self.method.name} does not support authorize intent")
+        transformed_request = transform_request(self.method, merged_request, credential)
 
         return await verify_or_challenge(
             authorization=authorization,
             intent=intent,
-            request=request,
+            request=transformed_request,
             realm=self.realm,
             secret_key=self.secret_key,
             method=self.method.name,

--- a/src/mpay/server/verify.py
+++ b/src/mpay/server/verify.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
 from mpay import Challenge, Credential, Receipt
 from mpay._parsing import ParseError
+
+DEFAULT_EXPIRES_MINUTES = 5
 
 if TYPE_CHECKING:
     from mpay.server.intent import Intent
@@ -95,6 +98,10 @@ def _create_challenge(
     secret_key: str,
 ) -> Challenge:
     """Create a new payment challenge with HMAC-bound ID."""
+    if "expires" not in request:
+        expires = datetime.now(UTC) + timedelta(minutes=DEFAULT_EXPIRES_MINUTES)
+        request = {**request, "expires": expires.isoformat().replace("+00:00", "Z")}
+
     return Challenge.create(
         secret_key=secret_key,
         realm=realm,

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -36,7 +36,8 @@ class TestVerifyOrChallenge:
         assert isinstance(result, Challenge)
         assert result.method == "tempo"
         assert result.intent == "charge"
-        assert result.request == {"amount": "1000"}
+        assert result.request["amount"] == "1000"
+        assert "expires" in result.request  # default expires is added
 
     @pytest.mark.asyncio
     async def test_returns_challenge_when_invalid_scheme(self) -> None:


### PR DESCRIPTION
Ports recent changes from the mpay TypeScript SDK to pympay:

## Changes

- **Remove authorize intent** - Matches `abbfd52`
- **Default expires to 5 minutes** - Charge requests now default to 5min expiry if not specified (`56940ed`)
- **Extract tempo defaults** - Shared `_defaults.py` module with `CHAIN_ID` and `RPC_URL` (`e725a9d`)
- **Add defaults parameter to Mpay** - Allows setting default request values at handler level (`e91db64`)
- **Add transform_request hook** - Methods can now transform requests with credential context for feePayer logic (`c42f96a`)

## Usage

```python
# Defaults example
payment = Mpay(
    method=TempoMethod(),
    realm="api.example.com",
    secret_key="...",
    defaults={"currency": "0x...", "recipient": "0x..."},
)

# Only need to specify amount per-request
result = await payment.charge(
    authorization=request.headers.get("Authorization"),
    request={"amount": "1000"},
)
```

## Testing

All 120 tests pass.