### PR TITLE
fix: use Python 3.12 in publish workflow

### DIFF
--- a/.changelog/fix-publish-python-version.md
+++ b/.changelog/fix-publish-python-version.md
@@ -1,0 +1,5 @@
+---
+pympp: patch
+---
+
+Fixed PyPI publish workflow by using Python 3.12 for building (package requires >=3.12).

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,10 @@ jobs:
         with:
           persist-credentials: true
 
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
       - uses: wevm/changelogs@master
         with:
           ecosystem: python


### PR DESCRIPTION
The `wevm/changelogs` action hardcodes Python 3.11, but pympp requires `>=3.12`. This caused `python -m build` to fail silently during the 0.1.1 publish attempt.

Fix: add `actions/setup-python@v5` with `python-version: '3.12'` before the changelogs action, so hatchling can build the package.

This also includes a patch changeset to trigger a new release (`0.1.2`) to test the full end-to-end flow.