### PR TITLE
feat: mandate JCS (RFC 8785) for canonical JSON serialization of request parameter

### DIFF
--- a/.changelog/proud-waves-swim.md
+++ b/.changelog/proud-waves-swim.md
@@ -1,0 +1,5 @@
+---
+pympp: patch
+---
+
+Added `sort_keys=True` to all `json.dumps()` calls to ensure JCS (RFC 8785) canonical JSON serialization when generating challenge IDs and credentials.

--- a/src/mpp/__init__.py
+++ b/src/mpp/__init__.py
@@ -92,7 +92,7 @@ def generate_challenge_id(
             request={"amount": "1000000", "currency": "0x...", "recipient": "0x..."},
         )
     """
-    request_json = json.dumps(request, separators=(",", ":"), ensure_ascii=False)
+    request_json = json.dumps(request, separators=(",", ":"), sort_keys=True, ensure_ascii=False)
     request_b64 = _b64url_encode(request_json)
 
     segments = [realm, method, intent, request_b64, expires or "", digest or ""]
@@ -186,7 +186,7 @@ class Challenge:
             expires=expires,
             digest=digest,
         )
-        request_json = json.dumps(request, separators=(",", ":"), ensure_ascii=False)
+        request_json = json.dumps(request, separators=(",", ":"), sort_keys=True, ensure_ascii=False)
         request_b64 = _b64url_encode(request_json)
         return cls(
             id=challenge_id,

--- a/src/mpp/extensions/mcp/types.py
+++ b/src/mpp/extensions/mcp/types.py
@@ -165,7 +165,7 @@ class MCPCredential:
 
         from mpp import ChallengeEcho, Credential
 
-        request_json = json.dumps(self.challenge.request, separators=(",", ":"))
+        request_json = json.dumps(self.challenge.request, separators=(",", ":"), sort_keys=True)
         request_b64 = base64.urlsafe_b64encode(request_json.encode()).decode().rstrip("=")
 
         echo = ChallengeEcho(

--- a/tests/test_challenge_id.py
+++ b/tests/test_challenge_id.py
@@ -74,7 +74,7 @@ class TestGenerateChallengeId:
             expires="2026-02-01T00:00:00Z",
             digest="sha-256=abc123def456",
         )
-        assert result == "96xfZu2wzXD-f-l-hClS9OgODVgIoPWSCWhUw6a4I1Q"
+        assert result == "jDq_IazIMny5JJk3-xm3eSxGaP6XbbaApxBi6fG_320"
 
     def test_different_secret_different_id(self) -> None:
         """Same parameters with different secret produces different ID."""
@@ -116,7 +116,7 @@ class TestGenerateChallengeId:
                 "description": "Payment for café ☕",
             },
         )
-        assert result == "stLlKuOMkHscBIqCE78v48-CY-I0JIQkm1rjotcb-rQ"
+        assert result == "sBt2jC0UaKG5HgqRYgWHI0O3j36TvF8AMTc6ZncA7kc"
 
     def test_nested_method_details(self) -> None:
         """Request with nested methodDetails object."""
@@ -132,7 +132,7 @@ class TestGenerateChallengeId:
                 "methodDetails": {"chainId": 42431, "feePayer": True},
             },
         )
-        assert result == "AbaOnesHVxXeDbG9eStLZOlBwTI87_8g7skZwL9tOvA"
+        assert result == "feHfQQxI0Sf6UhvhHUijemERZaMkJJxuHzyWXnB6188"
 
 
 class TestChallengeCreate:


### PR DESCRIPTION
## Problem

The `request` parameter is base64url-encoded JSON that feeds into the HMAC-SHA256 challenge ID computation. Without canonical serialization, different implementations may produce different JSON key orderings, resulting in different HMAC values for the same logical request.

This breaks cross-implementation interoperability: a challenge created by one implementation may not be verifiable by another if the JSON keys happen to be in a different order.

## Changes

- Adds `sort_keys=True` to all `json.dumps()` calls that serialize request parameters (JCS for our use case)
- Updates 3 test vectors whose HMAC values changed due to key reordering
- No new dependencies needed — Python's stdlib `json.dumps(sort_keys=True)` satisfies RFC 8785 for our data types

Spec change: https://github.com/tempoxyz/mpp-specs/pull/141