### PR TITLE
chore: use published pytempo from PyPI

### DIFF
--- a/.changelog/odd-hens-twist.md
+++ b/.changelog/odd-hens-twist.md
@@ -1,0 +1,5 @@
+---
+mpay: patch
+---
+
+Switched pytempo dependency from git reference to PyPI package version.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ Documentation = "https://github.com/tempoxyz/pympay#readme"
 
 [project.optional-dependencies]
 tempo = [
-    "pytempo @ git+https://github.com/tempoxyz/pytempo.git@main",
+    "pytempo>=0.2.1",
     "pydantic>=2.0",
 ]
 server = ["pydantic>=2.0", "python-dotenv>=1.0"]
@@ -52,9 +52,6 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/mpay"]
-
-[tool.hatch.metadata]
-allow-direct-references = true
 
 [tool.ruff]
 line-length = 100


### PR DESCRIPTION
Switches the `pytempo` dependency from a git reference to the published PyPI package (`>=0.2.1`). Also removes the `allow-direct-references` hatch metadata since it's no longer needed.

All 198 tests pass.