### PR TITLE
fix: persist checkout credentials for publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,8 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: true
 
       - uses: wevm/changelogs@master
         with:


### PR DESCRIPTION
The publish workflow fails with `fatal: could not read Username for 'https://github.com'` when `wevm/changelogs` tries to `git push` the release branch.

`actions/checkout@v4` removes the credential helper after checkout by default. Setting `persist-credentials: true` keeps it active so subsequent git operations can authenticate.