### PR TITLE
feat: add parseUnits syntactic sugar for human-readable amounts

### DIFF
--- a/src/mpay/_units.py
+++ b/src/mpay/_units.py
@@ -1,0 +1,77 @@
+"""Unit conversion utilities for human-readable amounts.
+
+Converts decimal string amounts to base unit integers, matching the
+parseUnits behavior in the TypeScript SDK (viem's parseUnits).
+
+Example:
+    >>> parse_units("1.5", 6)
+    1500000
+    >>> parse_units("0.000025", 6)
+    25
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
+
+def parse_units(value: str, decimals: int) -> int:
+    """Convert a human-readable decimal string to base units.
+
+    Args:
+        value: Decimal string amount (e.g., "1.5", "0.000025").
+        decimals: Number of decimal places for the token.
+
+    Returns:
+        Integer amount in base units.
+
+    Raises:
+        ValueError: If value is not a valid decimal string.
+    """
+    try:
+        d = Decimal(value)
+    except InvalidOperation:
+        raise ValueError(f"Invalid amount: {value!r}") from None
+
+    result = d * (10**decimals)
+
+    if result != int(result):
+        raise ValueError(
+            f"Amount {value!r} with {decimals} decimals produces fractional base units"
+        )
+
+    return int(result)
+
+
+def transform_units(request: dict[str, Any]) -> dict[str, Any]:
+    """Transform request amounts from human-readable to base units.
+
+    If `decimals` is present in the request, converts `amount` and
+    optionally `suggestedDeposit` from human-readable decimal strings
+    to base unit strings, then removes the `decimals` key.
+
+    If `decimals` is not present, returns the request unchanged.
+
+    Args:
+        request: Payment request parameters.
+
+    Returns:
+        Request with amounts converted to base units.
+    """
+    if "decimals" not in request:
+        return request
+
+    result = {**request}
+    decimals = result.pop("decimals")
+
+    if not isinstance(decimals, int):
+        raise ValueError(f"decimals must be an integer, got {type(decimals).__name__}")
+
+    if "amount" in result:
+        result["amount"] = str(parse_units(result["amount"], decimals))
+
+    if "suggestedDeposit" in result and result["suggestedDeposit"] is not None:
+        result["suggestedDeposit"] = str(parse_units(result["suggestedDeposit"], decimals))
+
+    return result

--- a/src/mpay/methods/tempo/_defaults.py
+++ b/src/mpay/methods/tempo/_defaults.py
@@ -1,4 +1,8 @@
-"""Shared defaults for Tempo payment method (mainnet)."""
+"""Shared defaults for Tempo payment method."""
 
+# Tempo Moderato testnet
+MODERATO_CHAIN_ID = 42431
+
+# Tempo mainnet
 CHAIN_ID = 4217
 RPC_URL = "https://rpc.tempo.xyz"

--- a/src/mpay/server/mpay.py
+++ b/src/mpay/server/mpay.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from mpay import Challenge, Credential, Receipt
+from mpay import Challenge, Credential, Receipt, StreamReceipt
 from mpay._parsing import ParseError
+from mpay._units import transform_units
 from mpay.server.method import transform_request
 from mpay.server.verify import verify_or_challenge
 
@@ -88,7 +89,51 @@ class Mpay:
         if intent is None:
             raise ValueError(f"Method {self.method.name} does not support charge intent")
 
-        merged_request = {**self.defaults, **request}
+        merged_request = transform_units({**self.defaults, **request})
+
+        credential: Credential | None = None
+        if authorization and authorization.lower().startswith("payment "):
+            try:
+                credential = Credential.from_authorization(authorization)
+            except ParseError:
+                pass
+
+        transformed_request = transform_request(self.method, merged_request, credential)
+
+        return await verify_or_challenge(
+            authorization=authorization,
+            intent=intent,
+            request=transformed_request,
+            realm=self.realm,
+            secret_key=self.secret_key,
+            method=self.method.name,
+        )
+
+    async def stream(
+        self,
+        authorization: str | None,
+        request: dict[str, Any],
+    ) -> Challenge | tuple[Credential, StreamReceipt]:
+        """Handle a stream intent.
+
+        If no valid Authorization header is provided, returns a Challenge
+        that should be sent as a 402 response.
+
+        If a valid credential is provided, verifies it and returns
+        the (Credential, StreamReceipt) tuple.
+
+        Args:
+            authorization: The Authorization header value (or None).
+            request: Payment request parameters (amount, unitType, currency, etc.).
+
+        Returns:
+            Challenge if payment required, or (Credential, StreamReceipt) if verified.
+        """
+        intent = self.method.intents.get("stream")
+        if intent is None:
+            raise ValueError(f"Method {self.method.name} does not support stream intent")
+
+        merged_request = transform_units({**self.defaults, **request})
 
         credential: Credential | None = None
         if authorization and authorization.lower().startswith("payment "):

--- a/src/mpay/server/verify.py
+++ b/src/mpay/server/verify.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any
 
 from mpay import Challenge, Credential, Receipt
 from mpay._parsing import ParseError
+from mpay._units import transform_units
 
 DEFAULT_EXPIRES_MINUTES = 5
 
@@ -73,6 +74,7 @@ async def verify_or_challenge(
         )
     """
     method_name = method or "tempo"
+    request = transform_units(request)
 
     if authorization is None:
         return _create_challenge(method_name, intent.name, request, realm, secret_key)

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -1,0 +1,82 @@
+"""Tests for unit conversion utilities."""
+
+import pytest
+
+from mpay._units import parse_units, transform_units
+
+
+class TestParseUnits:
+    def test_whole_number(self) -> None:
+        assert parse_units("1", 6) == 1_000_000
+
+    def test_decimal(self) -> None:
+        assert parse_units("1.5", 6) == 1_500_000
+
+    def test_small_decimal(self) -> None:
+        assert parse_units("0.000025", 6) == 25
+
+    def test_zero_decimals(self) -> None:
+        assert parse_units("100", 0) == 100
+
+    def test_large_amount(self) -> None:
+        assert parse_units("10", 6) == 10_000_000
+
+    def test_zero(self) -> None:
+        assert parse_units("0", 6) == 0
+
+    def test_invalid_amount(self) -> None:
+        with pytest.raises(ValueError, match="Invalid amount"):
+            parse_units("abc", 6)
+
+    def test_fractional_base_units(self) -> None:
+        with pytest.raises(ValueError, match="fractional base units"):
+            parse_units("0.0000001", 6)
+
+
+class TestTransformUnits:
+    def test_converts_amount(self) -> None:
+        result = transform_units(
+            {
+                "amount": "1",
+                "decimals": 6,
+                "currency": "0x123",
+            }
+        )
+        assert result["amount"] == "1000000"
+        assert result["currency"] == "0x123"
+        assert "decimals" not in result
+
+    def test_converts_suggested_deposit(self) -> None:
+        result = transform_units(
+            {
+                "amount": "0.000025",
+                "decimals": 6,
+                "unitType": "llm_token",
+                "suggestedDeposit": "10",
+            }
+        )
+        assert result["amount"] == "25"
+        assert result["suggestedDeposit"] == "10000000"
+        assert "decimals" not in result
+
+    def test_no_decimals_passthrough(self) -> None:
+        request = {"amount": "1000000", "currency": "0x123"}
+        result = transform_units(request)
+        assert result == request
+
+    def test_none_suggested_deposit(self) -> None:
+        result = transform_units(
+            {
+                "amount": "1",
+                "decimals": 6,
+                "suggestedDeposit": None,
+            }
+        )
+        assert result["amount"] == "1000000"
+        assert result["suggestedDeposit"] is None
+
+    def test_no_mutation(self) -> None:
+        original = {"amount": "1", "decimals": 6}
+        transform_units(original)
+        assert "decimals" in original
+        assert original["amount"] == "1"


### PR DESCRIPTION
Adds `decimals` parameter support to charge and stream methods, matching the TypeScript SDK ([wevm/mpay#20](https://github.com/wevm/mpay/pull/20)) behavior.

When `decimals` is provided, `amount` (and `suggestedDeposit` for stream) are converted from human-readable decimal strings to base unit strings automatically.

### Before
```python
await payment.charge(
    authorization=auth,
    request={"amount": "1000000", "currency": "0x...", ...},
)
```

### After
```python
await payment.charge(
    authorization=auth,
    request={"amount": "1", "decimals": 6, "currency": "0x...", ...},
)
```

Applied in `Mpay.charge`, `Mpay.stream`, and `verify_or_challenge` so all server paths get the sugar. If `decimals` is omitted, behavior is unchanged.

**Files changed:**
- `src/mpay/_units.py` — `parse_units` and `transform_units` utilities
- `src/mpay/server/mpay.py` — apply transform in charge/stream
- `src/mpay/server/verify.py` — apply transform in standalone path
- `tests/test_units.py` — unit tests