### PR TITLE
feat: auto-generate attribution memo for MPP transactions

### DIFF
--- a/src/mpay/methods/tempo/_attribution.py
+++ b/src/mpay/methods/tempo/_attribution.py
@@ -46,15 +46,21 @@ def encode(server_id: str, client_id: str | None = None) -> str:
 def is_mpp_memo(memo: str) -> bool:
     if len(memo) != 66:
         return False
-    memo_tag = bytes.fromhex(memo[2:10])
-    memo_version = int(memo[10:12], 16)
+    try:
+        memo_tag = bytes.fromhex(memo[2:10])
+        memo_version = int(memo[10:12], 16)
+    except ValueError:
+        return False
     return memo_tag == TAG and memo_version == _VERSION
 
 
 def verify_server(memo: str, server_id: str) -> bool:
     if not is_mpp_memo(memo):
         return False
-    memo_server = bytes.fromhex(memo[12:32])
+    try:
+        memo_server = bytes.fromhex(memo[12:32])
+    except ValueError:
+        return False
     return memo_server == _fingerprint(server_id)
 
 
@@ -70,12 +76,15 @@ def decode(memo: str) -> DecodedMemo | None:
     if not is_mpp_memo(memo):
         return None
 
-    version = int(memo[10:12], 16)
-    server_fingerprint = "0x" + memo[12:32]
-    client_hex = memo[32:52]
-    nonce = "0x" + memo[52:]
+    try:
+        version = int(memo[10:12], 16)
+        server_fingerprint = "0x" + memo[12:32]
+        client_hex = memo[32:52]
+        nonce = "0x" + memo[52:]
 
-    client_fingerprint = None if bytes.fromhex(client_hex) == _ANONYMOUS else "0x" + client_hex
+        client_fingerprint = None if bytes.fromhex(client_hex) == _ANONYMOUS else "0x" + client_hex
+    except ValueError:
+        return None
 
     return DecodedMemo(
         version=version,

--- a/src/mpay/methods/tempo/_attribution.py
+++ b/src/mpay/methods/tempo/_attribution.py
@@ -1,0 +1,85 @@
+"""MPP attribution memo encoding for TIP-20 ``transferWithMemo``.
+
+When no user-provided memo is present, the SDK auto-generates an
+attribution memo so MPP transactions are identifiable on-chain.
+
+Byte Layout (32 bytes)
+~~~~~~~~~~~~~~~~~~~~~~
+
+| Offset | Size | Field                                     |
+|--------|------|-------------------------------------------|
+| 0..3   | 4    | TAG = keccak256("mpp")[0..3]               |
+| 4      | 1    | version (0x01)                            |
+| 5..14  | 10   | serverId = keccak256(serverId)[0..9]       |
+| 15..24 | 10   | clientId = keccak256(clientId)[0..9] or 0s |
+| 25..31 | 7    | nonce (random bytes)                      |
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+from eth_hash.auto import keccak
+
+TAG: bytes = keccak(b"mpp")[:4]
+
+_VERSION = 0x01
+_ANONYMOUS = bytes(10)
+
+
+def _fingerprint(value: str) -> bytes:
+    return keccak(value.encode())[:10]
+
+
+def encode(server_id: str, client_id: str | None = None) -> str:
+    buf = bytearray(32)
+    buf[0:4] = TAG
+    buf[4] = _VERSION
+    buf[5:15] = _fingerprint(server_id)
+    if client_id:
+        buf[15:25] = _fingerprint(client_id)
+    buf[25:32] = os.urandom(7)
+    return "0x" + buf.hex()
+
+
+def is_mpp_memo(memo: str) -> bool:
+    if len(memo) != 66:
+        return False
+    memo_tag = bytes.fromhex(memo[2:10])
+    memo_version = int(memo[10:12], 16)
+    return memo_tag == TAG and memo_version == _VERSION
+
+
+def verify_server(memo: str, server_id: str) -> bool:
+    if not is_mpp_memo(memo):
+        return False
+    memo_server = bytes.fromhex(memo[12:32])
+    return memo_server == _fingerprint(server_id)
+
+
+@dataclass(frozen=True, slots=True)
+class DecodedMemo:
+    version: int
+    server_fingerprint: str
+    client_fingerprint: str | None
+    nonce: str
+
+
+def decode(memo: str) -> DecodedMemo | None:
+    if not is_mpp_memo(memo):
+        return None
+
+    version = int(memo[10:12], 16)
+    server_fingerprint = "0x" + memo[12:32]
+    client_hex = memo[32:52]
+    nonce = "0x" + memo[52:]
+
+    client_fingerprint = None if bytes.fromhex(client_hex) == _ANONYMOUS else "0x" + client_hex
+
+    return DecodedMemo(
+        version=version,
+        server_fingerprint=server_fingerprint,
+        client_fingerprint=client_fingerprint,
+        nonce=nonce,
+    )

--- a/src/mpay/methods/tempo/client.py
+++ b/src/mpay/methods/tempo/client.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from mpay import Challenge, Credential
+from mpay.methods.tempo._attribution import encode as encode_attribution
 from mpay.methods.tempo._defaults import RPC_URL
 from mpay.methods.tempo._rpc import get_tx_params
 
@@ -56,6 +57,7 @@ class TempoMethod:
     currency: str | None = None
     recipient: str | None = None
     decimals: int = 6
+    client_id: str | None = None
     _intents: dict[str, Intent] = field(default_factory=dict)
 
     @property
@@ -96,6 +98,8 @@ class TempoMethod:
 
         method_details = request.get("methodDetails", {})
         memo = method_details.get("memo") if isinstance(method_details, dict) else None
+        if memo is None:
+            memo = encode_attribution(server_id=challenge.realm, client_id=self.client_id)
 
         raw_tx, chain_id = await self._build_tempo_transfer(
             amount=request["amount"],
@@ -198,6 +202,7 @@ def tempo(
     currency: str | None = None,
     recipient: str | None = None,
     decimals: int = 6,
+    client_id: str | None = None,
 ) -> TempoMethod:
     """Create a Tempo payment method.
 
@@ -209,6 +214,7 @@ def tempo(
         currency: Default currency address for charges.
         recipient: Default recipient address for charges.
         decimals: Token decimal places for amount conversion (default: 6).
+        client_id: Optional client identity for attribution memos.
 
     Returns:
         A configured TempoMethod instance.
@@ -227,6 +233,7 @@ def tempo(
         currency=currency,
         recipient=recipient,
         decimals=decimals,
+        client_id=client_id,
     )
     method._intents = dict(intents)
     return method

--- a/src/mpay/methods/tempo/client.py
+++ b/src/mpay/methods/tempo/client.py
@@ -185,8 +185,9 @@ class TempoMethod:
         to_padded = to[2:].lower().zfill(64)
         amount_padded = hex(amount)[2:].zfill(64)
         memo_clean = memo[2:] if memo.startswith("0x") else memo
-        memo_padded = memo_clean.lower().zfill(64)
-        return f"0x{selector}{to_padded}{amount_padded}{memo_padded}"
+        if len(memo_clean) != 64:
+            raise ValueError(f"memo must be exactly 32 bytes (64 hex chars), got {len(memo_clean)}")
+        return f"0x{selector}{to_padded}{amount_padded}{memo_clean.lower()}"
 
 
 # ──────────────────────────────────────────────────────────────────

--- a/tests/test_attribution.py
+++ b/tests/test_attribution.py
@@ -1,0 +1,93 @@
+"""Tests for MPP attribution memo encoding."""
+
+from mpay.methods.tempo._attribution import (
+    TAG,
+    DecodedMemo,
+    decode,
+    encode,
+    is_mpp_memo,
+    verify_server,
+)
+
+
+class TestTag:
+    def test_tag_value(self) -> None:
+        assert TAG == bytes.fromhex("ef1ed712")
+
+    def test_tag_length(self) -> None:
+        assert len(TAG) == 4
+
+
+class TestEncode:
+    def test_produces_66_char_hex(self) -> None:
+        memo = encode(server_id="api.example.com")
+        assert memo.startswith("0x")
+        assert len(memo) == 66
+
+    def test_with_client_id(self) -> None:
+        memo = encode(server_id="api.example.com", client_id="my-app")
+        assert len(memo) == 66
+        assert is_mpp_memo(memo)
+
+    def test_without_client_id_is_anonymous(self) -> None:
+        memo = encode(server_id="api.example.com")
+        decoded = decode(memo)
+        assert decoded is not None
+        assert decoded.client_fingerprint is None
+
+    def test_unique_nonces(self) -> None:
+        memos = {encode(server_id="api.example.com") for _ in range(10)}
+        assert len(memos) == 10
+
+
+class TestIsMppMemo:
+    def test_true_for_encoded(self) -> None:
+        memo = encode(server_id="api.example.com")
+        assert is_mpp_memo(memo) is True
+
+    def test_false_for_zeros(self) -> None:
+        assert is_mpp_memo("0x" + "00" * 32) is False
+
+    def test_false_for_wrong_length(self) -> None:
+        assert is_mpp_memo("0xabcd") is False
+
+    def test_false_for_wrong_version(self) -> None:
+        memo = encode(server_id="api.example.com")
+        bad = memo[:10] + "ff" + memo[12:]
+        assert is_mpp_memo(bad) is False
+
+
+class TestVerifyServer:
+    def test_correct_server(self) -> None:
+        memo = encode(server_id="api.example.com")
+        assert verify_server(memo, "api.example.com") is True
+
+    def test_wrong_server(self) -> None:
+        memo = encode(server_id="api.example.com")
+        assert verify_server(memo, "other.example.com") is False
+
+    def test_non_mpp_memo(self) -> None:
+        assert verify_server("0x" + "00" * 32, "api.example.com") is False
+
+
+class TestDecode:
+    def test_round_trip(self) -> None:
+        memo = encode(server_id="api.example.com", client_id="my-app")
+        decoded = decode(memo)
+        assert decoded is not None
+        assert isinstance(decoded, DecodedMemo)
+        assert decoded.version == 1
+        assert decoded.server_fingerprint.startswith("0x")
+        assert len(decoded.server_fingerprint) == 22  # 0x + 20 hex chars (10 bytes)
+        assert decoded.client_fingerprint is not None
+        assert decoded.nonce.startswith("0x")
+        assert len(decoded.nonce) == 16  # 0x + 14 hex chars (7 bytes)
+
+    def test_returns_none_for_non_mpp(self) -> None:
+        assert decode("0x" + "00" * 32) is None
+
+    def test_anonymous_client(self) -> None:
+        memo = encode(server_id="api.example.com")
+        decoded = decode(memo)
+        assert decoded is not None
+        assert decoded.client_fingerprint is None

--- a/tests/test_attribution.py
+++ b/tests/test_attribution.py
@@ -56,6 +56,9 @@ class TestIsMppMemo:
         bad = memo[:10] + "ff" + memo[12:]
         assert is_mpp_memo(bad) is False
 
+    def test_false_for_non_hex(self) -> None:
+        assert is_mpp_memo("0x" + "zz" * 32) is False
+
 
 class TestVerifyServer:
     def test_correct_server(self) -> None:
@@ -85,6 +88,9 @@ class TestDecode:
 
     def test_returns_none_for_non_mpp(self) -> None:
         assert decode("0x" + "00" * 32) is None
+
+    def test_returns_none_for_non_hex(self) -> None:
+        assert decode("0x" + "zz" * 32) is None
 
     def test_anonymous_client(self) -> None:
         memo = encode(server_id="api.example.com")


### PR DESCRIPTION
Ports the mppx (TypeScript) attribution memo to the Python SDK. When no user-provided memo exists, the client auto-generates a 32-byte attribution memo so every MPP transaction is identifiable on-chain via `transferWithMemo`.

## Changes

- **`src/mpay/methods/tempo/_attribution.py`** — New module with `encode`, `decode`, `is_mpp_memo`, `verify_server`, matching the byte layout from `mppx/src/tempo/Attribution.ts`
- **`src/mpay/methods/tempo/client.py`** — `create_credential()` now auto-generates an attribution memo when no user memo is provided; added `client_id` to `TempoMethod` and `tempo()` factory
- **`tests/test_attribution.py`** — Tests for TAG value, encode/decode round-trips, `is_mpp_memo`, `verify_server`, anonymous client handling

## Byte Layout (32 bytes)

| Offset | Size | Field |
|--------|------|-------|
| 0..3 | 4 | TAG = keccak256("mpp")[0..3] = `0xef1ed712` |
| 4 | 1 | version (`0x01`) |
| 5..14 | 10 | serverId fingerprint |
| 15..24 | 10 | clientId fingerprint (or zeros) |
| 25..31 | 7 | random nonce |