### PR TITLE
feat: make intents explicit in tempo() — remove implicit ChargeIntent default

### DIFF
--- a/.changelog/explicit-intents.md
+++ b/.changelog/explicit-intents.md
@@ -1,0 +1,5 @@
+---
+mpay: major
+---
+
+**Breaking:** `tempo()` now requires an explicit `intents` parameter. The implicit `ChargeIntent` default has been removed.

--- a/README.md
+++ b/README.md
@@ -17,9 +17,10 @@ Python SDK for the Machine Payments Protocol (MPP) - an implementation of the ["
 ```python
 from mpay import Challenge
 from mpay.server import Mpay
-from mpay.methods.tempo import tempo
+from mpay.methods.tempo import tempo, ChargeIntent
 mpay = Mpay.create(
     method=tempo(
+        intents={"charge": ChargeIntent()},
         currency="0x20c0000000000000000000000000000000000001",
         recipient="0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
     ),
@@ -50,11 +51,11 @@ async def handler(request):
 
 ```python
 from mpay.client import Client
-from mpay.methods.tempo import tempo, TempoAccount
+from mpay.methods.tempo import tempo, TempoAccount, ChargeIntent
 
 account = TempoAccount.from_key("0x...")
 
-async with Client(methods=[tempo(account=account)]) as client:
+async with Client(methods=[tempo(account=account, intents={"charge": ChargeIntent()})]) as client:
     r1 = await client.get("https://api.example.com/a")
     r2 = await client.get("https://api.example.com/b")
 ```
@@ -63,13 +64,13 @@ async with Client(methods=[tempo(account=account)]) as client:
 
 ```python
 from mpay.client import get
-from mpay.methods.tempo import tempo, TempoAccount
+from mpay.methods.tempo import tempo, TempoAccount, ChargeIntent
 
 account = TempoAccount.from_key("0x...")
 
 response = await get(
     "https://api.example.com/resource",
-    methods=[tempo(account=account)],
+    methods=[tempo(account=account, intents={"charge": ChargeIntent()})],
 )
 ```
 
@@ -80,7 +81,7 @@ from mpay.client import PaymentTransport
 import httpx
 
 transport = PaymentTransport(
-    methods=[tempo(...)],
+    methods=[tempo(intents={"charge": ChargeIntent()}, ...)],
     inner=httpx.AsyncHTTPTransport(),
 )
 
@@ -92,11 +93,11 @@ async with httpx.AsyncClient(transport=transport) as client:
 
 ```python
 from mpay import Challenge, Credential
-from mpay.methods.tempo import tempo, TempoAccount
+from mpay.methods.tempo import tempo, TempoAccount, ChargeIntent
 import httpx
 
 account = TempoAccount.from_key("0x...")
-method = tempo(account=account)
+method = tempo(account=account, intents={"charge": ChargeIntent()})
 
 async with httpx.AsyncClient() as client:
     res = await client.get("https://api.example.com/resource")
@@ -264,12 +265,15 @@ async def my_charge(credential: Credential, request: dict) -> Receipt:
 
 ```python
 from mpay.methods.tempo import tempo, TempoAccount, ChargeIntent
+
 method = tempo(
+    intents={"charge": ChargeIntent()},
     currency="0x20c0000000000000000000000000000000000001",
     recipient="0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
 )
+
 account = TempoAccount.from_key("0x...")
-client_method = tempo(account=account)
+client_method = tempo(account=account, intents={"charge": ChargeIntent()})
 ```
 
 ## Code Style

--- a/examples/api-server/server.py
+++ b/examples/api-server/server.py
@@ -22,7 +22,11 @@ DESTINATION = os.environ.get(
 )
 
 mpay = Mpay.create(
-    method=tempo(currency=ALPHA_USD, recipient=DESTINATION),
+    method=tempo(
+        currency=ALPHA_USD,
+        recipient=DESTINATION,
+        intents={"charge": ChargeIntent(rpc_url=RPC_URL)},
+    ),
 )
 
 

--- a/examples/fetch/fetch.py
+++ b/examples/fetch/fetch.py
@@ -7,7 +7,7 @@ import os
 import sys
 
 from mpay.client import Client
-from mpay.methods.tempo import TempoAccount, tempo
+from mpay.methods.tempo import ChargeIntent, TempoAccount, tempo
 
 
 def parse_args() -> argparse.Namespace:
@@ -47,7 +47,7 @@ async def run(args: argparse.Namespace) -> int:
     account = TempoAccount.from_key(key)
 
     rpc_url = args.rpc_url or os.environ.get("TEMPO_RPC_URL")
-    method = tempo(account=account, rpc_url=rpc_url) if rpc_url else tempo(account=account)
+    method = tempo(account=account, rpc_url=rpc_url or "https://rpc.tempo.xyz", intents={"charge": ChargeIntent()})
 
     async with Client(methods=[method]) as client:
         response = await client.request(

--- a/examples/httpx-client.md
+++ b/examples/httpx-client.md
@@ -17,13 +17,13 @@ The simplest way to make paid requests:
 
 ```python
 from mpay.client import get
-from mpay.methods.tempo import tempo, TempoAccount
+from mpay.methods.tempo import tempo, TempoAccount, ChargeIntent
 
 account = TempoAccount.from_key("0x...")
 
 response = await get(
     "https://api.example.com/resource",
-    methods=[tempo(account=account)],
+    methods=[tempo(account=account, intents={"charge": ChargeIntent()})],
 )
 ```
 
@@ -33,11 +33,11 @@ For multiple requests, use the `Client` wrapper:
 
 ```python
 from mpay.client import Client
-from mpay.methods.tempo import tempo, TempoAccount
+from mpay.methods.tempo import tempo, TempoAccount, ChargeIntent
 
 account = TempoAccount.from_key("0x...")
 
-async with Client(methods=[tempo(account=account)]) as client:
+async with Client(methods=[tempo(account=account, intents={"charge": ChargeIntent()})]) as client:
     r1 = await client.get("https://api.example.com/a")
     r2 = await client.get("https://api.example.com/b")
 ```
@@ -48,13 +48,13 @@ For full control, use `PaymentTransport` with a custom httpx client:
 
 ```python
 from mpay.client import PaymentTransport
-from mpay.methods.tempo import tempo, TempoAccount
+from mpay.methods.tempo import tempo, TempoAccount, ChargeIntent
 import httpx
 
 account = TempoAccount.from_key("0x...")
 
 transport = PaymentTransport(
-    methods=[tempo(account=account)],
+    methods=[tempo(account=account, intents={"charge": ChargeIntent()})],
     inner=httpx.AsyncHTTPTransport(),
 )
 
@@ -68,11 +68,11 @@ For complete control over the payment flow:
 
 ```python
 from mpay import Challenge, Credential
-from mpay.methods.tempo import tempo, TempoAccount
+from mpay.methods.tempo import tempo, TempoAccount, ChargeIntent
 import httpx
 
 account = TempoAccount.from_key("0x...")
-method = tempo(account=account)
+method = tempo(account=account, intents={"charge": ChargeIntent()})
 
 async with httpx.AsyncClient() as client:
     # Initial request - expect 402

--- a/examples/mcp-server/client.py
+++ b/examples/mcp-server/client.py
@@ -32,7 +32,7 @@ from mpay.extensions.mcp import (
     MCPChallenge,
     MCPCredential,
 )
-from mpay.methods.tempo import TempoAccount, tempo
+from mpay.methods.tempo import ChargeIntent, TempoAccount, tempo
 
 SERVER_URL = os.environ.get("MCP_SERVER_URL", "http://127.0.0.1:8000/sse")
 
@@ -48,7 +48,7 @@ async def run_client() -> None:
         sys.exit(1)
 
     account = TempoAccount.from_key(private_key)
-    method = tempo(account=account)
+    method = tempo(account=account, intents={"charge": ChargeIntent()})
 
     print(f"Client address: {account.address}")
     print()

--- a/src/mpay/methods/tempo/__init__.py
+++ b/src/mpay/methods/tempo/__init__.py
@@ -3,20 +3,22 @@
 Example:
     # Client-side
     from mpay.client import get
-    from mpay.methods.tempo import tempo, TempoAccount
+    from mpay.methods.tempo import tempo, TempoAccount, ChargeIntent
 
     account = TempoAccount.from_key("0x...")
     response = await get(
         "https://api.example.com/resource",
-        methods=[tempo(account=account, rpc_url="https://rpc.tempo.xyz")],
+        methods=[tempo(
+            account=account,
+            intents={"charge": ChargeIntent()},
+        )],
     )
 
     # Server-side
     from mpay.server import verify_or_challenge
     from mpay.methods.tempo import ChargeIntent
 
-    client = create_client(...)
-    intent = ChargeIntent(client)
+    intent = ChargeIntent(rpc_url="https://rpc.tempo.xyz")
     result = await verify_or_challenge(
         authorization=request.headers.get("Authorization"),
         intent=intent,

--- a/src/mpay/methods/tempo/client.py
+++ b/src/mpay/methods/tempo/client.py
@@ -11,7 +11,6 @@ from typing import TYPE_CHECKING, Any
 
 from mpay import Challenge, Credential
 from mpay.methods.tempo._defaults import RPC_URL
-from mpay.methods.tempo.intents import ChargeIntent
 from mpay.methods.tempo.stream.chain import (
     compute_channel_id,
     encode_approve_call,
@@ -67,12 +66,6 @@ class TempoMethod:
     recipient: str | None = None
     decimals: int = 6
     _intents: dict[str, Intent] = field(default_factory=dict)
-
-    def __post_init__(self) -> None:
-        if not self._intents:
-            self._intents = {
-                "charge": ChargeIntent(rpc_url=self.rpc_url),
-            }
 
     @property
     def intents(self) -> dict[str, Intent]:
@@ -629,33 +622,34 @@ class StreamMethod:
 
 
 def tempo(
+    intents: dict[str, Intent],
     account: TempoAccount | None = None,
     rpc_url: str = RPC_URL,
     root_account: str | None = None,
     currency: str | None = None,
     recipient: str | None = None,
     decimals: int = 6,
-    intents: dict[str, Intent] | None = None,
 ) -> TempoMethod:
     """Create a Tempo payment method.
 
     Args:
+        intents: Intents to register (e.g. charge, stream).
         account: Account for signing transactions.
         rpc_url: Tempo RPC endpoint URL.
         root_account: Root account address for access key signing.
         currency: Default currency address for charges.
         recipient: Default recipient address for charges.
         decimals: Token decimal places for amount conversion (default: 6).
-        intents: Additional intents to register (merged with default charge).
 
     Returns:
         A configured TempoMethod instance.
 
     Example:
-        from mpay.methods.tempo import tempo, TempoAccount
+        from mpay.methods.tempo import ChargeIntent
 
-        account = TempoAccount.from_key("0x...")
-        method = tempo(account=account)
+        method = tempo(
+            intents={"charge": ChargeIntent()},
+        )
     """
     method = TempoMethod(
         account=account,
@@ -665,6 +659,5 @@ def tempo(
         recipient=recipient,
         decimals=decimals,
     )
-    if intents:
-        method._intents.update(intents)
+    method._intents = dict(intents)
     return method

--- a/tests/test_mpay_create.py
+++ b/tests/test_mpay_create.py
@@ -11,6 +11,7 @@ import pytest
 
 from mpay import Challenge, Credential, Receipt
 from mpay.methods.tempo import tempo
+from mpay.methods.tempo.intents import ChargeIntent
 from mpay.server import Mpay
 
 
@@ -30,6 +31,7 @@ class TestMpayCreate:
         method = tempo(
             currency="0x20c0000000000000000000000000000000000001",
             recipient="0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
+            intents={"charge": ChargeIntent()},
         )
         mpay = Mpay.create(
             method=method,
@@ -44,7 +46,7 @@ class TestMpayCreate:
     def test_create_auto_realm(self) -> None:
         with patch.dict(os.environ, {"MPAY_REALM": "auto.example.com"}):
             mpay = Mpay.create(
-                method=tempo(),
+                method=tempo(intents={"charge": ChargeIntent()}),
                 secret_key="test-secret",
             )
             assert mpay.realm == "auto.example.com"
@@ -55,7 +57,7 @@ class TestMpayCreate:
             os.environ.pop("HOST", None)
             os.environ.pop("HOSTNAME", None)
             mpay = Mpay.create(
-                method=tempo(),
+                method=tempo(intents={"charge": ChargeIntent()}),
                 secret_key="test-secret",
             )
             assert mpay.realm == "my-app.vercel.app"
@@ -63,7 +65,7 @@ class TestMpayCreate:
     def test_create_auto_realm_fallback(self) -> None:
         with patch.dict(os.environ, {}, clear=True):
             mpay = Mpay.create(
-                method=tempo(),
+                method=tempo(intents={"charge": ChargeIntent()}),
                 secret_key="test-secret",
             )
             assert mpay.realm == "localhost"
@@ -75,7 +77,7 @@ class TestMpayCreate:
             patch("mpay.server._defaults._ENV_FILE", env_file),
         ):
             mpay = Mpay.create(
-                method=tempo(),
+                method=tempo(intents={"charge": ChargeIntent()}),
                 realm="test.com",
             )
             assert len(mpay.secret_key) == 36  # UUID format
@@ -85,7 +87,7 @@ class TestMpayCreate:
     def test_create_auto_secret_key_from_env(self) -> None:
         with patch.dict(os.environ, {"MPAY_SECRET_KEY": "env-secret"}):
             mpay = Mpay.create(
-                method=tempo(),
+                method=tempo(intents={"charge": ChargeIntent()}),
                 realm="test.com",
             )
             assert mpay.secret_key == "env-secret"
@@ -96,8 +98,8 @@ class TestMpayCreate:
             patch.dict(os.environ, {}, clear=True),
             patch("mpay.server._defaults._ENV_FILE", env_file),
         ):
-            mpay1 = Mpay.create(method=tempo(), realm="test.com")
-            mpay2 = Mpay.create(method=tempo(), realm="test.com")
+            mpay1 = Mpay.create(method=tempo(intents={"charge": ChargeIntent()}), realm="test.com")
+            mpay2 = Mpay.create(method=tempo(intents={"charge": ChargeIntent()}), realm="test.com")
             assert mpay1.secret_key == mpay2.secret_key
 
 
@@ -108,6 +110,7 @@ class TestMpayCharge:
             method=tempo(
                 currency="0x20c0000000000000000000000000000000000001",
                 recipient="0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
+                intents={"charge": ChargeIntent()},
             ),
             realm="test.com",
             secret_key="test-secret",
@@ -127,6 +130,7 @@ class TestMpayCharge:
             method=tempo(
                 currency="0x20c0000000000000000000000000000000000001",
                 recipient="0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
+                intents={"charge": ChargeIntent()},
             ),
             realm="test.com",
             secret_key="test-secret",
@@ -146,6 +150,7 @@ class TestMpayCharge:
             method=tempo(
                 currency="0x20c0000000000000000000000000000000000001",
                 recipient="0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
+                intents={"charge": ChargeIntent()},
             ),
             realm="test.com",
             secret_key="test-secret",
@@ -161,6 +166,7 @@ class TestMpayCharge:
             method=tempo(
                 currency="0x20c0000000000000000000000000000000000001",
                 recipient="0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
+                intents={"charge": ChargeIntent()},
             ),
             realm="test.com",
             secret_key="test-secret",
@@ -175,6 +181,7 @@ class TestMpayCharge:
             method=tempo(
                 currency="0x20c0000000000000000000000000000000000001",
                 recipient="0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
+                intents={"charge": ChargeIntent()},
             ),
             realm="test.com",
             secret_key="test-secret",
@@ -189,6 +196,7 @@ class TestMpayCharge:
             method=tempo(
                 currency="0x20c0000000000000000000000000000000000001",
                 recipient="0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
+                intents={"charge": ChargeIntent()},
             ),
             realm="test.com",
             secret_key="test-secret",
@@ -206,7 +214,7 @@ class TestMpayCharge:
     @pytest.mark.asyncio
     async def test_charge_missing_currency_raises(self) -> None:
         mpay = Mpay.create(
-            method=tempo(),
+            method=tempo(intents={"charge": ChargeIntent()}),
             realm="test.com",
             secret_key="test-secret",
         )
@@ -216,7 +224,7 @@ class TestMpayCharge:
     @pytest.mark.asyncio
     async def test_charge_missing_recipient_raises(self) -> None:
         mpay = Mpay.create(
-            method=tempo(currency="0xabc"),
+            method=tempo(currency="0xabc", intents={"charge": ChargeIntent()}),
             realm="test.com",
             secret_key="test-secret",
         )

--- a/tests/test_tempo.py
+++ b/tests/test_tempo.py
@@ -66,7 +66,7 @@ class TestTempoAccount:
 class TestTempoMethod:
     def test_tempo_factory(self) -> None:
         """tempo() should create a TempoMethod."""
-        method = tempo()
+        method = tempo(intents={"charge": ChargeIntent()})
         assert isinstance(method, TempoMethod)
         assert method.name == "tempo"
 
@@ -74,20 +74,20 @@ class TestTempoMethod:
         """tempo() should accept account and rpc_url."""
         key = "0x" + "d" * 64
         account = TempoAccount.from_key(key)
-        method = tempo(account=account, rpc_url="https://custom.rpc")
+        method = tempo(account=account, rpc_url="https://custom.rpc", intents={"charge": ChargeIntent(rpc_url="https://custom.rpc")})
         assert method.account == account
         assert method.rpc_url == "https://custom.rpc"
 
     def test_intents_property(self) -> None:
-        """Should have charge intent by default."""
-        method = tempo()
+        """Should have only the intents explicitly provided."""
+        method = tempo(intents={"charge": ChargeIntent()})
         assert "charge" in method.intents
         assert isinstance(method.intents["charge"], ChargeIntent)
 
     @pytest.mark.asyncio
     async def test_create_credential_no_account(self) -> None:
         """Should raise if no account configured."""
-        method = tempo()
+        method = tempo(intents={"charge": ChargeIntent()})
         challenge = Challenge(
             id="test",
             method="tempo",
@@ -102,7 +102,7 @@ class TestTempoMethod:
         """Should raise for unsupported intent."""
         key = "0x" + "e" * 64
         account = TempoAccount.from_key(key)
-        method = tempo(account=account)
+        method = tempo(account=account, intents={"charge": ChargeIntent()})
         challenge = Challenge(
             id="test",
             method="tempo",
@@ -114,7 +114,7 @@ class TestTempoMethod:
 
     def test_encode_transfer(self) -> None:
         """Should encode TIP-20 transfer correctly."""
-        method = tempo()
+        method = tempo(intents={"charge": ChargeIntent()})
         data = method._encode_transfer("0x742d35Cc6634c0532925a3b844bC9e7595F8fE00", 1000000)
         assert data.startswith("0xa9059cbb")
         assert len(data) == 138
@@ -401,7 +401,7 @@ class TestSponsoredTransfer:
     async def test_client_builds_sponsored_transaction(self, httpx_mock: HTTPXMock) -> None:
         """Client should build and return raw tx when fee_payer=True."""
         account = TempoAccount.from_key(TEST_PRIVATE_KEY)
-        method = tempo(account=account, rpc_url="https://rpc.test")
+        method = tempo(account=account, rpc_url="https://rpc.test", intents={"charge": ChargeIntent(rpc_url="https://rpc.test")})
 
         httpx_mock.add_response(
             url="https://rpc.test",

--- a/tests/test_tempo.py
+++ b/tests/test_tempo.py
@@ -74,7 +74,11 @@ class TestTempoMethod:
         """tempo() should accept account and rpc_url."""
         key = "0x" + "d" * 64
         account = TempoAccount.from_key(key)
-        method = tempo(account=account, rpc_url="https://custom.rpc", intents={"charge": ChargeIntent(rpc_url="https://custom.rpc")})
+        method = tempo(
+            account=account,
+            rpc_url="https://custom.rpc",
+            intents={"charge": ChargeIntent(rpc_url="https://custom.rpc")},
+        )
         assert method.account == account
         assert method.rpc_url == "https://custom.rpc"
 
@@ -401,7 +405,11 @@ class TestSponsoredTransfer:
     async def test_client_builds_sponsored_transaction(self, httpx_mock: HTTPXMock) -> None:
         """Client should build and return raw tx when fee_payer=True."""
         account = TempoAccount.from_key(TEST_PRIVATE_KEY)
-        method = tempo(account=account, rpc_url="https://rpc.test", intents={"charge": ChargeIntent(rpc_url="https://rpc.test")})
+        method = tempo(
+            account=account,
+            rpc_url="https://rpc.test",
+            intents={"charge": ChargeIntent(rpc_url="https://rpc.test")},
+        )
 
         httpx_mock.add_response(
             url="https://rpc.test",


### PR DESCRIPTION
## Breaking Change

`tempo()` now requires an explicit `intents` parameter. Previously it silently injected a `ChargeIntent` as a default, making it non-obvious which intents were active.

### Before
```python
method = tempo(account=account)
# charge intent silently included
```

### After
```python
method = tempo(
    account=account,
    intents={"charge": ChargeIntent()},
)
```

### Why

- The implicit default was a footgun — passing `intents={"stream": StreamIntent(...)}` silently *merged* with the hidden charge intent
- No way to opt out of charge
- Non-obvious what intents were active

### Changes
- Removed implicit `ChargeIntent` in `TempoMethod.__post_init__`
- Made `intents` a required parameter in `tempo()` factory
- Updated all call sites across tests, examples, and docs