### PR TITLE
fix: add release environment and permissions to release workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,7 @@ jobs:
   release:
     name: Version
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
Adds `environment: release` so the job can access `PYPI_TOKEN`, and sets changelogs to patch bump (v0.1.1).