### PR TITLE
Add integration tests for local Tempo devnet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install lint fix format format-check test check all
+.PHONY: install lint fix format format-check test test-integration test-integration-testnet check all
 
 install:
 	uv sync --all-extras --dev
@@ -18,6 +18,12 @@ format-check:
 
 test:
 	uv run pytest -v
+
+test-integration:
+	TEMPO_RPC_URL=http://localhost:8545 uv run pytest -m integration -v
+
+test-integration-testnet:
+	TEMPO_RPC_URL=https://rpc.testnet.tempo.xyz uv run pytest -m integration -v
 
 check: lint format-check test
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,3 +74,4 @@ typeCheckingMode = "standard"
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
+markers = ["integration: requires TEMPO_RPC_URL (real Tempo node)"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import os
+import time
+
+import httpx
+import pytest
+
+from mpay.methods.tempo import TempoAccount
+from mpay.methods.tempo.intents import ChargeIntent
+
+PATH_USD = "0x20c0000000000000000000000000000000000000"
+ALPHA_USD = "0x20c0000000000000000000000000000000000001"
+
+INTEGRATION = pytest.mark.skipif(
+    not os.environ.get("TEMPO_RPC_URL"),
+    reason="TEMPO_RPC_URL not set (no local node)",
+)
+
+
+@pytest.fixture(scope="session")
+def rpc_url():
+    return os.environ["TEMPO_RPC_URL"]
+
+
+@pytest.fixture(scope="session")
+def is_local_node(rpc_url):
+    return "localhost" in rpc_url or "127.0.0.1" in rpc_url
+
+
+@pytest.fixture(scope="session")
+def tx_timeout(is_local_node):
+    return int(os.environ.get("TEMPO_TEST_TIMEOUT", "10" if is_local_node else "60"))
+
+
+@pytest.fixture(scope="session")
+def chain_id(rpc_url):
+    with httpx.Client(timeout=30) as client:
+        resp = client.post(
+            rpc_url,
+            json={"jsonrpc": "2.0", "method": "eth_chainId", "params": [], "id": 1},
+        )
+        return int(resp.json()["result"], 16)
+
+
+@pytest.fixture(scope="session")
+def currency(is_local_node):
+    if os.environ.get("TEMPO_CURRENCY"):
+        return os.environ["TEMPO_CURRENCY"]
+    return PATH_USD if is_local_node else ALPHA_USD
+
+
+@pytest.fixture(scope="session")
+def escrow_contract(rpc_url):
+    addr = os.environ.get("TEMPO_ESCROW_ADDRESS", "0x9d136eEa063eDE5418A6BC7bEafF009bBb6CFa70")
+    with httpx.Client(timeout=10) as client:
+        resp = client.post(
+            rpc_url,
+            json={
+                "jsonrpc": "2.0",
+                "method": "eth_getCode",
+                "params": [addr, "latest"],
+                "id": 1,
+            },
+        )
+        code = resp.json().get("result", "0x")
+        if code == "0x" or code == "0x0":
+            return None
+    return addr
+
+
+@pytest.fixture
+def charge_intent(rpc_url):
+    return ChargeIntent(rpc_url=rpc_url)
+
+
+def _tip20_balance(rpc_url: str, token: str, address: str) -> int:
+    call_data = "0x70a08231" + "0" * 24 + address[2:].lower()
+    with httpx.Client(timeout=10) as client:
+        resp = client.post(
+            rpc_url,
+            json={
+                "jsonrpc": "2.0",
+                "method": "eth_call",
+                "params": [{"to": token, "data": call_data}, "latest"],
+                "id": 1,
+            },
+        )
+        return int(resp.json()["result"], 16)
+
+
+def _fund_account(rpc_url: str, address: str) -> None:
+    with httpx.Client(timeout=30) as client:
+        resp = client.post(
+            rpc_url,
+            json={
+                "jsonrpc": "2.0",
+                "method": "tempo_fundAddress",
+                "params": [address],
+                "id": 1,
+            },
+        )
+        result = resp.json()
+        if "error" in result:
+            raise RuntimeError(f"tempo_fundAddress failed: {result['error']}")
+
+    for _ in range(100):
+        if _tip20_balance(rpc_url, PATH_USD, address) > 0:
+            return
+        time.sleep(0.2)
+    raise RuntimeError(f"Account {address} not funded after 100 attempts")
+
+
+@pytest.fixture(scope="session")
+def funded_payer(rpc_url, is_local_node):
+    if is_local_node:
+        key = "0x" + os.urandom(32).hex()
+        account = TempoAccount.from_key(key)
+        _fund_account(rpc_url, account.address)
+        return account
+    return TempoAccount.from_env("TEMPO_TEST_PRIVATE_KEY")
+
+
+@pytest.fixture(scope="session")
+def funded_recipient(rpc_url, is_local_node):
+    if is_local_node:
+        key = "0x" + os.urandom(32).hex()
+        account = TempoAccount.from_key(key)
+        _fund_account(rpc_url, account.address)
+        return account
+    return TempoAccount.from_env("TEMPO_TEST_RECIPIENT_KEY")

--- a/tests/test_client_integration.py
+++ b/tests/test_client_integration.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import httpx
+import pytest
+
+from mpay import Challenge
+from mpay.client import PaymentTransport
+from mpay.methods.tempo import tempo
+from mpay.methods.tempo.intents import ChargeIntent
+from mpay.server.verify import verify_or_challenge
+from tests.conftest import INTEGRATION
+
+pytestmark = [pytest.mark.integration, INTEGRATION]
+
+
+class RealVerifyTransport(httpx.AsyncBaseTransport):
+    def __init__(self, intent, request_params, realm, secret_key):
+        self.intent = intent
+        self.request_params = request_params
+        self.realm = realm
+        self.secret_key = secret_key
+
+    async def handle_async_request(self, request):
+        if request.url.path == "/free":
+            return httpx.Response(200, json={"free": True})
+
+        auth = request.headers.get("authorization")
+        result = await verify_or_challenge(
+            authorization=auth,
+            intent=self.intent,
+            request=self.request_params,
+            realm=self.realm,
+            secret_key=self.secret_key,
+        )
+
+        if isinstance(result, Challenge):
+            headers = {"www-authenticate": result.to_www_authenticate(self.realm)}
+            return httpx.Response(402, headers=headers)
+
+        credential, receipt = result
+        return httpx.Response(
+            200,
+            json={"paid": True, "payer": credential.source},
+            headers={"payment-receipt": receipt.to_payment_receipt()},
+        )
+
+    async def aclose(self) -> None:
+        pass
+
+
+@pytest.fixture
+def server_transport(rpc_url, funded_recipient, currency, chain_id):
+    intent = ChargeIntent(rpc_url=rpc_url)
+    request_params = {
+        "amount": "1000000",
+        "currency": currency,
+        "recipient": funded_recipient.address,
+        "expires": (datetime.now(UTC) + timedelta(hours=1)).isoformat().replace("+00:00", "Z"),
+        "methodDetails": {
+            "feePayer": False,
+            "chainId": chain_id,
+        },
+    }
+    return RealVerifyTransport(
+        intent=intent,
+        request_params=request_params,
+        realm="test.local",
+        secret_key="test-secret-key",
+    )
+
+
+class TestClientServerIntegration:
+    async def test_free_endpoint_no_payment(self, server_transport):
+        async with httpx.AsyncClient(
+            transport=server_transport, base_url="http://test"
+        ) as client:
+            response = await client.get("/free")
+            assert response.status_code == 200
+            assert response.json() == {"free": True}
+
+    async def test_paid_endpoint_returns_402_without_auth(self, server_transport):
+        async with httpx.AsyncClient(
+            transport=server_transport, base_url="http://test"
+        ) as client:
+            response = await client.get("/paid")
+            assert response.status_code == 402
+            assert response.headers["www-authenticate"].startswith("Payment ")
+
+    async def test_full_payment_roundtrip(self, rpc_url, funded_payer, server_transport):
+        method = tempo(account=funded_payer, rpc_url=rpc_url)
+        payment_transport = PaymentTransport(methods=[method], inner=server_transport)
+
+        async with httpx.AsyncClient(
+            transport=payment_transport, base_url="http://test"
+        ) as client:
+            response = await client.get("/paid")
+            assert response.status_code == 200
+            data = response.json()
+            assert data["paid"] is True
+            assert funded_payer.address.lower() in data["payer"].lower()
+
+    async def test_payment_roundtrip_no_matching_method(self, server_transport):
+        payment_transport = PaymentTransport(methods=[], inner=server_transport)
+
+        async with httpx.AsyncClient(
+            transport=payment_transport, base_url="http://test"
+        ) as client:
+            response = await client.get("/paid")
+            assert response.status_code == 402

--- a/tests/test_stream_integration.py
+++ b/tests/test_stream_integration.py
@@ -1,0 +1,406 @@
+from __future__ import annotations
+
+import asyncio
+import secrets
+from datetime import UTC, datetime
+
+import httpx
+import pytest
+
+from mpay import Credential
+from mpay.methods.tempo import TempoAccount
+from mpay.methods.tempo.intents import StreamIntent
+from mpay.methods.tempo.stream.chain import (
+    compute_channel_id,
+    encode_approve_call,
+    encode_open_call,
+    get_on_chain_channel,
+    get_tx_params,
+)
+from mpay.methods.tempo.stream.storage import ChannelState, MemoryStorage, SessionState
+from mpay.methods.tempo.stream.types import SignedVoucher, Voucher
+from mpay.methods.tempo.stream.voucher import sign_voucher
+from tests.conftest import INTEGRATION
+
+pytestmark = [pytest.mark.integration, INTEGRATION]
+
+REQUIRES_ESCROW = pytest.mark.skipif(
+    "not config.getfixturevalue('escrow_contract')",
+    reason="No escrow contract deployed on this network",
+)
+
+
+@pytest.fixture(autouse=True)
+def _skip_without_escrow(escrow_contract):
+    if escrow_contract is None:
+        pytest.skip("No escrow contract deployed on this network")
+
+
+async def _open_channel(
+    rpc_url: str,
+    payer: TempoAccount,
+    payee_address: str,
+    currency: str,
+    escrow_contract: str,
+    deposit: int,
+) -> str:
+    from pytempo import Call, TempoTransaction
+
+    salt = "0x" + secrets.token_hex(32)
+    chain_id, nonce, gas_price = await get_tx_params(rpc_url, payer.address)
+
+    channel_id = await compute_channel_id(
+        rpc_url,
+        escrow_contract,
+        payer.address,
+        payee_address,
+        currency,
+        deposit,
+        salt,
+        payer.address,
+    )
+
+    approve_data = encode_approve_call(escrow_contract, deposit)
+    open_data = encode_open_call(payee_address, currency, deposit, salt, payer.address)
+
+    tx = TempoTransaction.create(
+        chain_id=chain_id,
+        gas_limit=2_000_000,
+        max_fee_per_gas=gas_price,
+        max_priority_fee_per_gas=gas_price,
+        nonce=nonce,
+        nonce_key=0,
+        fee_token=currency,
+        calls=(
+            Call.create(to=currency, value=0, data=approve_data),
+            Call.create(to=escrow_contract, value=0, data=open_data),
+        ),
+    )
+    signed = tx.sign(payer.private_key)
+    raw_tx = "0x" + signed.encode().hex()
+
+    async with httpx.AsyncClient(timeout=30) as client:
+        resp = await client.post(
+            rpc_url,
+            json={
+                "jsonrpc": "2.0",
+                "method": "eth_sendRawTransaction",
+                "params": [raw_tx],
+                "id": 1,
+            },
+        )
+        result = resp.json()
+        if "error" in result:
+            raise RuntimeError(f"Open channel RPC error: {result['error']}")
+        tx_hash = result["result"]
+
+    await _wait_for_receipt(rpc_url, tx_hash)
+
+    return channel_id
+
+
+async def _wait_for_receipt(rpc_url: str, tx_hash: str, max_attempts: int = 30, delay: float = 1.0):
+    async with httpx.AsyncClient(timeout=30) as client:
+        for _ in range(max_attempts):
+            resp = await client.post(
+                rpc_url,
+                json={
+                    "jsonrpc": "2.0",
+                    "method": "eth_getTransactionReceipt",
+                    "params": [tx_hash],
+                    "id": 1,
+                },
+            )
+            result = resp.json().get("result")
+            if result is not None:
+                if result.get("status") != "0x1":
+                    raise RuntimeError(f"Transaction reverted: {tx_hash}")
+                return result
+            await asyncio.sleep(delay)
+    raise RuntimeError(f"Receipt not found: {tx_hash}")
+
+
+def _make_challenge(
+    *,
+    challenge_id: str = "integration-challenge",
+    currency: str,
+    recipient: str,
+    escrow_contract: str,
+    chain_id: int,
+):
+    class MockChallenge:
+        pass
+
+    c = MockChallenge()
+    c.id = challenge_id
+    c.request = {
+        "amount": "1000000",
+        "unitType": "token",
+        "currency": currency,
+        "recipient": recipient,
+        "methodDetails": {
+            "escrowContract": escrow_contract,
+            "chainId": chain_id,
+        },
+    }
+    return c
+
+
+class TestStreamIntegration:
+    async def test_open_channel_on_chain(
+        self,
+        rpc_url,
+        funded_payer,
+        funded_recipient,
+        currency,
+        escrow_contract,
+        chain_id,
+    ):
+        channel_id = await _open_channel(
+            rpc_url,
+            funded_payer,
+            funded_recipient.address,
+            currency,
+            escrow_contract,
+            10_000_000,
+        )
+
+        on_chain = await get_on_chain_channel(rpc_url, escrow_contract, channel_id)
+
+        assert on_chain.deposit == 10_000_000
+        assert on_chain.payer.lower() == funded_payer.address.lower()
+        assert on_chain.payee.lower() == funded_recipient.address.lower()
+        assert on_chain.finalized is False
+
+    async def test_voucher_flow(
+        self,
+        rpc_url,
+        funded_payer,
+        funded_recipient,
+        currency,
+        escrow_contract,
+        chain_id,
+    ):
+        channel_id = await _open_channel(
+            rpc_url,
+            funded_payer,
+            funded_recipient.address,
+            currency,
+            escrow_contract,
+            10_000_000,
+        )
+
+        storage = MemoryStorage()
+        intent = StreamIntent(
+            storage=storage,
+            escrow_contract=escrow_contract,
+            chain_id=chain_id,
+            rpc_url=rpc_url,
+        )
+
+        on_chain = await get_on_chain_channel(rpc_url, escrow_contract, channel_id)
+
+        initial_voucher = Voucher(channel_id=channel_id, cumulative_amount=0)
+        initial_sig = sign_voucher(funded_payer, initial_voucher, escrow_contract, chain_id)
+
+        await storage.update_channel(
+            channel_id,
+            lambda _: ChannelState(
+                channel_id=channel_id,
+                payer=on_chain.payer,
+                payee=on_chain.payee,
+                token=on_chain.token,
+                authorized_signer=funded_payer.address,
+                deposit=on_chain.deposit,
+                settled_on_chain=0,
+                highest_voucher_amount=0,
+                highest_voucher=SignedVoucher(
+                    channel_id=channel_id,
+                    cumulative_amount=0,
+                    signature=initial_sig,
+                ),
+                active_session_id="integration-challenge",
+                finalized=False,
+                created_at=datetime.now(UTC),
+            ),
+        )
+        await storage.update_session(
+            "integration-challenge",
+            lambda _: SessionState(
+                challenge_id="integration-challenge",
+                channel_id=channel_id,
+                accepted_cumulative=0,
+                spent=0,
+                units=0,
+                created_at=datetime.now(UTC),
+            ),
+        )
+
+        voucher = Voucher(channel_id=channel_id, cumulative_amount=2_000_000)
+        sig = sign_voucher(funded_payer, voucher, escrow_contract, chain_id)
+
+        challenge = _make_challenge(
+            currency=currency,
+            recipient=funded_recipient.address,
+            escrow_contract=escrow_contract,
+            chain_id=chain_id,
+        )
+
+        credential = Credential(
+            challenge=challenge,
+            payload={
+                "action": "voucher",
+                "channelId": channel_id,
+                "cumulativeAmount": "2000000",
+                "signature": sig,
+            },
+        )
+
+        receipt = await intent.verify(credential, {})
+
+        assert receipt.status == "success"
+        assert receipt.reference == channel_id
+
+        ch = await storage.get_channel(channel_id)
+        assert ch is not None
+        assert ch.highest_voucher_amount == 2_000_000
+
+    async def test_close_channel(
+        self,
+        rpc_url,
+        funded_payer,
+        funded_recipient,
+        currency,
+        escrow_contract,
+        chain_id,
+    ):
+        channel_id = await _open_channel(
+            rpc_url,
+            funded_payer,
+            funded_recipient.address,
+            currency,
+            escrow_contract,
+            10_000_000,
+        )
+
+        storage = MemoryStorage()
+        intent = StreamIntent(
+            storage=storage,
+            escrow_contract=escrow_contract,
+            chain_id=chain_id,
+            rpc_url=rpc_url,
+        )
+
+        on_chain = await get_on_chain_channel(rpc_url, escrow_contract, channel_id)
+
+        initial_voucher = Voucher(channel_id=channel_id, cumulative_amount=0)
+        initial_sig = sign_voucher(funded_payer, initial_voucher, escrow_contract, chain_id)
+
+        await storage.update_channel(
+            channel_id,
+            lambda _: ChannelState(
+                channel_id=channel_id,
+                payer=on_chain.payer,
+                payee=on_chain.payee,
+                token=on_chain.token,
+                authorized_signer=funded_payer.address,
+                deposit=on_chain.deposit,
+                settled_on_chain=0,
+                highest_voucher_amount=0,
+                highest_voucher=SignedVoucher(
+                    channel_id=channel_id,
+                    cumulative_amount=0,
+                    signature=initial_sig,
+                ),
+                active_session_id="close-challenge",
+                finalized=False,
+                created_at=datetime.now(UTC),
+            ),
+        )
+        await storage.update_session(
+            "close-challenge",
+            lambda _: SessionState(
+                challenge_id="close-challenge",
+                channel_id=channel_id,
+                accepted_cumulative=0,
+                spent=0,
+                units=0,
+                created_at=datetime.now(UTC),
+            ),
+        )
+
+        voucher = Voucher(channel_id=channel_id, cumulative_amount=3_000_000)
+        voucher_sig = sign_voucher(funded_payer, voucher, escrow_contract, chain_id)
+
+        challenge_v = _make_challenge(
+            challenge_id="close-challenge",
+            currency=currency,
+            recipient=funded_recipient.address,
+            escrow_contract=escrow_contract,
+            chain_id=chain_id,
+        )
+        credential_v = Credential(
+            challenge=challenge_v,
+            payload={
+                "action": "voucher",
+                "channelId": channel_id,
+                "cumulativeAmount": "3000000",
+                "signature": voucher_sig,
+            },
+        )
+        await intent.verify(credential_v, {})
+
+        close_voucher = Voucher(channel_id=channel_id, cumulative_amount=3_000_000)
+        close_sig = sign_voucher(funded_payer, close_voucher, escrow_contract, chain_id)
+
+        challenge_c = _make_challenge(
+            challenge_id="close-challenge",
+            currency=currency,
+            recipient=funded_recipient.address,
+            escrow_contract=escrow_contract,
+            chain_id=chain_id,
+        )
+        credential_c = Credential(
+            challenge=challenge_c,
+            payload={
+                "action": "close",
+                "channelId": channel_id,
+                "cumulativeAmount": "3000000",
+                "signature": close_sig,
+            },
+        )
+        receipt = await intent.verify(credential_c, {})
+
+        assert receipt.status == "success"
+
+        ch = await storage.get_channel(channel_id)
+        assert ch is not None
+        assert ch.finalized is True
+        assert ch.highest_voucher_amount == 3_000_000
+
+    async def test_get_on_chain_channel_reads_state(
+        self,
+        rpc_url,
+        funded_payer,
+        funded_recipient,
+        currency,
+        escrow_contract,
+    ):
+        channel_id = await _open_channel(
+            rpc_url,
+            funded_payer,
+            funded_recipient.address,
+            currency,
+            escrow_contract,
+            10_000_000,
+        )
+
+        on_chain = await get_on_chain_channel(rpc_url, escrow_contract, channel_id)
+
+        assert on_chain.deposit == 10_000_000
+        assert on_chain.settled == 0
+        assert on_chain.finalized is False
+        assert on_chain.payer.lower() == funded_payer.address.lower()
+        assert on_chain.payee.lower() == funded_recipient.address.lower()
+        assert on_chain.token.lower() == currency.lower()
+        assert on_chain.close_requested_at == 0

--- a/tests/test_tempo_integration.py
+++ b/tests/test_tempo_integration.py
@@ -1,0 +1,212 @@
+"""Integration tests for Tempo charge intent against a real node.
+
+Requires TEMPO_RPC_URL to be set. Run with:
+    TEMPO_RPC_URL=http://localhost:8545 pytest -m integration -v
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+
+import httpx
+import pytest
+
+from mpay import Challenge
+from mpay.methods.tempo import tempo
+from mpay.server.intent import VerificationError
+from tests import make_credential
+from tests.conftest import INTEGRATION
+
+pytestmark = [pytest.mark.integration, INTEGRATION]
+
+
+def _future_expires() -> str:
+    return (datetime.now(UTC) + timedelta(hours=1)).isoformat().replace("+00:00", "Z")
+
+
+async def _send_transfer(
+    rpc_url: str,
+    payer,
+    currency: str,
+    recipient_addr: str,
+    amount: int,
+    *,
+    nonce_key: int = 0,
+) -> str:
+    from pytempo import Call, TempoTransaction
+
+    from mpay.methods.tempo.stream.chain import get_tx_params
+
+    cid, nonce, gas_price = await get_tx_params(rpc_url, payer.address)
+
+    selector = "a9059cbb"
+    to_padded = recipient_addr[2:].lower().zfill(64)
+    amount_padded = hex(amount)[2:].zfill(64)
+    data = f"0x{selector}{to_padded}{amount_padded}"
+
+    tx = TempoTransaction.create(
+        chain_id=cid,
+        gas_limit=100_000,
+        max_fee_per_gas=gas_price,
+        max_priority_fee_per_gas=gas_price,
+        nonce=nonce,
+        nonce_key=nonce_key,
+        fee_token=currency,
+        calls=(Call.create(to=currency, value=0, data=data),),
+    )
+    signed = tx.sign(payer.private_key)
+    raw_tx = "0x" + signed.encode().hex()
+
+    async with httpx.AsyncClient(timeout=30) as client:
+        resp = await client.post(
+            rpc_url,
+            json={
+                "jsonrpc": "2.0",
+                "method": "eth_sendRawTransaction",
+                "params": [raw_tx],
+                "id": 1,
+            },
+        )
+        result = resp.json()
+        if "error" in result:
+            raise RuntimeError(f"RPC error: {result['error']}")
+        tx_hash = result["result"]
+
+    await _wait_for_receipt(rpc_url, tx_hash)
+    return tx_hash
+
+
+async def _wait_for_receipt(
+    rpc_url: str, tx_hash: str, max_attempts: int = 30, delay: float = 1.0
+) -> dict:
+    async with httpx.AsyncClient(timeout=30) as client:
+        for _ in range(max_attempts):
+            resp = await client.post(
+                rpc_url,
+                json={
+                    "jsonrpc": "2.0",
+                    "method": "eth_getTransactionReceipt",
+                    "params": [tx_hash],
+                    "id": 1,
+                },
+            )
+            result = resp.json().get("result")
+            if result is not None:
+                if result.get("status") != "0x1":
+                    raise RuntimeError(f"Transaction reverted: {tx_hash}")
+                return result
+            await asyncio.sleep(delay)
+    raise RuntimeError(f"Receipt not found after {max_attempts} attempts: {tx_hash}")
+
+
+class TestChargeIntegration:
+    async def test_create_credential_builds_real_tx(
+        self, rpc_url, funded_payer, funded_recipient, currency
+    ):
+        method = tempo(account=funded_payer, rpc_url=rpc_url)
+        challenge = Challenge(
+            id="integ-create-cred",
+            method="tempo",
+            intent="charge",
+            request={
+                "amount": "1000000",
+                "currency": currency,
+                "recipient": funded_recipient.address,
+                "expires": _future_expires(),
+            },
+        )
+
+        credential = await method.create_credential(challenge)
+
+        assert credential.payload["type"] == "transaction"
+        assert credential.payload["signature"].startswith("0x76")
+        assert funded_payer.address in credential.source
+
+    async def test_verify_transaction_credential(
+        self, rpc_url, funded_payer, funded_recipient, currency, charge_intent, chain_id
+    ):
+        method = tempo(account=funded_payer, rpc_url=rpc_url)
+        expires = _future_expires()
+        request_dict = {
+            "amount": "1000000",
+            "currency": currency,
+            "recipient": funded_recipient.address,
+            "expires": expires,
+            "methodDetails": {
+                "feePayer": False,
+                "chainId": chain_id,
+            },
+        }
+        challenge = Challenge(
+            id="integ-verify-tx",
+            method="tempo",
+            intent="charge",
+            request=request_dict,
+        )
+
+        credential = await method.create_credential(challenge)
+        receipt = await charge_intent.verify(credential, request_dict)
+
+        assert receipt.status == "success"
+        assert receipt.reference.startswith("0x")
+        assert len(receipt.reference) >= 66
+
+    async def test_verify_hash_credential(
+        self, rpc_url, funded_payer, funded_recipient, currency, charge_intent
+    ):
+        tx_hash = await _send_transfer(
+            rpc_url, funded_payer, currency, funded_recipient.address, 1000000
+        )
+
+        expires = _future_expires()
+        request_dict = {
+            "amount": "1000000",
+            "currency": currency,
+            "recipient": funded_recipient.address,
+            "expires": expires,
+        }
+        credential = make_credential(payload={"type": "hash", "hash": tx_hash})
+        receipt = await charge_intent.verify(credential, request_dict)
+
+        assert receipt.status == "success"
+        assert receipt.reference == tx_hash
+
+    async def test_verify_rejects_insufficient_transfer(
+        self, rpc_url, funded_payer, funded_recipient, currency, charge_intent
+    ):
+        tx_hash = await _send_transfer(
+            rpc_url, funded_payer, currency, funded_recipient.address, 100
+        )
+
+        expires = _future_expires()
+        request_dict = {
+            "amount": "1000000",
+            "currency": currency,
+            "recipient": funded_recipient.address,
+            "expires": expires,
+        }
+        credential = make_credential(payload={"type": "hash", "hash": tx_hash})
+
+        with pytest.raises(VerificationError):
+            await charge_intent.verify(credential, request_dict)
+
+    async def test_verify_rejects_wrong_recipient(
+        self, rpc_url, funded_payer, currency, charge_intent
+    ):
+        tx_hash = await _send_transfer(
+            rpc_url, funded_payer, currency, funded_payer.address, 1000000
+        )
+
+        wrong_recipient = "0x0000000000000000000000000000000000000001"
+        expires = _future_expires()
+        request_dict = {
+            "amount": "1000000",
+            "currency": currency,
+            "recipient": wrong_recipient,
+            "expires": expires,
+        }
+        credential = make_credential(payload={"type": "hash", "hash": tx_hash})
+
+        with pytest.raises(VerificationError):
+            await charge_intent.verify(credential, request_dict)


### PR DESCRIPTION
## Summary

Integration tests that run against a real local Tempo node (`tempo-eval-node`).

- **5 charge intent tests** — create credential, verify transaction, verify hash, reject insufficient amount, reject wrong recipient
- **4 client→server roundtrip tests** — free endpoint passthrough, 402 without auth, full payment roundtrip with real on-chain tx, no matching method fallback
- **4 stream/escrow tests** — open channel, voucher flow, close channel, read on-chain state (auto-skip when escrow contract not deployed)

## How to run

```bash
# Start local Tempo devnet
docker run -d --name tempo-eval-node -p 8545:8545 ghcr.io/tempoxyz/tempo-eval-node:latest

# Run integration tests
TEMPO_RPC_URL=http://localhost:8545 pytest -m integration -v

# Or via Makefile
make test-integration
```

## Details

- All 198 existing unit tests continue to pass (integration tests skip when `TEMPO_RPC_URL` is unset)
- Auto-detects local node and uses PathUSD (`0x...0000`) as currency, since that's what `tempo_fundAddress` provides
- Stream tests require the TempoStreamChannel escrow contract deployed (source in `ai-payments/packages/stream-channels`); they auto-skip if not present
- No fee payer dependency — tests submit transactions directly to the local RPC

## Current results

| Suite | Result |
|-------|--------|
| Unit tests | 198 passed, 13 skipped |
| Charge integration | 5 passed |
| Client integration | 4 passed |
| Stream integration | 4 skipped (no escrow contract on devnet) |