### PR TITLE
fix: use correct changelogs action ref

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: wevm/changelogs-rs@changelogs@0.6.0
+      - uses: wevm/changelogs@master
         with:
           ecosystem: python
           pypi-token: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
Fixes the release workflow — `wevm/changelogs-rs@changelogs@0.6.0` has two `@` symbols which GitHub Actions can't parse. Changed to `wevm/changelogs@master`.