### PR TITLE
fix: sort imports to satisfy ruff I001

### DIFF
--- a/.changelog/nice-sharks-sing.md
+++ b/.changelog/nice-sharks-sing.md
@@ -1,0 +1,5 @@
+---
+pympp: patch
+---
+
+Sorted imports to satisfy ruff I001 linting rules in `src/mpp/methods/tempo/intents.py`.

--- a/src/mpp/methods/tempo/intents.py
+++ b/src/mpp/methods/tempo/intents.py
@@ -10,6 +10,7 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
 from mpp import Credential, Receipt
+from mpp.errors import VerificationError
 from mpp.methods.tempo._defaults import DEFAULT_FEE_PAYER_URL, rpc_url_for_chain
 from mpp.methods.tempo.schemas import (
     ChargeRequest,
@@ -17,7 +18,6 @@ from mpp.methods.tempo.schemas import (
     HashCredentialPayload,
     TransactionCredentialPayload,
 )
-from mpp.errors import VerificationError
 
 if TYPE_CHECKING:
     import httpx


### PR DESCRIPTION
Fixes CI on main — the `from mpp.errors import VerificationError` line in `intents.py` was out of isort order.