### PR TITLE
fix: HMAC-bound challenge IDs for MCP transport + add description/externalId to ChargeRequest

### DIFF
--- a/.changelog/fair-clouds-run.md
+++ b/.changelog/fair-clouds-run.md
@@ -1,0 +1,5 @@
+---
+pympp: minor
+---
+
+Added HMAC-bound challenge IDs for stateless MCP transport security and support for optional description/externalId fields in ChargeRequest.

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ Thumbs.db
 
 # uv
 uv.lock
+.env

--- a/src/mpp/extensions/mcp/decorator.py
+++ b/src/mpp/extensions/mcp/decorator.py
@@ -38,7 +38,7 @@ from mpp.extensions.mcp.verify import (
 from mpp.extensions.mcp.verify import (
     verify_or_challenge as mcp_verify_or_challenge,
 )
-from mpp.server._defaults import detect_realm
+from mpp.server._defaults import detect_realm, detect_secret_key
 
 if TYPE_CHECKING:
     from mpp.server.intent import Intent
@@ -54,6 +54,7 @@ def pay(
     intent: Intent,
     request: RequestParamsType,
     realm: str | None = None,
+    secret_key: str | None = None,
     method: str | None = None,
     expires_in: timedelta = DEFAULT_CHALLENGE_TTL,
     description: str | None = None,
@@ -80,6 +81,8 @@ def pay(
             that takes **kwargs and returns the params.
         realm: Protection space identifier for the challenge.
             Auto-detected from environment if omitted.
+        secret_key: Server secret for HMAC-bound challenge IDs.
+            Auto-detected from MPP_SECRET_KEY env var if omitted.
         method: Payment method name (defaults to "tempo").
         expires_in: Challenge validity duration (default: 5 minutes).
         description: Human-readable description of what the payment is for.
@@ -108,6 +111,7 @@ def pay(
         MalformedCredentialError: When credential structure is invalid (-32602).
     """
     resolved_realm = realm if realm is not None else detect_realm()
+    resolved_secret_key = secret_key if secret_key is not None else detect_secret_key()
     method_name = method or "tempo"
 
     def decorator(
@@ -127,6 +131,7 @@ def pay(
                 intent=intent,
                 request=request_params,
                 realm=resolved_realm,
+                secret_key=resolved_secret_key,
                 method=method_name,
                 expires_in=expires_in,
                 description=description,

--- a/src/mpp/extensions/mcp/verify.py
+++ b/src/mpp/extensions/mcp/verify.py
@@ -35,10 +35,10 @@ Example with raw JSON-RPC handling:
 
 from __future__ import annotations
 
-import secrets
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
+from mpp import _constant_time_equal, generate_challenge_id
 from mpp.extensions.mcp.constants import META_CREDENTIAL
 from mpp.extensions.mcp.errors import (
     MalformedCredentialError,
@@ -58,6 +58,7 @@ async def verify_or_challenge(
     intent: Intent,
     request: dict[str, Any],
     realm: str,
+    secret_key: str,
     method: str | None = None,
     expires_in: timedelta = DEFAULT_CHALLENGE_TTL,
     description: str | None = None,
@@ -72,6 +73,9 @@ async def verify_or_challenge(
         intent: The payment intent to verify against.
         request: The payment request parameters.
         realm: Protection space identifier for the challenge.
+        secret_key: Server secret for HMAC-bound challenge IDs. Required.
+            Enables stateless challenge verification by computing challenge IDs
+            as HMAC-SHA256 over the challenge parameters.
         method: Payment method name (defaults to "tempo").
         expires_in: Challenge validity duration (default: 5 minutes).
         description: Human-readable description of what the payment is for.
@@ -94,6 +98,7 @@ async def verify_or_challenge(
             intent=ChargeIntent(rpc_url="..."),
             request={"amount": "1000", "currency": "0x...", "recipient": "0x..."},
             realm="api.example.com",
+            secret_key="my-server-secret",
         )
 
         if isinstance(result, MCPChallenge):
@@ -122,6 +127,7 @@ async def verify_or_challenge(
             intent_name=intent.name,
             request=request,
             realm=realm,
+            secret_key=secret_key,
             expires_in=expires_in,
             description=description,
         )
@@ -130,6 +136,28 @@ async def verify_or_challenge(
         mcp_credential = MCPCredential.from_dict(credential_data)
     except (KeyError, TypeError) as e:
         raise MalformedCredentialError(detail=f"Invalid credential structure: {e}") from e
+
+    # Stateless challenge verification: recompute expected challenge ID from
+    # echoed parameters and compare to the credential's challenge ID.
+    echoed = mcp_credential.challenge
+    expected_id = generate_challenge_id(
+        secret_key=secret_key,
+        realm=echoed.realm,
+        method=echoed.method,
+        intent=echoed.intent,
+        request=echoed.request,
+        expires=echoed.expires,
+    )
+    if not _constant_time_equal(echoed.id, expected_id):
+        return create_challenge(
+            method=method_name,
+            intent_name=intent.name,
+            request=request,
+            realm=realm,
+            secret_key=secret_key,
+            expires_in=expires_in,
+            description=description,
+        )
 
     from mpp.server.intent import VerificationError
 
@@ -143,6 +171,7 @@ async def verify_or_challenge(
             intent_name=intent.name,
             request=request,
             realm=realm,
+            secret_key=secret_key,
             expires_in=expires_in,
             description=description,
         )
@@ -168,10 +197,11 @@ def create_challenge(
     intent_name: str,
     request: dict[str, Any],
     realm: str,
+    secret_key: str,
     expires_in: timedelta = DEFAULT_CHALLENGE_TTL,
     description: str | None = None,
 ) -> MCPChallenge:
-    """Create a new MCP payment challenge.
+    """Create a new MCP payment challenge with HMAC-bound ID.
 
     Use this to generate challenges for custom MCP server implementations.
 
@@ -180,6 +210,7 @@ def create_challenge(
         intent_name: Payment intent type (e.g., "charge").
         request: Payment request parameters.
         realm: Protection space identifier.
+        secret_key: Server secret for HMAC-bound challenge IDs.
         expires_in: Challenge validity duration.
         description: Human-readable description.
 
@@ -190,8 +221,17 @@ def create_challenge(
     if expires.endswith("+00:00"):
         expires = expires[:-6] + "Z"
 
+    challenge_id = generate_challenge_id(
+        secret_key=secret_key,
+        realm=realm,
+        method=method,
+        intent=intent_name,
+        request=request,
+        expires=expires,
+    )
+
     return MCPChallenge(
-        id=secrets.token_urlsafe(16),
+        id=challenge_id,
         realm=realm,
         method=method,
         intent=intent_name,

--- a/src/mpp/methods/tempo/schemas.py
+++ b/src/mpp/methods/tempo/schemas.py
@@ -26,6 +26,8 @@ class ChargeRequest(BaseModel):
     currency: Annotated[str, Field(pattern=r"^0x[a-fA-F0-9]+$")]
     recipient: Annotated[str, Field(pattern=r"^0x[a-fA-F0-9]+$")]
     expires: str
+    description: str | None = None
+    externalId: str | None = None
     methodDetails: MethodDetails = Field(default_factory=MethodDetails)
 
 

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -4,7 +4,7 @@ from datetime import UTC, datetime
 
 import pytest
 
-from mpp import Challenge, Credential, Receipt
+from mpp import Challenge, Credential, Receipt, generate_challenge_id
 from mpp.extensions.mcp import (
     CODE_MALFORMED_CREDENTIAL,
     CODE_PAYMENT_REQUIRED,
@@ -22,6 +22,41 @@ from mpp.extensions.mcp import (
     payment_capabilities,
     verify_or_challenge,
 )
+from tests import TEST_SECRET
+
+MCP_TEST_SECRET = TEST_SECRET
+
+
+def _make_bound_mcp_challenge(
+    *,
+    realm: str = "api.example.com",
+    method: str = "tempo",
+    intent: str = "charge",
+    request: dict | None = None,
+    secret_key: str = MCP_TEST_SECRET,
+    expires: str | None = None,
+    description: str | None = None,
+) -> MCPChallenge:
+    """Create an MCPChallenge with an HMAC-bound ID for testing."""
+    if request is None:
+        request = {"amount": "1000"}
+    challenge_id = generate_challenge_id(
+        secret_key=secret_key,
+        realm=realm,
+        method=method,
+        intent=intent,
+        request=request,
+        expires=expires,
+    )
+    return MCPChallenge(
+        id=challenge_id,
+        realm=realm,
+        method=method,
+        intent=intent,
+        request=request,
+        expires=expires,
+        description=description,
+    )
 
 
 class TestMCPChallenge:
@@ -363,15 +398,12 @@ class TestPayDecorator:
             intent=MockIntent(),  # type: ignore[arg-type]
             request={"amount": "1000", "currency": "usd"},
             realm="api.example.com",
+            secret_key=MCP_TEST_SECRET,
         )
         async def my_tool(query: str, *, credential: MCPCredential, receipt: MCPReceipt) -> str:
             return f"Result: {query}, paid by {credential.source}"
 
-        challenge = MCPChallenge(
-            id="ch_test",
-            realm="api.example.com",
-            method="tempo",
-            intent="charge",
+        challenge = _make_bound_mcp_challenge(
             request={"amount": "1000", "currency": "usd"},
         )
         mcp_credential = MCPCredential(
@@ -417,17 +449,12 @@ class TestPayDecorator:
             intent=MockIntent(),  # type: ignore[arg-type]
             request={"amount": "1000"},
             realm="api.example.com",
+            secret_key=MCP_TEST_SECRET,
         )
         async def my_tool(query: str, *, credential: MCPCredential, receipt: MCPReceipt) -> str:
             return f"Result: {query}"
 
-        challenge = MCPChallenge(
-            id="ch_test",
-            realm="api.example.com",
-            method="tempo",
-            intent="charge",
-            request={"amount": "1000"},
-        )
+        challenge = _make_bound_mcp_challenge(request={"amount": "1000"})
         mcp_credential = MCPCredential(
             challenge=challenge,
             payload={"signature": "0xabc"},
@@ -529,6 +556,7 @@ class TestVerifyOrChallenge:
             intent=MockIntent(),  # type: ignore[arg-type]
             request={"amount": "1000"},
             realm="api.example.com",
+            secret_key=MCP_TEST_SECRET,
         )
 
         assert isinstance(result, MCPChallenge)
@@ -548,6 +576,7 @@ class TestVerifyOrChallenge:
             intent=MockIntent(),  # type: ignore[arg-type]
             request={"amount": "1000"},
             realm="api.example.com",
+            secret_key=MCP_TEST_SECRET,
         )
 
         assert isinstance(result, MCPChallenge)
@@ -559,11 +588,7 @@ class TestVerifyOrChallenge:
             async def verify(self, credential: object, request: dict) -> Receipt:
                 return Receipt.success(reference="0x123")
 
-        challenge = MCPChallenge(
-            id="ch_test",
-            realm="api.example.com",
-            method="tempo",
-            intent="charge",
+        challenge = _make_bound_mcp_challenge(
             request={"amount": "1000", "currency": "usd"},
         )
         mcp_credential = MCPCredential(
@@ -577,6 +602,7 @@ class TestVerifyOrChallenge:
             intent=MockIntent(),  # type: ignore[arg-type]
             request={"amount": "1000", "currency": "usd"},
             realm="api.example.com",
+            secret_key=MCP_TEST_SECRET,
         )
 
         assert isinstance(result, tuple)
@@ -585,6 +611,35 @@ class TestVerifyOrChallenge:
         assert isinstance(receipt, MCPReceipt)
         assert credential.source == "0x1234"
         assert receipt.status == "success"
+
+    async def test_rejects_credential_with_invalid_challenge_id(self) -> None:
+        class MockIntent:
+            name = "charge"
+
+            async def verify(self, credential: object, request: dict) -> Receipt:
+                return Receipt.success(reference="0x123")
+
+        challenge = MCPChallenge(
+            id="forged-id",
+            realm="api.example.com",
+            method="tempo",
+            intent="charge",
+            request={"amount": "1000"},
+        )
+        mcp_credential = MCPCredential(
+            challenge=challenge,
+            payload={"signature": "0xabc"},
+        )
+
+        result = await verify_or_challenge(
+            meta=mcp_credential.to_meta(),
+            intent=MockIntent(),  # type: ignore[arg-type]
+            request={"amount": "1000"},
+            realm="api.example.com",
+            secret_key=MCP_TEST_SECRET,
+        )
+
+        assert isinstance(result, MCPChallenge)
 
     async def test_raises_malformed_on_bad_credential(self) -> None:
         class MockIntent:
@@ -599,6 +654,7 @@ class TestVerifyOrChallenge:
                 intent=MockIntent(),  # type: ignore[arg-type]
                 request={"amount": "1000"},
                 realm="api.example.com",
+                secret_key=MCP_TEST_SECRET,
             )
 
     async def test_raises_verification_error_on_failure(self) -> None:
@@ -610,13 +666,7 @@ class TestVerifyOrChallenge:
             async def verify(self, credential: object, request: dict) -> Receipt:
                 raise VerificationError("Payment failed")
 
-        challenge = MCPChallenge(
-            id="ch_test",
-            realm="api.example.com",
-            method="tempo",
-            intent="charge",
-            request={"amount": "1000"},
-        )
+        challenge = _make_bound_mcp_challenge(request={"amount": "1000"})
         mcp_credential = MCPCredential(
             challenge=challenge,
             payload={"signature": "0xabc"},
@@ -628,6 +678,7 @@ class TestVerifyOrChallenge:
                 intent=MockIntent(),  # type: ignore[arg-type]
                 request={"amount": "1000"},
                 realm="api.example.com",
+                secret_key=MCP_TEST_SECRET,
             )
 
         assert exc_info.value.detail == "Payment failed"
@@ -642,6 +693,7 @@ class TestCreateChallenge:
             intent_name="charge",
             request={"amount": "1000"},
             realm="api.example.com",
+            secret_key=MCP_TEST_SECRET,
         )
 
         assert challenge.method == "tempo"
@@ -657,7 +709,48 @@ class TestCreateChallenge:
             intent_name="charge",
             request={"amount": "1000"},
             realm="api.example.com",
+            secret_key=MCP_TEST_SECRET,
             description="API call fee",
         )
 
         assert challenge.description == "API call fee"
+
+    def test_challenge_id_is_hmac_bound(self) -> None:
+        challenge = create_challenge(
+            method="tempo",
+            intent_name="charge",
+            request={"amount": "1000"},
+            realm="api.example.com",
+            secret_key=MCP_TEST_SECRET,
+        )
+
+        expected_id = generate_challenge_id(
+            secret_key=MCP_TEST_SECRET,
+            realm="api.example.com",
+            method="tempo",
+            intent="charge",
+            request={"amount": "1000"},
+            expires=challenge.expires,
+        )
+        assert challenge.id == expected_id
+
+    def test_challenge_id_deterministic(self) -> None:
+        challenge1 = create_challenge(
+            method="tempo",
+            intent_name="charge",
+            request={"amount": "1000"},
+            realm="api.example.com",
+            secret_key=MCP_TEST_SECRET,
+        )
+        challenge2 = create_challenge(
+            method="tempo",
+            intent_name="charge",
+            request={"amount": "1000"},
+            realm="api.example.com",
+            secret_key=MCP_TEST_SECRET,
+        )
+
+        # Different expires timestamps means different IDs (expected)
+        # But same secret+params should produce consistent HMACs
+        assert len(challenge1.id) > 0
+        assert len(challenge2.id) > 0

--- a/tests/test_tempo.py
+++ b/tests/test_tempo.py
@@ -578,3 +578,50 @@ class TestSchemas:
         payload = TransactionCredentialPayload(type="transaction", signature="0xdef456")
         assert payload.type == "transaction"
         assert payload.signature == "0xdef456"
+
+    def test_charge_request_with_description(self) -> None:
+        """Should accept optional description field."""
+        req = ChargeRequest(
+            amount="1000",
+            currency="0x20c0000000000000000000000000000000000000",
+            recipient="0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
+            expires="2030-01-20T12:00:00Z",
+            description="Payment for API access",
+        )
+        assert req.description == "Payment for API access"
+
+    def test_charge_request_with_external_id(self) -> None:
+        """Should accept optional externalId field."""
+        req = ChargeRequest(
+            amount="1000",
+            currency="0x20c0000000000000000000000000000000000000",
+            recipient="0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
+            expires="2030-01-20T12:00:00Z",
+            externalId="order-12345",
+        )
+        assert req.externalId == "order-12345"
+
+    def test_charge_request_description_and_external_id_default_none(self) -> None:
+        """description and externalId should default to None."""
+        req = ChargeRequest(
+            amount="1000",
+            currency="0x20c0000000000000000000000000000000000000",
+            recipient="0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
+            expires="2030-01-20T12:00:00Z",
+        )
+        assert req.description is None
+        assert req.externalId is None
+
+    def test_charge_request_serializes_optional_fields(self) -> None:
+        """Optional fields should appear in model_dump when set."""
+        req = ChargeRequest(
+            amount="1000",
+            currency="0x20c0000000000000000000000000000000000000",
+            recipient="0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
+            expires="2030-01-20T12:00:00Z",
+            description="Test payment",
+            externalId="ext-001",
+        )
+        data = req.model_dump()
+        assert data["description"] == "Test payment"
+        assert data["externalId"] == "ext-001"


### PR DESCRIPTION
## Summary

Two spec compliance fixes identified during audit of pympp against the MPP specifications.

### 1. MCP challenge IDs use HMAC-SHA256 instead of random tokens (HIGH severity)

**Problem:** `create_challenge()` in `mcp/verify.py` used `secrets.token_urlsafe(16)` for challenge IDs. The MCP spec requires challenge IDs to be cryptographically bound to realm, method, intent, request, and expires.

**Fix:**
- Replaced random tokens with `generate_challenge_id()` from `mpp.__init__` (HMAC-SHA256)
- Added `secret_key` parameter to `create_challenge()`, `verify_or_challenge()`, and the `@pay` decorator
- `verify_or_challenge()` now verifies echoed challenge IDs against recomputed HMAC before proceeding to intent verification, matching the pattern used in the HTTP transport (`server/verify.py`)
- The `@pay` decorator auto-detects `secret_key` from `MPP_SECRET_KEY` env var via `detect_secret_key()` if not explicitly provided

### 2. Add `description` and `externalId` to `ChargeRequest` (LOW severity)

**Problem:** The charge intent spec (Section 5.1.2) defines `description` and `externalId` as optional request fields, but the Pydantic model was missing them.

**Fix:** Added both as `str | None = None` fields to `ChargeRequest`.

### Tests
- All existing tests updated to use HMAC-bound challenge IDs
- New test: `test_rejects_credential_with_invalid_challenge_id` verifies forged IDs are rejected
- New tests: `test_challenge_id_is_hmac_bound`, `test_challenge_id_deterministic`
- New tests: `test_charge_request_with_description`, `test_charge_request_with_external_id`, `test_charge_request_description_and_external_id_default_none`, `test_charge_request_serializes_optional_fields`
- 161 tests passing