### PR TITLE
chore: remove release environment and debug step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,6 @@ jobs:
   release:
     name: Version
     runs-on: ubuntu-latest
-    environment: release
     permissions:
       contents: write
       pull-requests: write
@@ -18,20 +17,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: true
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-
-      - name: Debug twine upload
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-        run: |
-          pip install build twine
-          python -m build
-          ls -la dist/
-          twine upload dist/*
 
       - uses: wevm/changelogs@master
         with:


### PR DESCRIPTION
Removes the `environment: release` requirement and the temporary debug twine upload step.