### PR TITLE
chore: initial release

### DIFF
--- a/.changelog/initial-release.md
+++ b/.changelog/initial-release.md
@@ -1,0 +1,5 @@
+---
+mpay: minor
+---
+
+Initial release of mpay - HTTP 402 Payment Authentication for Python.


### PR DESCRIPTION
Adds changelog entry for the initial v0.1.0 release.

When merged, the release workflow will create an RC PR with the version bump. Merging that RC PR publishes to PyPI.