### PR TITLE
refactor: use chain_id as primary config, resolve rpc_url automatically

### DIFF
--- a/examples/api-server/server.py
+++ b/examples/api-server/server.py
@@ -7,7 +7,7 @@ from fastapi.responses import JSONResponse
 
 from mpp import Challenge, Credential, Receipt
 from mpp.methods.tempo import ChargeIntent, tempo
-from mpp.methods.tempo._defaults import PATH_USD, TESTNET_CHAIN_ID, TESTNET_RPC_URL
+from mpp.methods.tempo._defaults import PATH_USD, TESTNET_CHAIN_ID
 from mpp.server import Mpp
 
 app = FastAPI(
@@ -15,16 +15,16 @@ app = FastAPI(
     description="Example API demonstrating Machine Payments Protocol payment protection",
 )
 
-RPC_URL = os.environ.get("TEMPO_RPC_URL", TESTNET_RPC_URL)
 DESTINATION = os.environ.get(
     "PAYMENT_DESTINATION", "0x742d35Cc6634c0532925a3b844bC9e7595F8fE00"
 )
 
 server = Mpp.create(
     method=tempo(
+        chain_id=TESTNET_CHAIN_ID,
         currency=PATH_USD,
         recipient=DESTINATION,
-        intents={"charge": ChargeIntent(rpc_url=RPC_URL)},
+        intents={"charge": ChargeIntent()},
     ),
 )
 
@@ -41,7 +41,6 @@ async def paid_endpoint(request: Request):
     result = await server.charge(
         authorization=request.headers.get("Authorization"),
         amount="0.001",
-        chain_id=TESTNET_CHAIN_ID,
     )
 
     if isinstance(result, Challenge):
@@ -60,7 +59,7 @@ async def paid_endpoint(request: Request):
 
 
 @app.get("/paid-decorator")
-@server.pay(amount="0.001", chain_id=TESTNET_CHAIN_ID)
+@server.pay(amount="0.001")
 async def paid_decorator_endpoint(request: Request, credential: Credential, receipt: Receipt):
     """A paid endpoint using the server.pay() decorator."""
     return {

--- a/examples/custom-intents.md
+++ b/examples/custom-intents.md
@@ -119,8 +119,8 @@ from mpp.server import VerificationError
 class MultiMethodIntent:
     name = "charge"
 
-    def __init__(self, tempo_rpc: str, stripe_key: str):
-        self.tempo = ChargeIntent(rpc_url=tempo_rpc)
+    def __init__(self, tempo_chain_id: int, stripe_key: str):
+        self.tempo = ChargeIntent(rpc_url=rpc_url_for_chain(tempo_chain_id))
         self.stripe = StripeChargeIntent(api_key=stripe_key)
 
     async def verify(self, credential: Credential, request: dict) -> Receipt:

--- a/examples/mcp-server/server_decorator.py
+++ b/examples/mcp-server/server_decorator.py
@@ -7,7 +7,6 @@ Usage:
     python server_decorator.py
 
 Environment:
-    TEMPO_RPC_URL: Tempo RPC endpoint (default: https://rpc.testnet.tempo.xyz/)
     DESTINATION_ADDRESS: Payment recipient address (required)
     MCP_PORT: Port for SSE server (default: 8000)
 """
@@ -30,16 +29,15 @@ from mpp.extensions.mcp import (
     verify_or_challenge,
 )
 from mpp.methods.tempo import ChargeIntent
-from mpp.methods.tempo._defaults import PATH_USD, TESTNET_CHAIN_ID, TESTNET_RPC_URL
+from mpp.methods.tempo._defaults import PATH_USD, TESTNET_CHAIN_ID, rpc_url_for_chain
 
-RPC_URL = os.environ.get("TEMPO_RPC_URL", TESTNET_RPC_URL)
 DESTINATION = os.environ.get("DESTINATION_ADDRESS", "")
 PORT = int(os.environ.get("MCP_PORT", "8000"))
 
 if not DESTINATION:
     raise ValueError("DESTINATION_ADDRESS environment variable is required")
 
-intent = ChargeIntent(rpc_url=RPC_URL)
+intent = ChargeIntent(rpc_url=rpc_url_for_chain(TESTNET_CHAIN_ID))
 server = Server("paid-echo-server")
 sse = SseServerTransport("/messages/")
 

--- a/examples/mcp-server/server_manual.py
+++ b/examples/mcp-server/server_manual.py
@@ -8,7 +8,6 @@ Usage:
     python server_manual.py
 
 Environment:
-    TEMPO_RPC_URL: Tempo RPC endpoint (default: https://rpc.testnet.tempo.xyz/)
     DESTINATION_ADDRESS: Payment recipient address (required)
     MCP_PORT: Port for SSE server (default: 8000)
 """
@@ -32,16 +31,15 @@ from mpp.extensions.mcp import (
     verify_or_challenge,
 )
 from mpp.methods.tempo import ChargeIntent
-from mpp.methods.tempo._defaults import PATH_USD, TESTNET_CHAIN_ID, TESTNET_RPC_URL
+from mpp.methods.tempo._defaults import PATH_USD, TESTNET_CHAIN_ID, rpc_url_for_chain
 
-RPC_URL = os.environ.get("TEMPO_RPC_URL", TESTNET_RPC_URL)
 DESTINATION = os.environ.get("DESTINATION_ADDRESS", "")
 PORT = int(os.environ.get("MCP_PORT", "8000"))
 
 if not DESTINATION:
     raise ValueError("DESTINATION_ADDRESS environment variable is required")
 
-intent = ChargeIntent(rpc_url=RPC_URL)
+intent = ChargeIntent(rpc_url=rpc_url_for_chain(TESTNET_CHAIN_ID))
 server = Server("paid-echo-server-manual")
 sse = SseServerTransport("/messages/")
 

--- a/src/mpp/extensions/mcp/verify.py
+++ b/src/mpp/extensions/mcp/verify.py
@@ -95,7 +95,7 @@ async def verify_or_challenge(
         meta = params.get("_meta", {})
         result = await verify_or_challenge(
             meta=meta,
-            intent=ChargeIntent(rpc_url="..."),
+            intent=intent,  # ChargeIntent with rpc_url set by tempo()
             request={"amount": "1000", "currency": "0x...", "recipient": "0x..."},
             realm="api.example.com",
             secret_key="my-server-secret",

--- a/src/mpp/methods/tempo/__init__.py
+++ b/src/mpp/methods/tempo/__init__.py
@@ -15,15 +15,15 @@ Example:
     )
 
     # Server-side
-    from mpp.server import verify_or_challenge
-    from mpp.methods.tempo import ChargeIntent
+    from mpp.server import Mpp
+    from mpp.methods.tempo import tempo, ChargeIntent
+    from mpp.methods.tempo._defaults import TESTNET_CHAIN_ID
 
-    intent = ChargeIntent(rpc_url="https://rpc.tempo.xyz")
-    result = await verify_or_challenge(
-        authorization=request.headers.get("Authorization"),
-        intent=intent,
-        request={"amount": "1000", ...},
-        realm="api.example.com",
+    server = Mpp.create(
+        method=tempo(
+            chain_id=TESTNET_CHAIN_ID,
+            intents={"charge": ChargeIntent()},
+        ),
     )
 """
 

--- a/src/mpp/methods/tempo/_defaults.py
+++ b/src/mpp/methods/tempo/_defaults.py
@@ -6,10 +6,37 @@ RPC_URL = "https://rpc.tempo.xyz"
 PATH_USD = "0x20c0000000000000000000000000000000000000"
 PATH_USD_DECIMALS = 6
 
-# Testnet
+# Testnet (Moderato)
 TESTNET_CHAIN_ID = 42431
 TESTNET_RPC_URL = "https://rpc.testnet.tempo.xyz"
 ESCROW_CONTRACT = "0x9d136eEa063eDE5418A6BC7bEafF009bBb6CFa70"
+
+# Chain ID → RPC URL mapping
+RPC_URLS: dict[int, str] = {
+    CHAIN_ID: RPC_URL,
+    TESTNET_CHAIN_ID: TESTNET_RPC_URL,
+}
+
+
+def rpc_url_for_chain(chain_id: int) -> str:
+    """Resolve the default RPC URL for a chain ID.
+
+    Args:
+        chain_id: Tempo chain ID (4217 for mainnet, 42431 for testnet).
+
+    Returns:
+        The default RPC URL for the given chain ID.
+
+    Raises:
+        ValueError: If the chain ID is not recognized.
+    """
+    url = RPC_URLS.get(chain_id)
+    if url is None:
+        raise ValueError(
+            f"Unknown chain ID {chain_id}. Known chains: {', '.join(str(c) for c in RPC_URLS)}"
+        )
+    return url
+
 
 # Testnet only — the fee payer service sponsors gas on testnet.
 # On mainnet, the server itself must pay gas or provide its own fee payer.

--- a/src/mpp/methods/tempo/client.py
+++ b/src/mpp/methods/tempo/client.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 
 from mpp import Challenge, Credential
 from mpp.methods.tempo._attribution import encode as encode_attribution
-from mpp.methods.tempo._defaults import RPC_URL
+from mpp.methods.tempo._defaults import CHAIN_ID, rpc_url_for_chain
 from mpp.methods.tempo._rpc import get_tx_params
 
 if TYPE_CHECKING:
@@ -43,7 +43,7 @@ class TempoMethod:
         from mpp.methods.tempo import tempo, TempoAccount
 
         account = TempoAccount.from_key("0x...")
-        method = tempo(account=account, rpc_url="https://rpc.tempo.xyz")
+        method = tempo(account=account, chain_id=42431)
 
         # Use with client
         from mpp.client import get
@@ -53,7 +53,8 @@ class TempoMethod:
     name: str = "tempo"
     account: TempoAccount | None = None
     root_account: str | None = None
-    rpc_url: str = RPC_URL
+    chain_id: int = CHAIN_ID
+    rpc_url: str | None = None
     currency: str | None = None
     recipient: str | None = None
     decimals: int = 6
@@ -148,7 +149,8 @@ class TempoMethod:
         else:
             transfer_data = self._encode_transfer(recipient, int(amount))
 
-        chain_id, nonce, gas_price = await get_tx_params(self.rpc_url, self.account.address)
+        resolved_rpc = self.rpc_url or rpc_url_for_chain(self.chain_id)
+        chain_id, nonce, gas_price = await get_tx_params(resolved_rpc, self.account.address)
 
         tx = TempoTransaction.create(
             chain_id=chain_id,
@@ -198,7 +200,8 @@ class TempoMethod:
 def tempo(
     intents: dict[str, Intent],
     account: TempoAccount | None = None,
-    rpc_url: str = RPC_URL,
+    chain_id: int = CHAIN_ID,
+    rpc_url: str | None = None,
     root_account: str | None = None,
     currency: str | None = None,
     recipient: str | None = None,
@@ -210,7 +213,9 @@ def tempo(
     Args:
         intents: Intents to register (e.g. charge).
         account: Account for signing transactions.
-        rpc_url: Tempo RPC endpoint URL.
+        chain_id: Tempo chain ID (default: 4217 mainnet). Determines the
+            default RPC URL. Use 42431 for testnet (Moderato).
+        rpc_url: Override the default RPC URL for the chain.
         root_account: Root account address for access key signing.
         currency: Default currency address for charges.
         recipient: Default recipient address for charges.
@@ -222,13 +227,16 @@ def tempo(
 
     Example:
         from mpp.methods.tempo import ChargeIntent
+        from mpp.methods.tempo._defaults import TESTNET_CHAIN_ID
 
         method = tempo(
+            chain_id=TESTNET_CHAIN_ID,
             intents={"charge": ChargeIntent()},
         )
     """
     method = TempoMethod(
         account=account,
+        chain_id=chain_id,
         rpc_url=rpc_url,
         root_account=root_account,
         currency=currency,
@@ -236,5 +244,9 @@ def tempo(
         decimals=decimals,
         client_id=client_id,
     )
+    resolved_rpc = rpc_url or rpc_url_for_chain(chain_id)
+    for intent in intents.values():
+        if hasattr(intent, "rpc_url") and intent.rpc_url is None:
+            intent.rpc_url = resolved_rpc
     method._intents = dict(intents)
     return method

--- a/src/mpp/methods/tempo/intents.py
+++ b/src/mpp/methods/tempo/intents.py
@@ -10,7 +10,7 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
 from mpp import Credential, Receipt
-from mpp.methods.tempo._defaults import DEFAULT_FEE_PAYER_URL, RPC_URL
+from mpp.methods.tempo._defaults import DEFAULT_FEE_PAYER_URL
 from mpp.methods.tempo.schemas import (
     ChargeRequest,
     CredentialPayload,
@@ -62,37 +62,38 @@ class ChargeIntent:
 
     Verifies that a payment transaction matches the requested parameters.
 
+    When used via ``tempo()``, the ``rpc_url`` is propagated automatically
+    from the method level. You can also pass it directly for standalone use.
+
     This class manages an HTTP client lifecycle. Use as an async context manager
     for automatic cleanup, or call `aclose()` explicitly when done.
 
     Example:
-        from mpp.methods.tempo import ChargeIntent
+        from mpp.methods.tempo import tempo, ChargeIntent
 
-        # As context manager (recommended)
-        async with ChargeIntent(rpc_url="https://rpc.tempo.xyz") as intent:
-            receipt = await intent.verify(
-                credential=Credential(id="...", payload={"type": "hash", ...}),
-                request={"amount": "1000", "currency": "0x...", ...},
-            )
+        # rpc_url propagated from tempo()
+        method = tempo(
+            rpc_url="https://rpc.tempo.xyz",
+            intents={"charge": ChargeIntent()},
+        )
 
-        # Or with external client
-        async with httpx.AsyncClient() as client:
-            intent = ChargeIntent(rpc_url="...", http_client=client)
-            receipt = await intent.verify(...)
+        # Or standalone
+        intent = ChargeIntent(rpc_url="https://rpc.tempo.xyz")
     """
 
     name = "charge"
 
     def __init__(
         self,
-        rpc_url: str = RPC_URL,
+        rpc_url: str | None = None,
         http_client: httpx.AsyncClient | None = None,
         timeout: float = DEFAULT_TIMEOUT,
     ) -> None:
         """Initialize the charge intent.
 
         Args:
-            rpc_url: Tempo RPC endpoint URL.
+            rpc_url: Tempo RPC endpoint URL. If not set, will be inherited
+                from the ``tempo()`` factory.
             http_client: Optional httpx client for making RPC calls. If provided,
                 the caller is responsible for closing it.
             timeout: Request timeout in seconds (default: 30).
@@ -401,7 +402,6 @@ class ChargeIntent:
             raise VerificationError("Transaction contains no calls")
 
         expected_memo = request.methodDetails.memo
-        expected_selector = TRANSFER_WITH_MEMO_SELECTOR if expected_memo else TRANSFER_SELECTOR
 
         for call_item in calls_data:
             if not isinstance(call_item, (list, tuple)) or len(call_item) < 3:
@@ -431,7 +431,11 @@ class ChargeIntent:
                 continue
 
             selector = call_data[:8].lower()
-            if selector != expected_selector:
+
+            if expected_memo:
+                if selector != TRANSFER_WITH_MEMO_SELECTOR:
+                    continue
+            elif selector not in (TRANSFER_SELECTOR, TRANSFER_WITH_MEMO_SELECTOR):
                 continue
 
             if len(call_data) < 136:

--- a/src/mpp/server/mpp.py
+++ b/src/mpp/server/mpp.py
@@ -118,7 +118,7 @@ class Mpp:
             description: Optional human-readable description.
             memo: Optional 32-byte memo (hex string) for transferWithMemo.
             fee_payer: Whether to use a fee payer for gas sponsorship.
-            chain_id: Override the default chain ID (e.g., 42431 for moderato).
+            chain_id: Override the method's chain ID for this request.
 
         Returns:
             Challenge if payment required, or (Credential, Receipt) if verified.
@@ -137,6 +137,10 @@ class Mpp:
         if expires is None:
             expires = (datetime.now(UTC) + timedelta(seconds=DEFAULT_EXPIRY_SECONDS)).isoformat()
 
+        resolved_chain_id = chain_id
+        if resolved_chain_id is None:
+            resolved_chain_id = getattr(self.method, "chain_id", None)
+
         decimals = getattr(self.method, "decimals", DEFAULT_DECIMALS)
         base_amount = str(parse_units(amount, decimals))
 
@@ -147,14 +151,14 @@ class Mpp:
             "expires": expires,
         }
 
-        if memo or fee_payer or chain_id is not None:
-            method_details: dict[str, Any] = {}
-            if chain_id is not None:
-                method_details["chainId"] = chain_id
-            if memo:
-                method_details["memo"] = memo
-            if fee_payer:
-                method_details["feePayer"] = True
+        method_details: dict[str, Any] = {}
+        if resolved_chain_id is not None:
+            method_details["chainId"] = resolved_chain_id
+        if memo:
+            method_details["memo"] = memo
+        if fee_payer:
+            method_details["feePayer"] = True
+        if method_details:
             request["methodDetails"] = method_details
 
         return await verify_or_challenge(
@@ -196,7 +200,7 @@ class Mpp:
             recipient: Override the method's default recipient.
             description: Optional human-readable description.
             expires_in: Challenge validity duration. Defaults to 5 minutes.
-            chain_id: Override the default chain ID (e.g., 42431 for moderato).
+            chain_id: Override the method's chain ID for this request.
 
         Example:
             server = Mpp.create(method=tempo(currency=..., recipient=...))
@@ -242,8 +246,12 @@ class Mpp:
                 }
                 if expires is not None:
                     request["expires"] = expires
-                if chain_id is not None:
-                    request["methodDetails"] = {"chainId": chain_id}
+
+                resolved_chain_id = chain_id
+                if resolved_chain_id is None:
+                    resolved_chain_id = getattr(self.method, "chain_id", None)
+                if resolved_chain_id is not None:
+                    request["methodDetails"] = {"chainId": resolved_chain_id}
 
                 return await verify_or_challenge(
                     authorization=authorization,

--- a/tests/test_tempo.py
+++ b/tests/test_tempo.py
@@ -71,16 +71,46 @@ class TestTempoMethod:
         assert method.name == "tempo"
 
     def test_tempo_with_account(self) -> None:
-        """tempo() should accept account and rpc_url."""
+        """tempo() should accept account and chain_id."""
         key = "0x" + "d" * 64
         account = TempoAccount.from_key(key)
         method = tempo(
             account=account,
-            rpc_url="https://custom.rpc",
-            intents={"charge": ChargeIntent(rpc_url="https://custom.rpc")},
+            chain_id=42431,
+            intents={"charge": ChargeIntent()},
         )
         assert method.account == account
+        assert method.chain_id == 42431
+
+    def test_tempo_propagates_rpc_url_to_intents(self) -> None:
+        """tempo() should resolve rpc_url from chain_id and propagate to intents."""
+        intent = ChargeIntent()
+        assert intent.rpc_url is None
+        method = tempo(
+            chain_id=42431,
+            intents={"charge": intent},
+        )
+        assert method.intents["charge"].rpc_url == "https://rpc.testnet.tempo.xyz"
+
+    def test_tempo_does_not_override_explicit_intent_rpc_url(self) -> None:
+        """tempo() should not override an intent's explicitly-set rpc_url."""
+        intent = ChargeIntent(rpc_url="https://custom.rpc")
+        method = tempo(
+            chain_id=42431,
+            intents={"charge": intent},
+        )
+        assert method.intents["charge"].rpc_url == "https://custom.rpc"
+
+    def test_tempo_rpc_url_override(self) -> None:
+        """tempo() rpc_url should override the chain_id default."""
+        intent = ChargeIntent()
+        method = tempo(
+            chain_id=4217,
+            rpc_url="https://custom.rpc",
+            intents={"charge": intent},
+        )
         assert method.rpc_url == "https://custom.rpc"
+        assert method.intents["charge"].rpc_url == "https://custom.rpc"
 
     def test_intents_property(self) -> None:
         """Should have only the intents explicitly provided."""
@@ -128,21 +158,24 @@ class TestChargeIntent:
     @pytest.mark.asyncio
     async def test_context_manager(self) -> None:
         """Should work as async context manager."""
-        async with ChargeIntent(rpc_url="https://rpc.test") as intent:
+        intent = ChargeIntent()
+        intent.rpc_url = "https://rpc.test"
+        async with intent:
             assert intent.name == "charge"
 
     @pytest.mark.asyncio
     async def test_external_client(self) -> None:
         """Should accept external HTTP client."""
         mock_client = AsyncMock(spec=httpx.AsyncClient)
-        intent = ChargeIntent(rpc_url="https://rpc.test", http_client=mock_client)
+        intent = ChargeIntent(http_client=mock_client)
         assert intent._owns_client is False
         await intent.aclose()
 
     @pytest.mark.asyncio
     async def test_verify_expired_request(self) -> None:
         """Should reject expired requests."""
-        intent = ChargeIntent(rpc_url="https://rpc.test")
+        intent = ChargeIntent()
+        intent.rpc_url = "https://rpc.test"
         credential = make_credential(payload={"type": "hash", "hash": "0x123"})
         expired = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
 
@@ -160,7 +193,8 @@ class TestChargeIntent:
     @pytest.mark.asyncio
     async def test_verify_invalid_payload(self) -> None:
         """Should reject invalid credential payload."""
-        intent = ChargeIntent(rpc_url="https://rpc.test")
+        intent = ChargeIntent()
+        intent.rpc_url = "https://rpc.test"
         credential = make_credential(payload="not-a-dict")
         future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
 
@@ -178,7 +212,8 @@ class TestChargeIntent:
     @pytest.mark.asyncio
     async def test_verify_unknown_credential_type(self) -> None:
         """Should reject unknown credential types."""
-        intent = ChargeIntent(rpc_url="https://rpc.test")
+        intent = ChargeIntent()
+        intent.rpc_url = "https://rpc.test"
         credential = make_credential(payload={"type": "unknown"})
         future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
 
@@ -197,7 +232,8 @@ class TestChargeIntent:
     async def test_verify_hash_success(self) -> None:
         """Should verify hash credential with matching transfer logs."""
         future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
-        intent = ChargeIntent(rpc_url="https://rpc.test")
+        intent = ChargeIntent()
+        intent.rpc_url = "https://rpc.test"
 
         mock_client = AsyncMock()
         transfer_topic = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
@@ -246,7 +282,8 @@ class TestChargeIntent:
     async def test_verify_hash_tx_not_found(self) -> None:
         """Should reject when transaction not found."""
         future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
-        intent = ChargeIntent(rpc_url="https://rpc.test")
+        intent = ChargeIntent()
+        intent.rpc_url = "https://rpc.test"
 
         mock_client = AsyncMock()
         mock_client.post = AsyncMock(
@@ -270,7 +307,8 @@ class TestChargeIntent:
     async def test_verify_hash_tx_failed(self) -> None:
         """Should raise VerificationError for failed transaction."""
         future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
-        intent = ChargeIntent(rpc_url="https://rpc.test")
+        intent = ChargeIntent()
+        intent.rpc_url = "https://rpc.test"
 
         mock_client = AsyncMock()
         mock_client.post = AsyncMock(
@@ -297,7 +335,8 @@ class TestChargeIntent:
     async def test_verify_hash_no_matching_logs(self) -> None:
         """Should reject when no matching transfer logs."""
         future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
-        intent = ChargeIntent(rpc_url="https://rpc.test")
+        intent = ChargeIntent()
+        intent.rpc_url = "https://rpc.test"
 
         mock_client = AsyncMock()
         mock_client.post = AsyncMock(
@@ -324,7 +363,8 @@ class TestChargeIntent:
     async def test_verify_transaction_success(self) -> None:
         """Should verify transaction credential with matching transfer logs."""
         future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
-        intent = ChargeIntent(rpc_url="https://rpc.test")
+        intent = ChargeIntent()
+        intent.rpc_url = "https://rpc.test"
 
         asset = "0x1234567890123456789012345678901234567890"
         destination = "0x4567890123456789012345678901234567890123"
@@ -374,7 +414,8 @@ class TestChargeIntent:
     async def test_verify_transaction_rpc_error(self) -> None:
         """Should raise on RPC error."""
         future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
-        intent = ChargeIntent(rpc_url="https://rpc.test")
+        intent = ChargeIntent()
+        intent.rpc_url = "https://rpc.test"
 
         mock_client = AsyncMock()
         mock_client.post = AsyncMock(
@@ -407,8 +448,9 @@ class TestSponsoredTransfer:
         account = TempoAccount.from_key(TEST_PRIVATE_KEY)
         method = tempo(
             account=account,
+            chain_id=4217,
             rpc_url="https://rpc.test",
-            intents={"charge": ChargeIntent(rpc_url="https://rpc.test")},
+            intents={"charge": ChargeIntent()},
         )
 
         httpx_mock.add_response(
@@ -482,7 +524,8 @@ class TestSponsoredTransfer:
             },
         )
 
-        intent = ChargeIntent(rpc_url="https://rpc.test")
+        intent = ChargeIntent()
+        intent.rpc_url = "https://rpc.test"
         credential = make_credential(
             payload={"type": "transaction", "signature": "0x76abcdef"},
         )
@@ -518,7 +561,8 @@ class TestSponsoredTransfer:
             },
         )
 
-        intent = ChargeIntent(rpc_url="https://rpc.test")
+        intent = ChargeIntent()
+        intent.rpc_url = "https://rpc.test"
         credential = make_credential(
             payload={"type": "transaction", "signature": "0x76abcdef"},
         )


### PR DESCRIPTION
## Summary

Replace `rpc_url` with `chain_id` as the primary configuration parameter. The RPC URL is now resolved automatically from a `chain_id → URL` mapping (`4217` → mainnet, `42431` → testnet), matching the pattern used in **mppx**. `rpc_url` remains available as an optional override.

## Motivation

Users had to import and pass raw RPC URLs and `chain_id` separately, leading to misconfiguration (e.g., testnet account hitting mainnet RPC → 401). The mppx TypeScript SDK already resolves RPC URLs from chain IDs via a map — this brings pympp in line.

## API

```python
# Testnet — just set chain_id
server = Mpp.create(
    method=tempo(
        chain_id=TESTNET_CHAIN_ID,
        currency=PATH_USD,
        recipient=DESTINATION,
        intents={"charge": ChargeIntent()},
    ),
)

# Mainnet — default, nothing to configure
server = Mpp.create(
    method=tempo(
        currency=PATH_USD,
        recipient=DESTINATION,
        intents={"charge": ChargeIntent()},
    ),
)

# Custom RPC override
method = tempo(chain_id=4217, rpc_url="https://my-node.example.com", ...)

# Standalone ChargeIntent (e.g. MCP servers)
intent = ChargeIntent(rpc_url=rpc_url_for_chain(TESTNET_CHAIN_ID))
```

## Changes

- **`_defaults.py`**: Added `RPC_URLS` mapping and `rpc_url_for_chain()` resolver
- **`tempo()`**: Takes `chain_id` (default: 4217) as primary param, `rpc_url` as optional override. Propagates resolved URL to intents.
- **`Mpp.charge()` / `Mpp.pay()`**: Inherit `chain_id` from the method — no need to pass per-call
- **`ChargeIntent`**: Still accepts `rpc_url` directly for standalone use
- Updated all examples, docstrings, and tests
- 209 tests passing