### PR TITLE
chore: test publish pipeline

### DIFF
--- a/.changelog/test-publish.md
+++ b/.changelog/test-publish.md
@@ -1,0 +1,5 @@
+---
+pympp: patch
+---
+
+Test publish to verify end-to-end PyPI release pipeline.


### PR DESCRIPTION
Adds a patch changeset to test the end-to-end PyPI publish flow. Once merged, the changelogs action will open a version PR bumping to `0.1.1`, and merging that will publish to PyPI.