### PR TITLE
fix: client imports no longer pull in server dependencies

### DIFF
--- a/.changelog/lively-horses-nod.md
+++ b/.changelog/lively-horses-nod.md
@@ -1,0 +1,5 @@
+---
+pympp: patch
+---
+
+Moved `VerificationError` from `mpp.server.intent` to `mpp.errors` so that client-only imports no longer transitively load server dependencies. Added a re-export shim in `mpp.server.intent` for backwards compatibility and added import isolation tests to enforce the invariant.

--- a/src/mpp/errors.py
+++ b/src/mpp/errors.py
@@ -151,3 +151,7 @@ class PaymentActionRequiredError(PaymentError):
     def __init__(self, reason: str | None = None) -> None:
         msg = f"Payment requires action: {reason}." if reason else "Payment requires action."
         super().__init__(msg)
+
+
+class VerificationError(Exception):
+    """Payment verification failed."""

--- a/src/mpp/methods/tempo/intents.py
+++ b/src/mpp/methods/tempo/intents.py
@@ -17,7 +17,7 @@ from mpp.methods.tempo.schemas import (
     HashCredentialPayload,
     TransactionCredentialPayload,
 )
-from mpp.server.intent import VerificationError
+from mpp.errors import VerificationError
 
 if TYPE_CHECKING:
     import httpx

--- a/src/mpp/server/intent.py
+++ b/src/mpp/server/intent.py
@@ -13,8 +13,7 @@ if TYPE_CHECKING:
     from mpp import Credential, Receipt
 
 
-class VerificationError(Exception):
-    """Payment verification failed."""
+from mpp.errors import VerificationError as VerificationError  # noqa: F401 — re-export
 
 
 @runtime_checkable

--- a/tests/test_import_isolation.py
+++ b/tests/test_import_isolation.py
@@ -1,0 +1,55 @@
+"""Tests that client-only imports don't pull in server-only modules.
+
+The pympp[tempo] extra must work without the [server] extra installed.
+Rather than blocking individual packages, we assert the real invariant:
+client/method imports must never cause mpp.server to be loaded.
+"""
+
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+# Modules that a client-only install should be able to import.
+CLIENT_MODULES = [
+    "mpp",
+    "mpp.client",
+    "mpp.methods.tempo",
+    "mpp.methods.tempo.client",
+    "mpp.methods.tempo.intents",
+]
+
+# Modules that must NOT be loaded as a side-effect of the above imports.
+# mpp.server pulls in python-dotenv, pydantic, starlette, etc.
+SERVER_ONLY_MODULES = [
+    "mpp.server",
+    "mpp.server.mpp",
+    "mpp.server.decorator",
+    "mpp.server._defaults",
+]
+
+
+@pytest.mark.parametrize("client_module", CLIENT_MODULES)
+def test_client_import_does_not_load_server(client_module: str) -> None:
+    """Importing a client module must not transitively load mpp.server.*."""
+    script = textwrap.dedent(f"""\
+        import importlib, sys, json
+        importlib.import_module("{client_module}")
+        leaked = [m for m in {SERVER_ONLY_MODULES!r} if m in sys.modules]
+        print(json.dumps(leaked))
+    """)
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"Import of {client_module} crashed:\n{result.stderr.strip()}"
+    )
+    import json
+
+    leaked = json.loads(result.stdout.strip())
+    assert leaked == [], (
+        f"Importing {client_module} pulled in server modules: {leaked}"
+    )


### PR DESCRIPTION
## Problem

`pympp[tempo]` (client-only install, without `pympp[server]`) crashed on import:

```
ModuleNotFoundError: No module named 'dotenv'
```

**Root cause:** `mpp.methods.tempo.intents` imported `VerificationError` from `mpp.server.intent`, which triggered the full `mpp.server.__init__` → `mpp.server.decorator` → `mpp.server._defaults` → `python-dotenv` import chain.

## Fix

- Move `VerificationError` to `mpp.errors` (zero heavy dependencies)
- Re-export from `mpp.server.intent` for backwards compatibility
- Update `mpp.methods.tempo.intents` to import from `mpp.errors` directly

## Guard

Adds `test_import_isolation.py` — spawns a subprocess for each client module and asserts that `mpp.server.*` never appears in `sys.modules`. This catches any future import graph leaks regardless of which specific server dependency is involved.