### PR TITLE
Add PyPI publish workflow with trusted publishing

### DIFF
--- a/.changelog/README.md
+++ b/.changelog/README.md
@@ -1,0 +1,24 @@
+# Changelogs
+
+This folder contains changelog files that describe changes to be released.
+
+## Adding a changelog
+
+Run `changelogs add` to create a new changelog file.
+
+## File format
+
+Changelog files are markdown with YAML frontmatter:
+
+```markdown
+---
+package-name: minor
+other-package: patch
+---
+
+Description of the changes made.
+```
+
+## Releasing
+
+Run `changelogs version` to apply version bumps and generate changelogs.

--- a/.changelog/config.toml
+++ b/.changelog/config.toml
@@ -1,0 +1,26 @@
+# Ecosystem: "rust" | "python" (auto-detected if not specified)
+# ecosystem = "rust"
+
+# How to bump packages that depend on changed packages
+# "patch" | "minor" | "none"
+dependent_bump = "patch"
+
+[changelog]
+# "per-crate" - CHANGELOG.md in each package
+# "root" - Single CHANGELOG.md at workspace root
+format = "per-crate"
+
+# Fixed groups: all packages always share the same version
+# [[fixed]]
+# members = ["package-a", "package-b"]
+
+# Linked groups: versions sync when released together
+# [[linked]]
+# members = ["sdk-core", "sdk-macros"]
+
+# Packages to ignore
+ignore = []
+
+# AI-assisted changelog generation
+# [ai]
+# command = "amp ask"  # or "gh copilot suggest -t shell"

--- a/.changelog/config.toml
+++ b/.changelog/config.toml
@@ -1,26 +1,8 @@
-# Ecosystem: "rust" | "python" (auto-detected if not specified)
-# ecosystem = "rust"
+ecosystem = "python"
 
-# How to bump packages that depend on changed packages
-# "patch" | "minor" | "none"
 dependent_bump = "patch"
 
 [changelog]
-# "per-crate" - CHANGELOG.md in each package
-# "root" - Single CHANGELOG.md at workspace root
-format = "per-crate"
+format = "root"
 
-# Fixed groups: all packages always share the same version
-# [[fixed]]
-# members = ["package-a", "package-b"]
-
-# Linked groups: versions sync when released together
-# [[linked]]
-# members = ["sdk-core", "sdk-macros"]
-
-# Packages to ignore
 ignore = []
-
-# AI-assisted changelog generation
-# [ai]
-# command = "amp ask"  # or "gh copilot suggest -t shell"

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -17,11 +17,11 @@ jobs:
           ref: ${{ github.head_ref }}
       - name: Install changelogs
         run: curl -sSL https://changelogs.sh | sh
-      - name: Install Amp CLI
-        run: npm install -g @sourcegraph/amp
+      - name: Install Claude CLI
+        run: npm install -g @anthropic-ai/claude-code
       - name: Generate changelog
         env:
-          AMP_API_KEY: ${{ secrets.AMP_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
           CHANGED=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
           CODE_CHANGES=$(echo "$CHANGED" | grep -vE '^(\.changelog/|\.github/|\.gitignore|README\.md|AGENTS\.md)' || true)
@@ -29,7 +29,7 @@ jobs:
             echo "No code changes requiring changelog, skipping"
             exit 0
           fi
-          ~/.local/bin/changelogs add --ecosystem python --ai "amp -x" --ref origin/${{ github.base_ref }}
+          ~/.local/bin/changelogs add --ecosystem python --ai "claude -p" --ref origin/${{ github.base_ref }}
       - name: Commit changelog
         run: |
           if [ -n "$(git status --porcelain .changelog/)" ]; then

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -2,20 +2,40 @@ name: Changelog
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened]
 
 jobs:
   changelog:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
-
-      - run: npm install -g @sourcegraph/amp
-
-      - uses: wevm/changelogs/check@master
         with:
-          ai: 'amp -x'
+          fetch-depth: 0
+          ref: ${{ github.head_ref }}
+      - name: Install changelogs
+        run: curl -sSL https://changelogs.sh | sh
+      - name: Install Amp CLI
+        run: npm install -g @sourcegraph/amp
+      - name: Generate changelog
         env:
           AMP_API_KEY: ${{ secrets.AMP_API_KEY }}
+        run: |
+          CHANGED=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
+          CODE_CHANGES=$(echo "$CHANGED" | grep -vE '^(\.changelog/|\.github/|\.gitignore|README\.md|AGENTS\.md)' || true)
+          if [ -z "$CODE_CHANGES" ]; then
+            echo "No code changes requiring changelog, skipping"
+            exit 0
+          fi
+          ~/.local/bin/changelogs add --ecosystem python --ai "amp -x" --ref origin/${{ github.base_ref }}
+      - name: Commit changelog
+        run: |
+          if [ -n "$(git status --porcelain .changelog/)" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add .changelog/
+            git commit -m "chore: add changelog"
+            git push
+          fi

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,21 @@
+name: Changelog
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - run: npm install -g @sourcegraph/amp
+
+      - uses: wevm/changelogs/check@master
+        with:
+          ai: 'amp -x'
+        env:
+          AMP_API_KEY: ${{ secrets.AMP_API_KEY }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,19 +4,19 @@ on:
   push:
     branches: [main]
 
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
 jobs:
   release:
+    name: Version
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
-      - uses: wevm/changelogs@master
+      - uses: wevm/changelogs-rs@changelogs@0.6.0
         with:
+          ecosystem: python
           pypi-token: ${{ secrets.PYPI_TOKEN }}
+          conventional-commit: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,27 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Build package
+        run: uv build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,27 +1,22 @@
-name: Publish to PyPI
+name: Release
 
 on:
-  release:
-    types: [published]
+  push:
+    branches: [main]
 
 jobs:
-  publish:
-    name: Publish
+  release:
     runs-on: ubuntu-latest
-    environment: release
     permissions:
-      id-token: write
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v4
-
-      - name: Set up Python
-        run: uv python install 3.12
-
-      - name: Build package
-        run: uv build
-
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: wevm/changelogs@master
+        with:
+          pypi-token: ${{ secrets.PYPI_TOKEN }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,10 @@ authors = [
     {name = "Tempo"}
 ]
 license = {text = "MIT OR Apache-2.0"}
+
+[project.urls]
+Homepage = "https://github.com/tempoxyz/pympay"
+Documentation = "https://github.com/tempoxyz/pympay#readme"
 classifiers = [
     "License :: OSI Approved :: MIT License",
     "License :: OSI Approved :: Apache Software License",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,16 +11,16 @@ authors = [
     {name = "Tempo"}
 ]
 license = {text = "MIT OR Apache-2.0"}
-
-[project.urls]
-Homepage = "https://github.com/tempoxyz/pympay"
-Documentation = "https://github.com/tempoxyz/pympay#readme"
 classifiers = [
     "License :: OSI Approved :: MIT License",
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
 ]
+
+[project.urls]
+Homepage = "https://github.com/tempoxyz/pympay"
+Documentation = "https://github.com/tempoxyz/pympay#readme"
 
 [project.optional-dependencies]
 tempo = [


### PR DESCRIPTION
Adds a GitHub Actions workflow to publish to PyPI on release using OIDC trusted publishing (no API tokens needed).

**Changes:**
- `.github/workflows/publish.yml` — triggers on GitHub release, builds with `uv build`, publishes via `pypa/gh-action-pypi-publish`
- `pyproject.toml` — adds `[project.urls]` metadata

**Setup complete:**
- Trusted publisher configured on pypi.org for `tempoxyz/pympay` → `publish.yml` → `release` environment

**To publish:**
1. Ensure the `release` environment exists in repo settings
2. Create a GitHub release (e.g., tag `v0.1.0`)