### PR TITLE
chore: use changelogs python-version input

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,13 +19,10 @@ jobs:
         with:
           persist-credentials: true
 
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-
       - uses: wevm/changelogs@master
         with:
           ecosystem: python
+          python-version: '3.12'
           pypi-token: ${{ secrets.PYPI_TOKEN }}
           conventional-commit: true
         env:


### PR DESCRIPTION
Use the new `python-version` input on `wevm/changelogs@master` instead of a separate `actions/setup-python` step. The action now handles Python setup internally.