### PR TITLE
docs: align README format with mppx

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,16 +58,6 @@ async with Client(methods=[tempo(account=account, intents={"charge": ChargeInten
 | [fetch](./examples/fetch/) | CLI tool for fetching URLs with automatic payment handling |
 | [mcp-server](./examples/mcp-server/) | MCP server with payment-protected tools |
 
-## Development
-
-Always run formatting and lint checks before committing:
-
-```bash
-uv run ruff format .
-uv run ruff check .
-uv run python -m pytest tests/ -x -q
-```
-
 ## Protocol
 
 Built on the ["Payment" HTTP Authentication Scheme](https://datatracker.ietf.org/doc/draft-ietf-httpauth-payment/). See [payment-auth-spec](https://github.com/tempoxyz/payment-auth-spec) for the full specification.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ async with Client(methods=[tempo(account=account, intents={"charge": ChargeInten
 
 ## Protocol
 
-Built on the ["Payment" HTTP Authentication Scheme](https://datatracker.ietf.org/doc/draft-ietf-httpauth-payment/). See [payment-auth-spec](https://github.com/tempoxyz/payment-auth-spec) for the full specification.
+Built on the ["Payment" HTTP Authentication Scheme](https://datatracker.ietf.org/doc/draft-ietf-httpauth-payment/). See [mpp-specs](https://tempoxyz.github.io/mpp-specs/) for the full specification.
 
 ## License
 


### PR DESCRIPTION
Aligns the README structure with the mppx SDK format: title + description + badges → Documentation → Install → Quick Start → Examples → Protocol → License. Removes the Development section (dev commands are in AGENTS.md).