### PR TITLE
fix: add write permissions to release workflow

### DIFF
--- a/.changelog/explicit-intents.md
+++ b/.changelog/explicit-intents.md
@@ -1,5 +1,5 @@
 ---
-mpay: minor
+mpay: patch
 ---
 
 **Breaking:** `tempo()` now requires an explicit `intents` parameter. The implicit `ChargeIntent` default has been removed.

--- a/.changelog/explicit-intents.md
+++ b/.changelog/explicit-intents.md
@@ -1,5 +1,5 @@
 ---
-mpay: major
+mpay: minor
 ---
 
 **Breaking:** `tempo()` now requires an explicit `intents` parameter. The implicit `ChargeIntent` default has been removed.

--- a/.changelog/initial-release.md
+++ b/.changelog/initial-release.md
@@ -1,5 +1,5 @@
 ---
-mpay: minor
+mpay: patch
 ---
 
 Initial release of mpay - HTTP 402 Payment Authentication for Python.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,9 @@ jobs:
   release:
     name: Version
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
The release workflow failed with `Write access to repository not granted` because the job was missing `contents: write` and `pull-requests: write` permissions needed to push the RC branch and create the PR.