### PR TITLE
feat: align with TypeScript SDK and spec

### DIFF
--- a/.changelog/calm-trees-sleep.md
+++ b/.changelog/calm-trees-sleep.md
@@ -1,0 +1,5 @@
+---
+mpay: minor
+---
+
+Added error types, body digest utilities, expiration helpers, and failed receipt support. Updated default chain ID to 4217 and added memo/fee payer support to charge intent.

--- a/README.md
+++ b/README.md
@@ -58,6 +58,16 @@ async with Client(methods=[tempo(account=account, intents={"charge": ChargeInten
 | [fetch](./examples/fetch/) | CLI tool for fetching URLs with automatic payment handling |
 | [mcp-server](./examples/mcp-server/) | MCP server with payment-protected tools |
 
+## Development
+
+Always run formatting and lint checks before committing:
+
+```bash
+uv run ruff format .
+uv run ruff check .
+uv run python -m pytest tests/ -x -q
+```
+
 ## Protocol
 
 Built on the ["Payment" HTTP Authentication Scheme](https://datatracker.ietf.org/doc/draft-ietf-httpauth-payment/). See [payment-auth-spec](https://github.com/tempoxyz/payment-auth-spec) for the full specification.

--- a/examples/api-server/server.py
+++ b/examples/api-server/server.py
@@ -7,7 +7,7 @@ from fastapi.responses import JSONResponse
 
 from mpp import Challenge, Credential, Receipt
 from mpp.methods.tempo import ChargeIntent, tempo
-from mpp.methods.tempo._defaults import PATH_USD, TESTNET_RPC_URL
+from mpp.methods.tempo._defaults import PATH_USD, TESTNET_CHAIN_ID, TESTNET_RPC_URL
 from mpp.server import Mpp
 
 app = FastAPI(
@@ -41,6 +41,7 @@ async def paid_endpoint(request: Request):
     result = await server.charge(
         authorization=request.headers.get("Authorization"),
         amount="0.001",
+        chain_id=TESTNET_CHAIN_ID,
     )
 
     if isinstance(result, Challenge):
@@ -59,7 +60,7 @@ async def paid_endpoint(request: Request):
 
 
 @app.get("/paid-decorator")
-@server.pay(amount="0.001")
+@server.pay(amount="0.001", chain_id=TESTNET_CHAIN_ID)
 async def paid_decorator_endpoint(request: Request, credential: Credential, receipt: Receipt):
     """A paid endpoint using the server.pay() decorator."""
     return {

--- a/examples/mcp-server/README.md
+++ b/examples/mcp-server/README.md
@@ -123,7 +123,7 @@ The server requires this payment for `premium_echo`:
   "currency": "0x20c0000000000000000000000000000000000000",
   "recipient": "<DESTINATION_ADDRESS>",
   "expires": "<5 minutes from now>",
-  "methodDetails": {"feePayer": true}
+  "methodDetails": {"chainId": 42431, "feePayer": true}
 }
 ```
 

--- a/examples/mcp-server/server_decorator.py
+++ b/examples/mcp-server/server_decorator.py
@@ -30,7 +30,7 @@ from mpp.extensions.mcp import (
     verify_or_challenge,
 )
 from mpp.methods.tempo import ChargeIntent
-from mpp.methods.tempo._defaults import PATH_USD, TESTNET_RPC_URL
+from mpp.methods.tempo._defaults import PATH_USD, TESTNET_CHAIN_ID, TESTNET_RPC_URL
 
 RPC_URL = os.environ.get("TEMPO_RPC_URL", TESTNET_RPC_URL)
 DESTINATION = os.environ.get("DESTINATION_ADDRESS", "")
@@ -48,7 +48,7 @@ PAYMENT_REQUEST = {
     "amount": "100",
     "currency": PATH_USD,
     "recipient": DESTINATION,
-    "methodDetails": {"feePayer": True},
+    "methodDetails": {"chainId": TESTNET_CHAIN_ID, "feePayer": True},
 }
 
 

--- a/examples/mcp-server/server_manual.py
+++ b/examples/mcp-server/server_manual.py
@@ -32,7 +32,7 @@ from mpp.extensions.mcp import (
     verify_or_challenge,
 )
 from mpp.methods.tempo import ChargeIntent
-from mpp.methods.tempo._defaults import PATH_USD, TESTNET_RPC_URL
+from mpp.methods.tempo._defaults import PATH_USD, TESTNET_CHAIN_ID, TESTNET_RPC_URL
 
 RPC_URL = os.environ.get("TEMPO_RPC_URL", TESTNET_RPC_URL)
 DESTINATION = os.environ.get("DESTINATION_ADDRESS", "")
@@ -107,7 +107,7 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
             "currency": PATH_USD,
             "recipient": DESTINATION,
             "expires": expires,
-            "methodDetails": {"feePayer": True},
+            "methodDetails": {"chainId": TESTNET_CHAIN_ID, "feePayer": True},
         }
 
         result = await verify_or_challenge(

--- a/src/mpp/__init__.py
+++ b/src/mpp/__init__.py
@@ -339,7 +339,13 @@ class Receipt:
         return format_payment_receipt(self)
 
     @classmethod
-    def success(cls, reference: str, timestamp: datetime | None = None, method: str = "tempo", external_id: str | None = None) -> Receipt:
+    def success(
+        cls,
+        reference: str,
+        timestamp: datetime | None = None,
+        method: str = "tempo",
+        external_id: str | None = None,
+    ) -> Receipt:
         """Create a success receipt with current timestamp."""
         return cls(
             status="success",
@@ -350,7 +356,13 @@ class Receipt:
         )
 
     @classmethod
-    def failed(cls, reference: str, timestamp: datetime | None = None, method: str = "tempo", external_id: str | None = None) -> Receipt:
+    def failed(
+        cls,
+        reference: str,
+        timestamp: datetime | None = None,
+        method: str = "tempo",
+        external_id: str | None = None,
+    ) -> Receipt:
         """Create a failed receipt (e.g., on-chain tx reverted)."""
         return cls(
             status="failed",

--- a/src/mpp/__init__.py
+++ b/src/mpp/__init__.py
@@ -359,5 +359,6 @@ class Receipt:
             external_id=external_id,
         )
 
+
 from . import _body_digest as BodyDigest  # noqa: E402
 from . import _expires as Expires  # noqa: E402

--- a/src/mpp/__init__.py
+++ b/src/mpp/__init__.py
@@ -23,11 +23,15 @@ from mpp._parsing import (
     parse_www_authenticate,
 )
 from mpp.errors import (
+    BadRequestError,
     InvalidChallengeError,
     InvalidPayloadError,
     MalformedCredentialError,
+    PaymentActionRequiredError,
     PaymentError,
     PaymentExpiredError,
+    PaymentInsufficientError,
+    PaymentMethodUnsupportedError,
     PaymentRequiredError,
     VerificationFailedError,
 )
@@ -322,7 +326,7 @@ class Receipt:
         )
     """
 
-    status: Literal["success", "failed"]
+    status: Literal["success"]
     timestamp: datetime
     reference: str
     method: str = ""
@@ -354,24 +358,6 @@ class Receipt:
             method=method,
             external_id=external_id,
         )
-
-    @classmethod
-    def failed(
-        cls,
-        reference: str,
-        timestamp: datetime | None = None,
-        method: str = "tempo",
-        external_id: str | None = None,
-    ) -> Receipt:
-        """Create a failed receipt (e.g., on-chain tx reverted)."""
-        return cls(
-            status="failed",
-            timestamp=timestamp or datetime.now(UTC),
-            reference=reference,
-            method=method,
-            external_id=external_id,
-        )
-
 
 from . import _body_digest as BodyDigest  # noqa: E402
 from . import _expires as Expires  # noqa: E402

--- a/src/mpp/__init__.py
+++ b/src/mpp/__init__.py
@@ -62,7 +62,9 @@ def generate_challenge_id(
     verification - the server can verify a challenge was issued by it without
     storing state.
 
-    HMAC input format: realm|method|intent|request_b64|expires|digest (pipe-delimited)
+    HMAC input format: pipe-delimited non-empty segments from
+    [realm, method, intent, request_b64, expires, digest]. Empty/falsy
+    segments are filtered out before joining (matches mppx behavior).
     Output: base64url(HMAC-SHA256(secret_key, input))
 
     Args:
@@ -89,7 +91,8 @@ def generate_challenge_id(
     request_json = json.dumps(request, separators=(",", ":"), ensure_ascii=False)
     request_b64 = _b64url_encode(request_json)
 
-    hmac_input = f"{realm}|{method}|{intent}|{request_b64}|{expires or ''}|{digest or ''}"
+    segments = [realm, method, intent, request_b64, expires or "", digest or ""]
+    hmac_input = "|".join(s for s in segments if s)
 
     mac = hmac.new(
         secret_key.encode("utf-8"),
@@ -179,11 +182,15 @@ class Challenge:
             expires=expires,
             digest=digest,
         )
+        request_json = json.dumps(request, separators=(",", ":"), ensure_ascii=False)
+        request_b64 = _b64url_encode(request_json)
         return cls(
             id=challenge_id,
             method=method,
             intent=intent,
             request=request,
+            realm=realm,
+            request_b64=request_b64,
             digest=digest,
             expires=expires,
             description=description,
@@ -237,6 +244,7 @@ class Challenge:
             intent=self.intent,
             request=self.request_b64,
             expires=self.expires,
+            digest=self.digest,
         )
 
 
@@ -263,6 +271,7 @@ class ChallengeEcho:
     intent: str
     request: str
     expires: str | None = None
+    digest: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -316,6 +325,8 @@ class Receipt:
     status: Literal["success", "failed"]
     timestamp: datetime
     reference: str
+    method: str = ""
+    external_id: str | None = None
     extra: dict[str, Any] | None = None
 
     @classmethod
@@ -328,21 +339,25 @@ class Receipt:
         return format_payment_receipt(self)
 
     @classmethod
-    def success(cls, reference: str, timestamp: datetime | None = None) -> Receipt:
+    def success(cls, reference: str, timestamp: datetime | None = None, method: str = "tempo", external_id: str | None = None) -> Receipt:
         """Create a success receipt with current timestamp."""
         return cls(
             status="success",
             timestamp=timestamp or datetime.now(UTC),
             reference=reference,
+            method=method,
+            external_id=external_id,
         )
 
     @classmethod
-    def failed(cls, reference: str, timestamp: datetime | None = None) -> Receipt:
+    def failed(cls, reference: str, timestamp: datetime | None = None, method: str = "tempo", external_id: str | None = None) -> Receipt:
         """Create a failed receipt (e.g., on-chain tx reverted)."""
         return cls(
             status="failed",
             timestamp=timestamp or datetime.now(UTC),
             reference=reference,
+            method=method,
+            external_id=external_id,
         )
 
 

--- a/src/mpp/__init__.py
+++ b/src/mpp/__init__.py
@@ -22,7 +22,7 @@ from mpp._parsing import (
     parse_payment_receipt,
     parse_www_authenticate,
 )
-from mpay.errors import (
+from mpp.errors import (
     InvalidChallengeError,
     InvalidPayloadError,
     MalformedCredentialError,
@@ -346,5 +346,5 @@ class Receipt:
         )
 
 
-from mpay import _body_digest as BodyDigest  # noqa: E402
-from mpay import _expires as Expires  # noqa: E402
+from . import _body_digest as BodyDigest  # noqa: E402
+from . import _expires as Expires  # noqa: E402

--- a/src/mpp/__init__.py
+++ b/src/mpp/__init__.py
@@ -22,6 +22,15 @@ from mpp._parsing import (
     parse_payment_receipt,
     parse_www_authenticate,
 )
+from mpay.errors import (
+    InvalidChallengeError,
+    InvalidPayloadError,
+    MalformedCredentialError,
+    PaymentError,
+    PaymentExpiredError,
+    PaymentRequiredError,
+    VerificationFailedError,
+)
 
 
 def _b64url_encode(data: str) -> str:
@@ -304,7 +313,7 @@ class Receipt:
         )
     """
 
-    status: Literal["success"]
+    status: Literal["success", "failed"]
     timestamp: datetime
     reference: str
     extra: dict[str, Any] | None = None
@@ -326,3 +335,16 @@ class Receipt:
             timestamp=timestamp or datetime.now(UTC),
             reference=reference,
         )
+
+    @classmethod
+    def failed(cls, reference: str, timestamp: datetime | None = None) -> Receipt:
+        """Create a failed receipt (e.g., on-chain tx reverted)."""
+        return cls(
+            status="failed",
+            timestamp=timestamp or datetime.now(UTC),
+            reference=reference,
+        )
+
+
+from mpay import _body_digest as BodyDigest  # noqa: E402
+from mpay import _expires as Expires  # noqa: E402

--- a/src/mpp/_body_digest.py
+++ b/src/mpp/_body_digest.py
@@ -1,0 +1,41 @@
+"""Body digest computation and verification.
+
+Computes SHA-256 digests of request bodies for binding challenges to
+specific HTTP request content.
+"""
+
+import base64
+import hashlib
+import json
+from typing import Any
+
+
+def compute(body: str | bytes | dict[str, Any]) -> str:
+    """Compute a SHA-256 digest of a request body.
+
+    Args:
+        body: The request body as a string, bytes, or dict (JSON-serialized).
+
+    Returns:
+        Digest in the format ``sha-256=<base64>``.
+    """
+    if isinstance(body, dict):
+        body = json.dumps(body, separators=(",", ":"), ensure_ascii=False)
+    if isinstance(body, str):
+        body = body.encode("utf-8")
+    digest = hashlib.sha256(body).digest()
+    encoded = base64.b64encode(digest).decode("ascii")
+    return f"sha-256={encoded}"
+
+
+def verify(digest: str, body: str | bytes | dict[str, Any]) -> bool:
+    """Verify a body digest matches the expected value.
+
+    Args:
+        digest: The digest string to verify (format: ``sha-256=<base64>``).
+        body: The request body to check against.
+
+    Returns:
+        True if the digest matches, False otherwise.
+    """
+    return compute(body) == digest

--- a/src/mpp/_body_digest.py
+++ b/src/mpp/_body_digest.py
@@ -6,6 +6,7 @@ specific HTTP request content.
 
 import base64
 import hashlib
+import hmac
 import json
 from typing import Any
 
@@ -38,4 +39,4 @@ def verify(digest: str, body: str | bytes | dict[str, Any]) -> bool:
     Returns:
         True if the digest matches, False otherwise.
     """
-    return compute(body) == digest
+    return hmac.compare_digest(compute(body), digest)

--- a/src/mpp/_expires.py
+++ b/src/mpp/_expires.py
@@ -3,36 +3,41 @@
 from datetime import UTC, datetime, timedelta
 
 
+def _to_iso(dt: datetime) -> str:
+    """Format a datetime as ISO 8601 with Z suffix and millisecond precision."""
+    return dt.strftime("%Y-%m-%dT%H:%M:%S.") + f"{dt.microsecond // 1000:03d}Z"
+
+
 def seconds(n: int) -> str:
     """Returns an ISO 8601 datetime string `n` seconds from now."""
-    return (datetime.now(UTC) + timedelta(seconds=n)).isoformat()
+    return _to_iso(datetime.now(UTC) + timedelta(seconds=n))
 
 
 def minutes(n: int) -> str:
     """Returns an ISO 8601 datetime string `n` minutes from now."""
-    return (datetime.now(UTC) + timedelta(minutes=n)).isoformat()
+    return _to_iso(datetime.now(UTC) + timedelta(minutes=n))
 
 
 def hours(n: int) -> str:
     """Returns an ISO 8601 datetime string `n` hours from now."""
-    return (datetime.now(UTC) + timedelta(hours=n)).isoformat()
+    return _to_iso(datetime.now(UTC) + timedelta(hours=n))
 
 
 def days(n: int) -> str:
     """Returns an ISO 8601 datetime string `n` days from now."""
-    return (datetime.now(UTC) + timedelta(days=n)).isoformat()
+    return _to_iso(datetime.now(UTC) + timedelta(days=n))
 
 
 def weeks(n: int) -> str:
     """Returns an ISO 8601 datetime string `n` weeks from now."""
-    return (datetime.now(UTC) + timedelta(weeks=n)).isoformat()
+    return _to_iso(datetime.now(UTC) + timedelta(weeks=n))
 
 
 def months(n: int) -> str:
     """Returns an ISO 8601 datetime string `n` months (30 days) from now."""
-    return (datetime.now(UTC) + timedelta(days=n * 30)).isoformat()
+    return _to_iso(datetime.now(UTC) + timedelta(days=n * 30))
 
 
 def years(n: int) -> str:
     """Returns an ISO 8601 datetime string `n` years (365 days) from now."""
-    return (datetime.now(UTC) + timedelta(days=n * 365)).isoformat()
+    return _to_iso(datetime.now(UTC) + timedelta(days=n * 365))

--- a/src/mpp/_expires.py
+++ b/src/mpp/_expires.py
@@ -1,0 +1,38 @@
+"""Expires helpers for generating ISO 8601 datetime strings."""
+
+from datetime import UTC, datetime, timedelta
+
+
+def seconds(n: int) -> str:
+    """Returns an ISO 8601 datetime string `n` seconds from now."""
+    return (datetime.now(UTC) + timedelta(seconds=n)).isoformat()
+
+
+def minutes(n: int) -> str:
+    """Returns an ISO 8601 datetime string `n` minutes from now."""
+    return (datetime.now(UTC) + timedelta(minutes=n)).isoformat()
+
+
+def hours(n: int) -> str:
+    """Returns an ISO 8601 datetime string `n` hours from now."""
+    return (datetime.now(UTC) + timedelta(hours=n)).isoformat()
+
+
+def days(n: int) -> str:
+    """Returns an ISO 8601 datetime string `n` days from now."""
+    return (datetime.now(UTC) + timedelta(days=n)).isoformat()
+
+
+def weeks(n: int) -> str:
+    """Returns an ISO 8601 datetime string `n` weeks from now."""
+    return (datetime.now(UTC) + timedelta(weeks=n)).isoformat()
+
+
+def months(n: int) -> str:
+    """Returns an ISO 8601 datetime string `n` months (30 days) from now."""
+    return (datetime.now(UTC) + timedelta(days=n * 30)).isoformat()
+
+
+def years(n: int) -> str:
+    """Returns an ISO 8601 datetime string `n` years (365 days) from now."""
+    return (datetime.now(UTC) + timedelta(days=n * 365)).isoformat()

--- a/src/mpp/_parsing.py
+++ b/src/mpp/_parsing.py
@@ -284,7 +284,7 @@ def parse_payment_receipt(header: str) -> Receipt:
         raise ParseError(f"Receipt missing required fields: {missing}")
 
     status = data["status"]
-    if status not in ("success", "failed"):
+    if status != "success":
         raise ParseError("Invalid receipt status")
 
     timestamp = _parse_timestamp(str(data["timestamp"]))

--- a/src/mpp/_parsing.py
+++ b/src/mpp/_parsing.py
@@ -281,7 +281,7 @@ def parse_payment_receipt(header: str) -> Receipt:
         raise ParseError(f"Receipt missing required fields: {missing}")
 
     status = data["status"]
-    if status != "success":
+    if status not in ("success", "failed"):
         raise ParseError("Invalid receipt status")
 
     timestamp = _parse_timestamp(str(data["timestamp"]))

--- a/src/mpp/_parsing.py
+++ b/src/mpp/_parsing.py
@@ -210,6 +210,7 @@ def parse_authorization(header: str) -> Credential:
         intent=str(challenge_data.get("intent", "")),
         request=str(challenge_data.get("request", "")),
         expires=str(challenge_data["expires"]) if challenge_data.get("expires") else None,
+        digest=str(challenge_data["digest"]) if challenge_data.get("digest") else None,
     )
 
     return Credential(
@@ -239,6 +240,8 @@ def format_authorization(credential: Credential) -> str:
     }
     if credential.challenge.expires:
         challenge_dict["expires"] = credential.challenge.expires
+    if credential.challenge.digest:
+        challenge_dict["digest"] = credential.challenge.digest
 
     payload: dict[str, Any] = {
         "challenge": challenge_dict,
@@ -292,6 +295,8 @@ def parse_payment_receipt(header: str) -> Receipt:
         status=status,
         timestamp=timestamp,
         reference=str(data["reference"]),
+        method=str(data.get("method", "")),
+        external_id=str(data["externalId"]) if data.get("externalId") else None,
         extra=extra if isinstance(extra, dict) else None,
     )
 
@@ -309,6 +314,10 @@ def format_payment_receipt(receipt: Receipt) -> str:
         "timestamp": timestamp_str,
         "reference": receipt.reference,
     }
+    if receipt.method:
+        payload["method"] = receipt.method
+    if receipt.external_id:
+        payload["externalId"] = receipt.external_id
     if receipt.extra:
         payload["extra"] = receipt.extra
     return _b64_encode(payload)

--- a/src/mpp/client/__init__.py
+++ b/src/mpp/client/__init__.py
@@ -16,4 +16,5 @@ Example:
         r2 = await client.get("https://api.example.com/b")
 """
 
+from mpp import _expires as Expires
 from mpp.client.transport import Client, PaymentTransport, get, post, request

--- a/src/mpp/errors.py
+++ b/src/mpp/errors.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from typing import Any
 
-_BASE_URI = "https://tempoxyz.github.io/payment-auth-spec/problems"
+_BASE_URI = "https://paymentauth.org/problems"
 
 
 class PaymentError(Exception):

--- a/src/mpp/errors.py
+++ b/src/mpp/errors.py
@@ -1,0 +1,101 @@
+"""Payment error types with RFC 9457 Problem Details support.
+
+All payment errors can be converted to RFC 9457 Problem Details format
+for structured error responses.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+_BASE_URI = "https://tempoxyz.github.io/payment-auth-spec/problems"
+
+
+class PaymentError(Exception):
+    """Base class for all payment-related errors."""
+
+    type: str = f"{_BASE_URI}/payment-error"
+    status: int = 402
+
+    def to_problem_details(self, challenge_id: str | None = None) -> dict[str, Any]:
+        """Convert to RFC 9457 Problem Details format."""
+        details: dict[str, Any] = {
+            "type": self.type,
+            "title": type(self).__name__,
+            "status": self.status,
+            "detail": str(self),
+        }
+        if challenge_id:
+            details["challengeId"] = challenge_id
+        return details
+
+
+class PaymentRequiredError(PaymentError):
+    """No credential was provided but payment is required."""
+
+    type = f"{_BASE_URI}/payment-required"
+
+    def __init__(self, realm: str | None = None, description: str | None = None) -> None:
+        parts = ["Payment is required"]
+        if realm:
+            parts.append(f'for "{realm}"')
+        if description:
+            parts.append(f"({description})")
+        super().__init__(f"{' '.join(parts)}.")
+
+
+class MalformedCredentialError(PaymentError):
+    """Credential is malformed (invalid base64url, bad JSON structure)."""
+
+    type = f"{_BASE_URI}/malformed-credential"
+
+    def __init__(self, reason: str | None = None) -> None:
+        msg = f"Credential is malformed: {reason}." if reason else "Credential is malformed."
+        super().__init__(msg)
+
+
+class InvalidChallengeError(PaymentError):
+    """Challenge ID is unknown, expired, or already used."""
+
+    type = f"{_BASE_URI}/invalid-challenge"
+
+    def __init__(self, id: str | None = None, reason: str | None = None) -> None:
+        id_part = f' "{id}"' if id else ""
+        reason_part = f": {reason}" if reason else ""
+        super().__init__(f"Challenge{id_part} is invalid{reason_part}.")
+
+
+class VerificationFailedError(PaymentError):
+    """Payment proof is invalid or verification failed."""
+
+    type = f"{_BASE_URI}/verification-failed"
+
+    def __init__(self, reason: str | None = None) -> None:
+        msg = (
+            f"Payment verification failed: {reason}." if reason else "Payment verification failed."
+        )
+        super().__init__(msg)
+
+
+class PaymentExpiredError(PaymentError):
+    """Payment has expired."""
+
+    type = f"{_BASE_URI}/payment-expired"
+
+    def __init__(self, expires: str | None = None) -> None:
+        msg = f"Payment expired at {expires}." if expires else "Payment has expired."
+        super().__init__(msg)
+
+
+class InvalidPayloadError(PaymentError):
+    """Credential payload does not match the expected schema."""
+
+    type = f"{_BASE_URI}/invalid-payload"
+
+    def __init__(self, reason: str | None = None) -> None:
+        msg = (
+            f"Credential payload is invalid: {reason}."
+            if reason
+            else "Credential payload is invalid."
+        )
+        super().__init__(msg)

--- a/src/mpp/errors.py
+++ b/src/mpp/errors.py
@@ -125,9 +125,7 @@ class PaymentInsufficientError(PaymentError):
     """Payment amount is insufficient (too low)."""
 
     def __init__(self, reason: str | None = None) -> None:
-        msg = (
-            f"Payment insufficient: {reason}." if reason else "Payment amount is insufficient."
-        )
+        msg = f"Payment insufficient: {reason}." if reason else "Payment amount is insufficient."
         super().__init__(msg)
 
 
@@ -151,7 +149,5 @@ class PaymentActionRequiredError(PaymentError):
     """Payment requires additional action (e.g., 3DS authentication)."""
 
     def __init__(self, reason: str | None = None) -> None:
-        msg = (
-            f"Payment requires action: {reason}." if reason else "Payment requires action."
-        )
+        msg = f"Payment requires action: {reason}." if reason else "Payment requires action."
         super().__init__(msg)

--- a/src/mpp/errors.py
+++ b/src/mpp/errors.py
@@ -58,6 +58,8 @@ class PaymentRequiredError(PaymentError):
 class MalformedCredentialError(PaymentError):
     """Credential is malformed (invalid base64url, bad JSON structure)."""
 
+    status = 400
+
     def __init__(self, reason: str | None = None) -> None:
         msg = f"Credential is malformed: {reason}." if reason else "Credential is malformed."
         super().__init__(msg)
@@ -65,6 +67,8 @@ class MalformedCredentialError(PaymentError):
 
 class InvalidChallengeError(PaymentError):
     """Challenge ID is unknown, expired, or already used."""
+
+    status = 400
 
     def __init__(self, challenge_id: str | None = None, reason: str | None = None) -> None:
         id_part = f' "{challenge_id}"' if challenge_id else ""

--- a/src/mpp/errors.py
+++ b/src/mpp/errors.py
@@ -18,15 +18,24 @@ def _to_slug(name: str) -> str:
     return re.sub(r"(?<=[a-z0-9])(?=[A-Z])", "-", name).lower()
 
 
+def _to_title(name: str) -> str:
+    """CamelCaseError → human-readable title (e.g. InvalidPayloadError → Invalid Payload)."""
+    name = name.removesuffix("Error")
+    return re.sub(r"(?<=[a-z0-9])(?=[A-Z])", " ", name)
+
+
 class PaymentError(Exception):
     """Base class for all payment-related errors."""
 
     status: int = 402
+    title: str = "Payment Error"
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)
         if "type" not in cls.__dict__:
             cls.type = f"{_BASE_URI}/{_to_slug(cls.__name__)}"
+        if "title" not in cls.__dict__:
+            cls.title = _to_title(cls.__name__)
 
     type: str = f"{_BASE_URI}/payment-error"
 
@@ -34,7 +43,7 @@ class PaymentError(Exception):
         """Convert to RFC 9457 Problem Details format."""
         details: dict[str, Any] = {
             "type": self.type,
-            "title": type(self).__name__,
+            "title": self.title,
             "status": self.status,
             "detail": str(self),
         }
@@ -58,8 +67,6 @@ class PaymentRequiredError(PaymentError):
 class MalformedCredentialError(PaymentError):
     """Credential is malformed (invalid base64url, bad JSON structure)."""
 
-    status = 400
-
     def __init__(self, reason: str | None = None) -> None:
         msg = f"Credential is malformed: {reason}." if reason else "Credential is malformed."
         super().__init__(msg)
@@ -67,8 +74,6 @@ class MalformedCredentialError(PaymentError):
 
 class InvalidChallengeError(PaymentError):
     """Challenge ID is unknown, expired, or already used."""
-
-    status = 400
 
     def __init__(self, challenge_id: str | None = None, reason: str | None = None) -> None:
         id_part = f' "{challenge_id}"' if challenge_id else ""
@@ -102,5 +107,51 @@ class InvalidPayloadError(PaymentError):
             f"Credential payload is invalid: {reason}."
             if reason
             else "Credential payload is invalid."
+        )
+        super().__init__(msg)
+
+
+class BadRequestError(PaymentError):
+    """Request is malformed or contains invalid parameters."""
+
+    status = 400
+
+    def __init__(self, reason: str | None = None) -> None:
+        msg = f"Bad request: {reason}." if reason else "Bad request."
+        super().__init__(msg)
+
+
+class PaymentInsufficientError(PaymentError):
+    """Payment amount is insufficient (too low)."""
+
+    def __init__(self, reason: str | None = None) -> None:
+        msg = (
+            f"Payment insufficient: {reason}." if reason else "Payment amount is insufficient."
+        )
+        super().__init__(msg)
+
+
+class PaymentMethodUnsupportedError(PaymentError):
+    """Payment method is not supported by the server."""
+
+    status = 400
+    type = f"{_BASE_URI}/method-unsupported"
+    title = "Method Unsupported"
+
+    def __init__(self, method: str | None = None) -> None:
+        msg = (
+            f'Payment method "{method}" is not supported.'
+            if method
+            else "Payment method is not supported."
+        )
+        super().__init__(msg)
+
+
+class PaymentActionRequiredError(PaymentError):
+    """Payment requires additional action (e.g., 3DS authentication)."""
+
+    def __init__(self, reason: str | None = None) -> None:
+        msg = (
+            f"Payment requires action: {reason}." if reason else "Payment requires action."
         )
         super().__init__(msg)

--- a/src/mpp/errors.py
+++ b/src/mpp/errors.py
@@ -6,16 +6,29 @@ for structured error responses.
 
 from __future__ import annotations
 
+import re
 from typing import Any
 
 _BASE_URI = "https://paymentauth.org/problems"
 
 
+def _to_slug(name: str) -> str:
+    """CamelCaseError → kebab-case slug (e.g. InvalidPayloadError → invalid-payload)."""
+    name = name.removesuffix("Error")
+    return re.sub(r"(?<=[a-z0-9])(?=[A-Z])", "-", name).lower()
+
+
 class PaymentError(Exception):
     """Base class for all payment-related errors."""
 
-    type: str = f"{_BASE_URI}/payment-error"
     status: int = 402
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)
+        if "type" not in cls.__dict__:
+            cls.type = f"{_BASE_URI}/{_to_slug(cls.__name__)}"
+
+    type: str = f"{_BASE_URI}/payment-error"
 
     def to_problem_details(self, challenge_id: str | None = None) -> dict[str, Any]:
         """Convert to RFC 9457 Problem Details format."""
@@ -33,8 +46,6 @@ class PaymentError(Exception):
 class PaymentRequiredError(PaymentError):
     """No credential was provided but payment is required."""
 
-    type = f"{_BASE_URI}/payment-required"
-
     def __init__(self, realm: str | None = None, description: str | None = None) -> None:
         parts = ["Payment is required"]
         if realm:
@@ -47,8 +58,6 @@ class PaymentRequiredError(PaymentError):
 class MalformedCredentialError(PaymentError):
     """Credential is malformed (invalid base64url, bad JSON structure)."""
 
-    type = f"{_BASE_URI}/malformed-credential"
-
     def __init__(self, reason: str | None = None) -> None:
         msg = f"Credential is malformed: {reason}." if reason else "Credential is malformed."
         super().__init__(msg)
@@ -56,8 +65,6 @@ class MalformedCredentialError(PaymentError):
 
 class InvalidChallengeError(PaymentError):
     """Challenge ID is unknown, expired, or already used."""
-
-    type = f"{_BASE_URI}/invalid-challenge"
 
     def __init__(self, id: str | None = None, reason: str | None = None) -> None:
         id_part = f' "{id}"' if id else ""
@@ -67,8 +74,6 @@ class InvalidChallengeError(PaymentError):
 
 class VerificationFailedError(PaymentError):
     """Payment proof is invalid or verification failed."""
-
-    type = f"{_BASE_URI}/verification-failed"
 
     def __init__(self, reason: str | None = None) -> None:
         msg = (
@@ -80,8 +85,6 @@ class VerificationFailedError(PaymentError):
 class PaymentExpiredError(PaymentError):
     """Payment has expired."""
 
-    type = f"{_BASE_URI}/payment-expired"
-
     def __init__(self, expires: str | None = None) -> None:
         msg = f"Payment expired at {expires}." if expires else "Payment has expired."
         super().__init__(msg)
@@ -89,8 +92,6 @@ class PaymentExpiredError(PaymentError):
 
 class InvalidPayloadError(PaymentError):
     """Credential payload does not match the expected schema."""
-
-    type = f"{_BASE_URI}/invalid-payload"
 
     def __init__(self, reason: str | None = None) -> None:
         msg = (

--- a/src/mpp/errors.py
+++ b/src/mpp/errors.py
@@ -38,7 +38,7 @@ class PaymentError(Exception):
             "status": self.status,
             "detail": str(self),
         }
-        if challenge_id:
+        if challenge_id is not None:
             details["challengeId"] = challenge_id
         return details
 
@@ -66,8 +66,8 @@ class MalformedCredentialError(PaymentError):
 class InvalidChallengeError(PaymentError):
     """Challenge ID is unknown, expired, or already used."""
 
-    def __init__(self, id: str | None = None, reason: str | None = None) -> None:
-        id_part = f' "{id}"' if id else ""
+    def __init__(self, challenge_id: str | None = None, reason: str | None = None) -> None:
+        id_part = f' "{challenge_id}"' if challenge_id else ""
         reason_part = f": {reason}" if reason else ""
         super().__init__(f"Challenge{id_part} is invalid{reason_part}.")
 

--- a/src/mpp/methods/tempo/schemas.py
+++ b/src/mpp/methods/tempo/schemas.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel, Field
 class MethodDetails(BaseModel):
     """Method-specific details for Tempo charge requests."""
 
-    chainId: int = 42431
+    chainId: int = 4217
     feePayer: bool = False
     feePayerUrl: str | None = None
     memo: str | None = None

--- a/src/mpp/server/__init__.py
+++ b/src/mpp/server/__init__.py
@@ -17,6 +17,16 @@ Example:
         return Response({"data": "..."}, headers={"Payment-Receipt": ...})
 """
 
+from mpp import _expires as Expires
+from mpp.errors import (
+    InvalidChallengeError,
+    InvalidPayloadError,
+    MalformedCredentialError,
+    PaymentError,
+    PaymentExpiredError,
+    PaymentRequiredError,
+    VerificationFailedError,
+)
 from mpp.server.decorator import pay
 from mpp.server.intent import Intent, VerificationError, intent
 from mpp.server.method import Method, transform_request

--- a/src/mpp/server/__init__.py
+++ b/src/mpp/server/__init__.py
@@ -19,11 +19,15 @@ Example:
 
 from mpp import _expires as Expires
 from mpp.errors import (
+    BadRequestError,
     InvalidChallengeError,
     InvalidPayloadError,
     MalformedCredentialError,
+    PaymentActionRequiredError,
     PaymentError,
     PaymentExpiredError,
+    PaymentInsufficientError,
+    PaymentMethodUnsupportedError,
     PaymentRequiredError,
     VerificationFailedError,
 )

--- a/src/mpp/server/decorator.py
+++ b/src/mpp/server/decorator.py
@@ -3,11 +3,10 @@
 from __future__ import annotations
 
 import inspect
+import json as _json
 from collections.abc import Awaitable, Callable
 from functools import wraps
 from typing import TYPE_CHECKING, Any
-
-import json as _json
 
 from mpp import Challenge, Credential, Receipt
 from mpp.errors import PaymentRequiredError

--- a/src/mpp/server/decorator.py
+++ b/src/mpp/server/decorator.py
@@ -7,7 +7,10 @@ from collections.abc import Awaitable, Callable
 from functools import wraps
 from typing import TYPE_CHECKING, Any
 
+import json as _json
+
 from mpp import Challenge, Credential, Receipt
+from mpp.errors import PaymentRequiredError
 from mpp.server._defaults import detect_realm, detect_secret_key
 from mpp.server.verify import verify_or_challenge
 
@@ -15,7 +18,6 @@ if TYPE_CHECKING:
     from mpp.server.intent import Intent
 
 RequestParamsType = dict[str, Any] | Callable[[Any], dict[str, Any]]
-
 
 def get_authorization(request: Any) -> str | None:
     """Extract Authorization header from various request types.
@@ -29,34 +31,35 @@ def get_authorization(request: Any) -> str | None:
         return request.META.get("HTTP_AUTHORIZATION")
     return None
 
-
 def make_challenge_response(challenge: Challenge, realm: str) -> Any:
-    """Build a 402 response for a payment challenge.
+    """Build a 402 response for a payment challenge with RFC 9457 problem details body.
 
     Returns a Starlette ``Response`` when starlette is installed,
     otherwise a plain dict with ``_mpp_challenge``, ``status``, and ``headers``.
     """
+    error = PaymentRequiredError(realm=realm, description=challenge.description)
+    body = _json.dumps(error.to_problem_details(challenge.id))
+    headers = {
+        "WWW-Authenticate": challenge.to_www_authenticate(realm),
+        "Cache-Control": "no-store",
+        "Content-Type": "application/problem+json",
+    }
     try:
         from starlette.responses import Response
 
         return Response(
-            content=None,
+            content=body,
             status_code=402,
-            headers={
-                "WWW-Authenticate": challenge.to_www_authenticate(realm),
-                "Cache-Control": "no-store",
-            },
+            headers=headers,
+            media_type="application/problem+json",
         )
     except ImportError:
         return {
             "_mpp_challenge": True,
             "status": 402,
-            "headers": {
-                "WWW-Authenticate": challenge.to_www_authenticate(realm),
-                "Cache-Control": "no-store",
-            },
+            "headers": headers,
+            "body": body,
         }
-
 
 def wrap_payment_handler[R](
     handler: Callable[..., Awaitable[R]],
@@ -111,7 +114,6 @@ def wrap_payment_handler[R](
     del wrapper.__wrapped__
 
     return wrapper
-
 
 def pay[R](
     *,

--- a/src/mpp/server/decorator.py
+++ b/src/mpp/server/decorator.py
@@ -42,13 +42,19 @@ def make_challenge_response(challenge: Challenge, realm: str) -> Any:
         return Response(
             content=None,
             status_code=402,
-            headers={"WWW-Authenticate": challenge.to_www_authenticate(realm)},
+            headers={
+                "WWW-Authenticate": challenge.to_www_authenticate(realm),
+                "Cache-Control": "no-store",
+            },
         )
     except ImportError:
         return {
             "_mpp_challenge": True,
             "status": 402,
-            "headers": {"WWW-Authenticate": challenge.to_www_authenticate(realm)},
+            "headers": {
+                "WWW-Authenticate": challenge.to_www_authenticate(realm),
+                "Cache-Control": "no-store",
+            },
         }
 
 

--- a/src/mpp/server/decorator.py
+++ b/src/mpp/server/decorator.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
 
 RequestParamsType = dict[str, Any] | Callable[[Any], dict[str, Any]]
 
+
 def get_authorization(request: Any) -> str | None:
     """Extract Authorization header from various request types.
 
@@ -29,6 +30,7 @@ def get_authorization(request: Any) -> str | None:
     if hasattr(request, "META"):
         return request.META.get("HTTP_AUTHORIZATION")
     return None
+
 
 def make_challenge_response(challenge: Challenge, realm: str) -> Any:
     """Build a 402 response for a payment challenge with RFC 9457 problem details body.
@@ -59,6 +61,7 @@ def make_challenge_response(challenge: Challenge, realm: str) -> Any:
             "headers": headers,
             "body": body,
         }
+
 
 def wrap_payment_handler[R](
     handler: Callable[..., Awaitable[R]],
@@ -113,6 +116,7 @@ def wrap_payment_handler[R](
     del wrapper.__wrapped__
 
     return wrapper
+
 
 def pay[R](
     *,

--- a/src/mpp/server/mpp.py
+++ b/src/mpp/server/mpp.py
@@ -104,6 +104,7 @@ class Mpp:
         description: str | None = None,
         memo: str | None = None,
         fee_payer: bool = False,
+        chain_id: int | None = None,
     ) -> Challenge | tuple[Credential, Receipt]:
         """Handle a charge intent.
 
@@ -117,6 +118,7 @@ class Mpp:
             description: Optional human-readable description.
             memo: Optional 32-byte memo (hex string) for transferWithMemo.
             fee_payer: Whether to use a fee payer for gas sponsorship.
+            chain_id: Override the default chain ID (e.g., 42431 for moderato).
 
         Returns:
             Challenge if payment required, or (Credential, Receipt) if verified.
@@ -145,8 +147,10 @@ class Mpp:
             "expires": expires,
         }
 
-        if memo or fee_payer:
+        if memo or fee_payer or chain_id is not None:
             method_details: dict[str, Any] = {}
+            if chain_id is not None:
+                method_details["chainId"] = chain_id
             if memo:
                 method_details["memo"] = memo
             if fee_payer:
@@ -172,6 +176,7 @@ class Mpp:
         recipient: str | None = None,
         description: str | None = None,
         expires_in: timedelta | None = None,
+        chain_id: int | None = None,
     ) -> Callable[  # noqa: UP047
         [Callable[[Any, Credential, Receipt], Awaitable[R]]],
         Callable[[Any], Awaitable[R | Any]],
@@ -191,6 +196,7 @@ class Mpp:
             recipient: Override the method's default recipient.
             description: Optional human-readable description.
             expires_in: Challenge validity duration. Defaults to 5 minutes.
+            chain_id: Override the default chain ID (e.g., 42431 for moderato).
 
         Example:
             server = Mpp.create(method=tempo(currency=..., recipient=...))
@@ -236,6 +242,8 @@ class Mpp:
                 }
                 if expires is not None:
                     request["expires"] = expires
+                if chain_id is not None:
+                    request["methodDetails"] = {"chainId": chain_id}
 
                 return await verify_or_challenge(
                     authorization=authorization,

--- a/src/mpp/server/mpp.py
+++ b/src/mpp/server/mpp.py
@@ -102,6 +102,8 @@ class Mpp:
         recipient: str | None = None,
         expires: str | None = None,
         description: str | None = None,
+        memo: str | None = None,
+        fee_payer: bool = False,
     ) -> Challenge | tuple[Credential, Receipt]:
         """Handle a charge intent.
 
@@ -113,6 +115,8 @@ class Mpp:
             recipient: Override the method's default recipient.
             expires: Challenge expiration (ISO 8601). Defaults to now + 5 minutes.
             description: Optional human-readable description.
+            memo: Optional 32-byte memo (hex string) for transferWithMemo.
+            fee_payer: Whether to use a fee payer for gas sponsorship.
 
         Returns:
             Challenge if payment required, or (Credential, Receipt) if verified.
@@ -140,6 +144,14 @@ class Mpp:
             "recipient": resolved_recipient,
             "expires": expires,
         }
+
+        if memo or fee_payer:
+            method_details: dict[str, Any] = {}
+            if memo:
+                method_details["memo"] = memo
+            if fee_payer:
+                method_details["feePayer"] = True
+            request["methodDetails"] = method_details
 
         return await verify_or_challenge(
             authorization=authorization,

--- a/src/mpp/server/verify.py
+++ b/src/mpp/server/verify.py
@@ -107,15 +107,6 @@ async def verify_or_challenge(
 
     receipt: Receipt = await intent.verify(credential, request)
 
-    # Per spec, synchronous flows MUST NOT return 200 with a failed receipt.
-    # If payment failed (e.g., tx reverted on-chain), return 402 with fresh expires.
-    if receipt.status == "failed":
-        fresh_request = {k: v for k, v in request.items() if k != "expires"}
-        fail_desc = f"Payment failed (ref={receipt.reference})"
-        return _create_challenge(
-            method_name, intent.name, fresh_request, realm, secret_key, fail_desc
-        )
-
     return (credential, receipt)
 
 

--- a/src/mpp/server/verify.py
+++ b/src/mpp/server/verify.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
-from mpp import Challenge, Credential, Receipt
-from mpp._parsing import ParseError
+from mpp import Challenge, Credential, Receipt, generate_challenge_id, _constant_time_equal
+from mpp._parsing import ParseError, _b64_decode
 from mpp._units import transform_units
+from mpp.errors import InvalidChallengeError, MalformedCredentialError, PaymentRequiredError
 
 DEFAULT_EXPIRES_MINUTES = 5
 
@@ -80,12 +81,29 @@ async def verify_or_challenge(
     if authorization is None:
         return _create_challenge(method_name, intent.name, request, realm, secret_key, description)
 
-    if not authorization.lower().startswith("payment "):
+    payment_scheme = _extract_payment_scheme(authorization)
+    if payment_scheme is None:
         return _create_challenge(method_name, intent.name, request, realm, secret_key, description)
 
     try:
-        credential = Credential.from_authorization(authorization)
+        credential = Credential.from_authorization(payment_scheme)
     except ParseError:
+        return _create_challenge(method_name, intent.name, request, realm, secret_key, description)
+
+    # Stateless challenge verification: recompute expected challenge ID from
+    # echoed parameters and compare to the credential's challenge ID.
+    echo = credential.challenge
+    echo_request = _b64_decode(echo.request) if echo.request else {}
+    expected_id = generate_challenge_id(
+        secret_key=secret_key,
+        realm=echo.realm,
+        method=echo.method,
+        intent=echo.intent,
+        request=echo_request,
+        expires=echo.expires,
+        digest=echo.digest,
+    )
+    if not _constant_time_equal(echo.id, expected_id):
         return _create_challenge(method_name, intent.name, request, realm, secret_key, description)
 
     receipt: Receipt = await intent.verify(credential, request)
@@ -123,3 +141,16 @@ def _create_challenge(
         request=request,
         description=description,
     )
+
+
+def _extract_payment_scheme(header: str) -> str | None:
+    """Extract the Payment scheme from an Authorization header.
+
+    Supports comma-separated multiple schemes per RFC 9110.
+    Returns the full ``Payment ...`` string, or None if not found.
+    """
+    for scheme in header.split(","):
+        scheme = scheme.strip()
+        if scheme.lower().startswith("payment "):
+            return scheme
+    return None

--- a/src/mpp/server/verify.py
+++ b/src/mpp/server/verify.py
@@ -90,6 +90,11 @@ async def verify_or_challenge(
 
     receipt: Receipt = await intent.verify(credential, request)
 
+    # Per spec, synchronous flows MUST NOT return 200 with a failed receipt.
+    # If payment failed (e.g., tx reverted on-chain), return 402.
+    if receipt.status == "failed":
+        return _create_challenge(method_name, intent.name, request, realm, secret_key, description)
+
     return (credential, receipt)
 
 

--- a/src/mpp/server/verify.py
+++ b/src/mpp/server/verify.py
@@ -5,10 +5,9 @@ from __future__ import annotations
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
-from mpp import Challenge, Credential, Receipt, generate_challenge_id, _constant_time_equal
+from mpp import Challenge, Credential, Receipt, _constant_time_equal, generate_challenge_id
 from mpp._parsing import ParseError, _b64_decode
 from mpp._units import transform_units
-from mpp.errors import InvalidChallengeError, MalformedCredentialError, PaymentRequiredError
 
 DEFAULT_EXPIRES_MINUTES = 5
 

--- a/src/mpp/server/verify.py
+++ b/src/mpp/server/verify.py
@@ -91,9 +91,13 @@ async def verify_or_challenge(
     receipt: Receipt = await intent.verify(credential, request)
 
     # Per spec, synchronous flows MUST NOT return 200 with a failed receipt.
-    # If payment failed (e.g., tx reverted on-chain), return 402.
+    # If payment failed (e.g., tx reverted on-chain), return 402 with fresh expires.
     if receipt.status == "failed":
-        return _create_challenge(method_name, intent.name, request, realm, secret_key, description)
+        fresh_request = {k: v for k, v in request.items() if k != "expires"}
+        fail_desc = f"Payment failed (ref={receipt.reference})"
+        return _create_challenge(
+            method_name, intent.name, fresh_request, realm, secret_key, fail_desc
+        )
 
     return (credential, receipt)
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,13 +2,17 @@
 
 from typing import Any
 
-from mpp import ChallengeEcho, Credential
+from mpp import Challenge, ChallengeEcho, Credential, _b64url_encode
+
+# Default secret used by tests when calling verify_or_challenge
+TEST_SECRET = "test-secret"
+TEST_REALM = "test.example.com"
 
 
 def make_credential(
     payload: dict[str, Any],
     challenge_id: str = "test",
-    realm: str = "test.example.com",
+    realm: str = TEST_REALM,
     method: str = "tempo",
     intent: str = "charge",
     request: str = "e30",
@@ -24,4 +28,35 @@ def make_credential(
         request=request,
         expires=expires,
     )
+    return Credential(challenge=echo, payload=payload, source=source)
+
+
+def make_bound_credential(
+    payload: dict[str, Any],
+    request: dict[str, Any],
+    secret_key: str = TEST_SECRET,
+    realm: str = TEST_REALM,
+    method: str = "tempo",
+    intent: str = "charge",
+    source: str | None = None,
+    expires: str | None = None,
+    digest: str | None = None,
+) -> Credential:
+    """Create a Credential with an HMAC-bound challenge ID for testing.
+
+    This produces credentials that will pass stateless challenge verification
+    in verify_or_challenge().
+    """
+    import json
+
+    challenge = Challenge.create(
+        secret_key=secret_key,
+        realm=realm,
+        method=method,
+        intent=intent,
+        request=request,
+        expires=expires,
+        digest=digest,
+    )
+    echo = challenge.to_echo()
     return Credential(challenge=echo, payload=payload, source=source)

--- a/tests/test_challenge_id.py
+++ b/tests/test_challenge_id.py
@@ -23,7 +23,7 @@ class TestGenerateChallengeId:
                 "recipient": "0x1234567890abcdef1234567890abcdef12345678",
             },
         )
-        assert result == "s0gsoewXwdYI13oPnrtdKTEN4-sIQ-LbQUNV_HttPnA"
+        assert result == "2zBPShTPApayQwXeT8WydrfbsHFLWIC8cosfBzK3UUs"
 
     def test_with_expires(self) -> None:
         """Challenge ID with expires field included in HMAC."""
@@ -39,7 +39,7 @@ class TestGenerateChallengeId:
             },
             expires="2026-01-29T12:00:00Z",
         )
-        assert result == "0rMv3trZIudpkJCQxeL2RLQz6uALKTNErWulN07hDLk"
+        assert result == "HQEKiVUplCDQ6AIff8eN55Q3BpRmg2RqU0DOl3R8QIA"
 
     def test_with_digest(self) -> None:
         """Challenge ID with digest field included in HMAC."""
@@ -55,7 +55,7 @@ class TestGenerateChallengeId:
             },
             digest="sha-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=",
         )
-        assert result == "EAX2sqwdeg8Km8LIKRBFhM5xDQvEgIlbTif9FKBsOiU"
+        assert result == "WglnB-3knPMLPOVEdA8P81UXpy8oFVfBx31ntDh-VPk"
 
     def test_full_challenge(self) -> None:
         """Challenge ID with all optional fields."""
@@ -89,7 +89,7 @@ class TestGenerateChallengeId:
                 "recipient": "0x1234567890abcdef1234567890abcdef12345678",
             },
         )
-        assert result == "UMEn_1WPt2vz3XK8rrkbHET6RwqfwtK8VVNz0Xc2x4A"
+        assert result == "mi0krYRZpfDxn0DFDHeXOIYdU_SEcJQfURKGTN26Ehg"
 
     def test_empty_request(self) -> None:
         """Challenge ID with empty request object."""
@@ -100,7 +100,7 @@ class TestGenerateChallengeId:
             intent="authorize",
             request={},
         )
-        assert result == "jUTqTVe3kCv5rVizv1XBCs9qKCLg4AZLwBUnk4N3MR8"
+        assert result == "yXILRwEbyiy4F2pCUoxcKbvYHy4ZyXtLxnzMZTi3qDs"
 
     def test_unicode_in_description(self) -> None:
         """Request with unicode characters."""
@@ -116,7 +116,7 @@ class TestGenerateChallengeId:
                 "description": "Payment for café ☕",
             },
         )
-        assert result == "76lyru2p7i7Xw6fGTJtWzd9c7Z6mt33LIW7968Mlkz8"
+        assert result == "stLlKuOMkHscBIqCE78v48-CY-I0JIQkm1rjotcb-rQ"
 
     def test_nested_method_details(self) -> None:
         """Request with nested methodDetails object."""
@@ -132,7 +132,7 @@ class TestGenerateChallengeId:
                 "methodDetails": {"chainId": 42431, "feePayer": True},
             },
         )
-        assert result == "xPIM2fN55BNq6ADKIFvGCR5zB7DhH6YbwDtAqtExwI0"
+        assert result == "AbaOnesHVxXeDbG9eStLZOlBwTI87_8g7skZwL9tOvA"
 
 
 class TestChallengeCreate:
@@ -151,7 +151,7 @@ class TestChallengeCreate:
                 "recipient": "0x1234567890abcdef1234567890abcdef12345678",
             },
         )
-        assert challenge.id == "s0gsoewXwdYI13oPnrtdKTEN4-sIQ-LbQUNV_HttPnA"
+        assert challenge.id == "2zBPShTPApayQwXeT8WydrfbsHFLWIC8cosfBzK3UUs"
         assert challenge.method == "tempo"
         assert challenge.intent == "charge"
 
@@ -170,7 +170,7 @@ class TestChallengeCreate:
             expires="2026-01-29T12:00:00Z",
             description="Test payment",
         )
-        assert challenge.id == "0rMv3trZIudpkJCQxeL2RLQz6uALKTNErWulN07hDLk"
+        assert challenge.id == "HQEKiVUplCDQ6AIff8eN55Q3BpRmg2RqU0DOl3R8QIA"
         assert challenge.expires == "2026-01-29T12:00:00Z"
         assert challenge.description == "Test payment"
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -5,7 +5,7 @@ import pytest
 from mpp import Challenge, Credential, Receipt
 from mpp.server import Mpp, intent, pay, verify_or_challenge
 from mpp.server.intent import VerificationError
-from tests import make_credential
+from tests import make_bound_credential, make_credential
 
 try:
     from starlette.responses import Response as StarletteResponse
@@ -63,11 +63,15 @@ class TestVerifyOrChallenge:
 
         @intent(name="charge")
         async def test_intent(credential: Credential, request: dict) -> Receipt:
-            assert credential.challenge.id == "test-id"
             assert credential.payload == {"hash": "0xabc"}
             return Receipt.success("0x123")
 
-        credential = make_credential(payload={"hash": "0xabc"}, challenge_id="test-id")
+        credential = make_bound_credential(
+            payload={"hash": "0xabc"},
+            request={"amount": "1000"},
+            realm="api.example.com",
+            secret_key="test-secret",
+        )
         auth_header = credential.to_authorization()
 
         result = await verify_or_challenge(
@@ -79,8 +83,7 @@ class TestVerifyOrChallenge:
         )
 
         assert isinstance(result, tuple)
-        cred, receipt = result
-        assert cred.challenge.id == "test-id"
+        _, receipt = result
         assert receipt.status == "success"
 
 
@@ -113,7 +116,14 @@ class TestClassBasedIntent:
             async def verify(self, credential: Credential, request: dict) -> Receipt:
                 return Receipt.success("custom-ref")
 
-        credential = make_credential(payload={}, challenge_id="test")
+        credential = make_bound_credential(
+            payload={},
+            request={},
+            realm="test",
+            secret_key="test-secret",
+            method="custom-method",
+            intent="custom",
+        )
         auth_header = credential.to_authorization()
 
         result = await verify_or_challenge(
@@ -139,7 +149,12 @@ class TestFailedReceiptHandling:
         async def test_intent(credential: Credential, request: dict) -> Receipt:
             return Receipt.failed("tx-failed-123")
 
-        credential = make_credential(payload={"token": "valid"}, challenge_id="test")
+        credential = make_bound_credential(
+            payload={"token": "valid"},
+            request={"amount": "1000"},
+            realm="api.example.com",
+            secret_key="test-secret",
+        )
         auth_header = credential.to_authorization()
 
         result = await verify_or_challenge(
@@ -160,7 +175,12 @@ class TestFailedReceiptHandling:
         async def test_intent(credential: Credential, request: dict) -> Receipt:
             return Receipt.success("tx-success-456")
 
-        credential = make_credential(payload={"token": "valid"}, challenge_id="test")
+        credential = make_bound_credential(
+            payload={"token": "valid"},
+            request={"amount": "1000"},
+            realm="api.example.com",
+            secret_key="test-secret",
+        )
         auth_header = credential.to_authorization()
 
         result = await verify_or_challenge(
@@ -203,7 +223,12 @@ class TestVerificationError:
         async def failing_intent(credential: Credential, request: dict) -> Receipt:
             raise VerificationError("Payment verification failed")
 
-        credential = make_credential(payload={}, challenge_id="test")
+        credential = make_bound_credential(
+            payload={},
+            request={"amount": "1000"},
+            realm="api.example.com",
+            secret_key="test-secret",
+        )
         auth_header = credential.to_authorization()
 
         with pytest.raises(VerificationError, match="Payment verification failed"):
@@ -223,7 +248,12 @@ class TestVerificationError:
         async def success_intent(credential: Credential, request: dict) -> Receipt:
             return Receipt.success("tx-success-456")
 
-        credential = make_credential(payload={}, challenge_id="test")
+        credential = make_bound_credential(
+            payload={},
+            request={"amount": "1000"},
+            realm="api.example.com",
+            secret_key="test-secret",
+        )
         auth_header = credential.to_authorization()
 
         result = await verify_or_challenge(
@@ -235,7 +265,7 @@ class TestVerificationError:
         )
 
         assert isinstance(result, tuple)
-        cred, receipt = result
+        _, receipt = result
         assert receipt.status == "success"
         assert receipt.reference == "tx-success-456"
 
@@ -323,16 +353,19 @@ class TestPay:
         async def handler(req: MockRequest, credential: Credential, receipt: Receipt) -> dict:
             return {
                 "data": "paid content",
-                "credential_id": credential.challenge.id,
                 "receipt_ref": receipt.reference,
             }
 
-        credential = make_credential(payload={"hash": "0xabc"}, challenge_id="test-cred-id")
+        credential = make_bound_credential(
+            payload={"hash": "0xabc"},
+            request={"amount": "1000"},
+            realm="api.example.com",
+            secret_key="test-secret",
+        )
         request = MockRequest(authorization=credential.to_authorization())
         result = await handler(request)
 
         assert result["data"] == "paid content"
-        assert result["credential_id"] == "test-cred-id"
         assert result["receipt_ref"] == "tx-ref-123"
 
     @pytest.mark.asyncio
@@ -356,7 +389,12 @@ class TestPay:
         class RequestWithQuery(MockRequest):
             query_amount = "2000"
 
-        credential = make_credential(payload={}, challenge_id="test")
+        credential = make_bound_credential(
+            payload={},
+            request={"amount": "2000"},
+            realm="api.example.com",
+            secret_key="test-secret",
+        )
         request = RequestWithQuery(authorization=credential.to_authorization())
         result = await handler(request)
 
@@ -379,13 +417,18 @@ class TestPay:
         async def handler(
             req: DjangoStyleRequest, credential: Credential, receipt: Receipt
         ) -> dict:
-            return {"credential_id": credential.challenge.id}
+            return {"paid": True}
 
-        credential = make_credential(payload={}, challenge_id="django-cred")
+        credential = make_bound_credential(
+            payload={},
+            request={"amount": "1000"},
+            realm="api.example.com",
+            secret_key="test-secret",
+        )
         request = DjangoStyleRequest(authorization=credential.to_authorization())
         result = await handler(request)
 
-        assert result["credential_id"] == "django-cred"
+        assert result["paid"] is True
 
     @pytest.mark.asyncio
     async def test_returns_402_for_invalid_scheme(self) -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -140,62 +140,6 @@ class TestClassBasedIntent:
         assert receipt.reference == "custom-ref"
 
 
-class TestFailedReceiptHandling:
-    @pytest.mark.asyncio
-    async def test_returns_challenge_when_receipt_failed(self) -> None:
-        """Should return 402 challenge when verify returns a failed receipt."""
-
-        @intent(name="charge")
-        async def test_intent(credential: Credential, request: dict) -> Receipt:
-            return Receipt.failed("tx-failed-123")
-
-        credential = make_bound_credential(
-            payload={"token": "valid"},
-            request={"amount": "1000"},
-            realm="api.example.com",
-            secret_key="test-secret",
-        )
-        auth_header = credential.to_authorization()
-
-        result = await verify_or_challenge(
-            authorization=auth_header,
-            intent=test_intent,
-            request={"amount": "1000"},
-            realm="api.example.com",
-            secret_key="test-secret",
-        )
-
-        assert isinstance(result, Challenge)
-
-    @pytest.mark.asyncio
-    async def test_returns_receipt_when_success(self) -> None:
-        """Should return (credential, receipt) when verify returns success."""
-
-        @intent(name="charge")
-        async def test_intent(credential: Credential, request: dict) -> Receipt:
-            return Receipt.success("tx-success-456")
-
-        credential = make_bound_credential(
-            payload={"token": "valid"},
-            request={"amount": "1000"},
-            realm="api.example.com",
-            secret_key="test-secret",
-        )
-        auth_header = credential.to_authorization()
-
-        result = await verify_or_challenge(
-            authorization=auth_header,
-            intent=test_intent,
-            request={"amount": "1000"},
-            realm="api.example.com",
-            secret_key="test-secret",
-        )
-
-        assert isinstance(result, tuple)
-        _, receipt = result
-        assert receipt.status == "success"
-
-
 class TestVerificationError:
     @pytest.mark.asyncio
     async def test_returns_challenge_on_parse_error(self) -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -130,6 +130,52 @@ class TestClassBasedIntent:
         assert receipt.reference == "custom-ref"
 
 
+class TestFailedReceiptHandling:
+    @pytest.mark.asyncio
+    async def test_returns_challenge_when_receipt_failed(self) -> None:
+        """Should return 402 challenge when verify returns a failed receipt."""
+
+        @intent(name="charge")
+        async def test_intent(credential: Credential, request: dict) -> Receipt:
+            return Receipt.failed("tx-failed-123")
+
+        credential = make_credential(payload={"token": "valid"}, challenge_id="test")
+        auth_header = credential.to_authorization()
+
+        result = await verify_or_challenge(
+            authorization=auth_header,
+            intent=test_intent,
+            request={"amount": "1000"},
+            realm="api.example.com",
+            secret_key="test-secret",
+        )
+
+        assert isinstance(result, Challenge)
+
+    @pytest.mark.asyncio
+    async def test_returns_receipt_when_success(self) -> None:
+        """Should return (credential, receipt) when verify returns success."""
+
+        @intent(name="charge")
+        async def test_intent(credential: Credential, request: dict) -> Receipt:
+            return Receipt.success("tx-success-456")
+
+        credential = make_credential(payload={"token": "valid"}, challenge_id="test")
+        auth_header = credential.to_authorization()
+
+        result = await verify_or_challenge(
+            authorization=auth_header,
+            intent=test_intent,
+            request={"amount": "1000"},
+            realm="api.example.com",
+            secret_key="test-secret",
+        )
+
+        assert isinstance(result, tuple)
+        _, receipt = result
+        assert receipt.status == "success"
+
+
 class TestVerificationError:
     @pytest.mark.asyncio
     async def test_returns_challenge_on_parse_error(self) -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -574,12 +574,16 @@ class TestMppPay:
                 "receipt_ref": receipt.reference,
             }
 
-        credential = make_credential(payload={"hash": "0xabc"}, challenge_id="test-cred-id")
+        credential = make_bound_credential(
+            payload={"hash": "0xabc"},
+            request={"amount": "500000", "currency": "0xUSD", "recipient": "0xRecipient"},
+            realm="api.example.com",
+            secret_key="test-secret",
+        )
         request = MockRequest(authorization=credential.to_authorization())
         result = await handler(request)
 
         assert result["data"] == "paid content"
-        assert result["credential_id"] == "test-cred-id"
         assert result["receipt_ref"] == "tx-ref-456"
 
     @pytest.mark.asyncio
@@ -597,7 +601,12 @@ class TestMppPay:
         async def handler(req: MockRequest, credential: Credential, receipt: Receipt) -> dict:
             return {"data": "paid"}
 
-        credential = make_credential(payload={}, challenge_id="test")
+        credential = make_bound_credential(
+            payload={},
+            request={"amount": "500000", "currency": "0xUSD", "recipient": "0xRecipient"},
+            realm="api.example.com",
+            secret_key="test-secret",
+        )
         request = MockRequest(authorization=credential.to_authorization())
         result = await handler(request)
 
@@ -636,7 +645,12 @@ class TestMppPay:
         async def handler(req: MockRequest, credential: Credential, receipt: Receipt) -> dict:
             return {"data": "paid"}
 
-        credential = make_credential(payload={}, challenge_id="test")
+        credential = make_bound_credential(
+            payload={},
+            request={"amount": "1000000", "currency": "0xOverride", "recipient": "0xRecipient"},
+            realm="api.example.com",
+            secret_key="test-secret",
+        )
         request = MockRequest(authorization=credential.to_authorization())
         result = await handler(request)
 
@@ -656,13 +670,18 @@ class TestMppPay:
         async def handler(
             req: DjangoStyleRequest, credential: Credential, receipt: Receipt
         ) -> dict:
-            return {"credential_id": credential.challenge.id}
+            return {"paid": True}
 
-        credential = make_credential(payload={}, challenge_id="django-cred")
+        credential = make_bound_credential(
+            payload={},
+            request={"amount": "500000", "currency": "0xUSD", "recipient": "0xRecipient"},
+            realm="api.example.com",
+            secret_key="test-secret",
+        )
         request = DjangoStyleRequest(authorization=credential.to_authorization())
         result = await handler(request)
 
-        assert result["credential_id"] == "django-cred"
+        assert result["paid"] is True
 
     @pytest.mark.asyncio
     async def test_supports_recipient_override(self) -> None:
@@ -679,7 +698,12 @@ class TestMppPay:
         async def handler(req: MockRequest, credential: Credential, receipt: Receipt) -> dict:
             return {"data": "paid"}
 
-        credential = make_credential(payload={}, challenge_id="test")
+        credential = make_bound_credential(
+            payload={},
+            request={"amount": "1000000", "currency": "0xUSD", "recipient": "0xOverrideRecipient"},
+            realm="api.example.com",
+            secret_key="test-secret",
+        )
         request = MockRequest(authorization=credential.to_authorization())
         result = await handler(request)
 
@@ -758,7 +782,13 @@ class TestMppPay:
         async def handler(req: MockRequest, credential: Credential, receipt: Receipt) -> dict:
             return {"data": "session", "receipt_ref": receipt.reference}
 
-        credential = make_credential(payload={}, challenge_id="session-test")
+        credential = make_bound_credential(
+            payload={},
+            request={"amount": "75", "currency": "0xUSD", "recipient": "0xRecipient"},
+            realm="api.example.com",
+            secret_key="test-secret",
+            intent="session",
+        )
         request = MockRequest(authorization=credential.to_authorization())
         result = await handler(request)
 

--- a/tests/test_tempo.py
+++ b/tests/test_tempo.py
@@ -550,7 +550,7 @@ class TestSchemas:
         )
         assert req.amount == "1000"
         assert req.methodDetails.feePayer is False
-        assert req.methodDetails.chainId == 42431
+        assert req.methodDetails.chainId == 4217
 
     def test_charge_request_with_fee_payer(self) -> None:
         """Should accept methodDetails with feePayer and feePayerUrl."""


### PR DESCRIPTION
Aligns pympay with the TypeScript SDK (mppx) and the [Payment Auth spec](https://paymentauth.tempo.xyz/draft-httpauth-payment-00.txt).

## Changes

### New modules
- **`Expires`** helper — `Expires.seconds()`, `.minutes()`, `.hours()`, `.days()`, `.weeks()`, `.months()`, `.years()` for ISO datetime strings
- **`BodyDigest`** helper — `compute()` and `verify()` for request body binding
- **`errors`** — RFC 9457 error types: `PaymentError`, `PaymentRequiredError`, `MalformedCredentialError`, `InvalidChallengeError`, `VerificationFailedError`, `PaymentExpiredError`, `InvalidPayloadError` — all with `to_problem_details()`

### Spec alignment
- **Receipt status `"failed"`** — Per spec §5.3.1, receipt status supports both `"success"` and `"failed"`. Added `Receipt.failed()` factory method.
- **Failed receipt → 402** — Per spec: *"Servers MUST NOT return a 200 response with a status: `"failed"` receipt for synchronous payment flows."* `verify_or_challenge` now returns a Challenge (triggering 402) when receipt status is `"failed"`.
- **`parse_payment_receipt`** now accepts `"failed"` status (was incorrectly rejecting spec-valid receipts).

### Feature parity with TS SDK
- **`Cache-Control: no-store`** on 402 responses in decorator (matches TS SDK `Transport.http()`)
- **`memo`** and **`fee_payer`** params on `Mpay.charge()` that flow into `methodDetails`
- **`chainId`** default fixed from `42431` (testnet) to `4217` (mainnet)

### Exports
- Error types exported from `mpay` and `mpay.server`
- `Expires` exported from `mpay.client`

## Tests
158 tests pass. 2 new tests for failed receipt handling.