### PR TITLE
fix: inline publish with Python 3.12

### DIFF
--- a/.changelog/fix-inline-publish.md
+++ b/.changelog/fix-inline-publish.md
@@ -1,0 +1,5 @@
+---
+pympp: patch
+---
+
+Fixed PyPI publish by inlining build steps with Python 3.12 instead of relying on wevm/changelogs composite action which hardcodes Python 3.11.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   release:
-    name: Version
+    name: Version & Publish
     runs-on: ubuntu-latest
     environment: release
     permissions:
@@ -19,14 +19,71 @@ jobs:
         with:
           persist-credentials: true
 
-      - uses: actions/setup-python@v5
+      - name: Install changelogs
+        run: curl -sSL https://changelogs.sh | sh
+
+      - name: Check for pending changelogs
+        id: check
+        run: |
+          if [ -d ".changelog" ] && [ "$(find .changelog -name '*.md' ! -name 'README.md' 2>/dev/null | head -1)" ]; then
+            echo "hasChangelogs=true" >> $GITHUB_OUTPUT
+          else
+            echo "hasChangelogs=false" >> $GITHUB_OUTPUT
+          fi
+
+      # When there are pending changelogs, create a version PR
+      - name: Configure git
+        if: steps.check.outputs.hasChangelogs == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Run changelogs version
+        if: steps.check.outputs.hasChangelogs == 'true'
+        id: version
+        run: |
+          output=$(~/.local/bin/changelogs --ecosystem python version 2>&1)
+          echo "$output"
+          versions=$(echo "$output" | grep -oE '[a-zA-Z0-9_-]+ [0-9]+\.[0-9]+\.[0-9]+ → [0-9]+\.[0-9]+\.[0-9]+' | sed 's/ .* → /@/')
+          echo "title=chore: release \`$versions\`" >> $GITHUB_OUTPUT
+
+      - name: Create version PR
+        if: steps.check.outputs.hasChangelogs == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: changelog-release/main
+          title: ${{ steps.version.outputs.title }}
+          body: |
+            This PR was opened by the Changelogs release workflow.
+            When you're ready to release, merge this PR and the packages will be published.
+          commit-message: ${{ steps.version.outputs.title }}
+          delete-branch: true
+
+      # When no pending changelogs (version PR was just merged), publish to PyPI
+      - name: Setup Python
+        if: steps.check.outputs.hasChangelogs == 'false'
+        uses: actions/setup-python@v5
         with:
           python-version: '3.12'
 
-      - uses: wevm/changelogs@master
-        with:
-          ecosystem: python
-          pypi-token: ${{ secrets.PYPI_TOKEN }}
-          conventional-commit: true
+      - name: Build and publish
+        if: steps.check.outputs.hasChangelogs == 'false'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+        run: |
+          pip install build twine
+          python -m build
+          twine upload dist/* --skip-existing
+
+      - name: Create git tag
+        if: steps.check.outputs.hasChangelogs == 'false'
+        run: |
+          VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          PKG_NAME=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['name'])")
+          TAG="${PKG_NAME}@${VERSION}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG" -m "$TAG"
+          git push origin "$TAG"


### PR DESCRIPTION
The `wevm/changelogs` composite action hardcodes `setup-python` with 3.11 internally, overriding any pre-step. This means `python -m build` always runs under 3.11 but pympp requires `>=3.12`.

**Fix:** Stop using the composite action for publishing. Instead:
- Use `changelogs` CLI directly for versioning (creating PRs)
- Inline the build/publish steps with `actions/setup-python` 3.12 + `python -m build` + `twine upload`

To test faster: you can re-run the Release workflow on main after merging, or locally test with `python -m build && twine upload dist/* --repository testpypi`.