### PR TITLE
feat: add integration tests against real Tempo node

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install lint fix format format-check test check all
+.PHONY: install lint fix format format-check test test-integration node node-stop check all
 
 install:
 	uv sync --all-extras --dev
@@ -18,6 +18,25 @@ format-check:
 
 test:
 	uv run pytest -v
+
+test-integration:
+	TEMPO_RPC_URL=http://localhost:8545 uv run pytest -m integration -v
+
+node:
+	docker compose up -d
+	@echo "Waiting for Tempo node..."
+	@for i in $$(seq 1 30); do \
+		if curl -sf -X POST -H 'Content-Type: application/json' \
+			-d '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}' \
+			http://localhost:8545 > /dev/null 2>&1; then \
+			echo "Tempo node ready"; exit 0; \
+		fi; \
+		sleep 2; \
+	done; \
+	echo "Tempo node failed to start"; docker compose logs tempo; exit 1
+
+node-stop:
+	docker compose down
 
 check: lint format-check test
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+services:
+  tempo:
+    image: ghcr.io/tempoxyz/tempo:latest
+    ports:
+      - "8545:8545"
+    command: >
+      node
+      --dev
+      --dev.block-time 200ms
+      --http
+      --http.addr 0.0.0.0
+      --http.port 8545
+      --http.api all
+      --http.corsdomain '*'
+      --engine.legacy-state-root
+      --engine.disable-precompile-cache
+      --faucet.enabled
+      --faucet.private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
+      --faucet.amount 1000000000
+      --faucet.address 0x20c0000000000000000000000000000000000000
+      --faucet.address 0x20c0000000000000000000000000000000000001
+      --faucet.address 0x20c0000000000000000000000000000000000002
+      --faucet.address 0x20c0000000000000000000000000000000000003
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf -X POST -H 'Content-Type: application/json' -d '{\"jsonrpc\":\"2.0\",\"method\":\"eth_chainId\",\"params\":[],\"id\":1}' http://localhost:8545 || exit 1"]
+      interval: 2s
+      timeout: 5s
+      retries: 15

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,3 +75,4 @@ typeCheckingMode = "standard"
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
+markers = ["integration: requires TEMPO_RPC_URL (real Tempo node)"]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,12 +1,20 @@
 """mpp test suite."""
 
+import os
 from typing import Any
+
+import pytest
 
 from mpp import Challenge, ChallengeEcho, Credential, _b64url_encode
 
 # Default secret used by tests when calling verify_or_challenge
 TEST_SECRET = "test-secret"
 TEST_REALM = "test.example.com"
+
+INTEGRATION = pytest.mark.skipif(
+    not os.environ.get("TEMPO_RPC_URL"),
+    reason="TEMPO_RPC_URL not set (no local node)",
+)
 
 
 def make_credential(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import os
+import time
+
+import httpx
+import pytest
+
+from mpp.methods.tempo import TempoAccount
+from mpp.methods.tempo._defaults import PATH_USD
+from mpp.methods.tempo.intents import ChargeIntent
+
+# Standard dev key pre-funded on --dev nodes
+DEV_PRIVATE_KEY = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+
+
+@pytest.fixture(scope="session")
+def rpc_url():
+    return os.environ["TEMPO_RPC_URL"]
+
+
+@pytest.fixture(scope="session")
+def is_local_node(rpc_url):
+    return "localhost" in rpc_url or "127.0.0.1" in rpc_url
+
+
+@pytest.fixture(scope="session")
+def chain_id(rpc_url):
+    with httpx.Client(timeout=30) as client:
+        resp = client.post(
+            rpc_url,
+            json={"jsonrpc": "2.0", "method": "eth_chainId", "params": [], "id": 1},
+        )
+        return int(resp.json()["result"], 16)
+
+
+@pytest.fixture(scope="session")
+def currency():
+    if os.environ.get("TEMPO_CURRENCY"):
+        return os.environ["TEMPO_CURRENCY"]
+    return PATH_USD
+
+
+@pytest.fixture
+def charge_intent(rpc_url):
+    return ChargeIntent(rpc_url=rpc_url)
+
+
+def _tip20_balance(rpc_url: str, token: str, address: str, client: httpx.Client) -> int:
+    call_data = "0x70a08231" + "0" * 24 + address[2:].lower()
+    resp = client.post(
+        rpc_url,
+        json={
+            "jsonrpc": "2.0",
+            "method": "eth_call",
+            "params": [{"to": token, "data": call_data}, "latest"],
+            "id": 1,
+        },
+    )
+    return int(resp.json()["result"], 16)
+
+
+def _fund_account_via_dev_key(rpc_url: str, address: str, currency: str, amount: int) -> None:
+    """Fund an account by sending tokens from the pre-funded dev account."""
+    from pytempo import Call, TempoTransaction
+
+    dev_account = TempoAccount.from_key(DEV_PRIVATE_KEY)
+
+    with httpx.Client(timeout=30) as client:
+        chain_id_hex = client.post(
+            rpc_url,
+            json={"jsonrpc": "2.0", "method": "eth_chainId", "params": [], "id": 1},
+        ).json()["result"]
+        nonce_hex = client.post(
+            rpc_url,
+            json={
+                "jsonrpc": "2.0",
+                "method": "eth_getTransactionCount",
+                "params": [dev_account.address, "pending"],
+                "id": 1,
+            },
+        ).json()["result"]
+        gas_hex = client.post(
+            rpc_url,
+            json={"jsonrpc": "2.0", "method": "eth_gasPrice", "params": [], "id": 1},
+        ).json()["result"]
+
+    cid = int(chain_id_hex, 16)
+    nonce = int(nonce_hex, 16)
+    gas_price = int(gas_hex, 16)
+
+    selector = "a9059cbb"
+    to_padded = address[2:].lower().zfill(64)
+    amount_padded = hex(amount)[2:].zfill(64)
+    data = f"0x{selector}{to_padded}{amount_padded}"
+
+    tx = TempoTransaction.create(
+        chain_id=cid,
+        gas_limit=5_000_000,
+        max_fee_per_gas=gas_price,
+        max_priority_fee_per_gas=gas_price,
+        nonce=nonce,
+        nonce_key=0,
+        fee_token=currency,
+        calls=(Call.create(to=currency, value=0, data=data),),
+    )
+    signed = tx.sign(dev_account.private_key)
+    raw_tx = "0x" + signed.encode().hex()
+
+    with httpx.Client(timeout=30) as client:
+        resp = client.post(
+            rpc_url,
+            json={
+                "jsonrpc": "2.0",
+                "method": "eth_sendRawTransaction",
+                "params": [raw_tx],
+                "id": 1,
+            },
+        )
+        result = resp.json()
+        if "error" in result:
+            raise RuntimeError(f"Fund transfer failed: {result['error']}")
+        tx_hash = result["result"]
+
+        for _ in range(120):
+            resp = client.post(
+                rpc_url,
+                json={
+                    "jsonrpc": "2.0",
+                    "method": "eth_getTransactionReceipt",
+                    "params": [tx_hash],
+                    "id": 1,
+                },
+            )
+            receipt = resp.json().get("result")
+            if receipt is not None:
+                if receipt.get("status") != "0x1":
+                    raise RuntimeError(f"Fund transfer reverted: {tx_hash}")
+                return
+            time.sleep(0.5)
+    raise RuntimeError(f"Fund transfer receipt not found: {tx_hash}")
+
+
+def _fund_account(rpc_url: str, address: str, currency: str) -> None:
+    """Fund an account using tempo_fundAddress if available, else dev key transfer."""
+    with httpx.Client(timeout=30) as client:
+        resp = client.post(
+            rpc_url,
+            json={
+                "jsonrpc": "2.0",
+                "method": "tempo_fundAddress",
+                "params": [address],
+                "id": 1,
+            },
+        )
+        result = resp.json()
+        if "error" not in result:
+            for _ in range(100):
+                if _tip20_balance(rpc_url, currency, address, client) > 0:
+                    return
+                time.sleep(0.2)
+            raise RuntimeError(f"Account {address} not funded after tempo_fundAddress")
+
+    # Fallback: transfer from dev account
+    _fund_account_via_dev_key(rpc_url, address, currency, 100_000_000_000)
+
+    with httpx.Client(timeout=30) as client:
+        for _ in range(100):
+            if _tip20_balance(rpc_url, currency, address, client) > 0:
+                return
+            time.sleep(0.2)
+    raise RuntimeError(f"Account {address} not funded after 100 attempts")
+
+
+@pytest.fixture(scope="session")
+def funded_payer(rpc_url, is_local_node, currency):
+    if is_local_node:
+        key = "0x" + os.urandom(32).hex()
+        account = TempoAccount.from_key(key)
+        _fund_account(rpc_url, account.address, currency)
+        return account
+    return TempoAccount.from_env("TEMPO_TEST_PRIVATE_KEY")
+
+
+@pytest.fixture(scope="session")
+def funded_recipient(rpc_url, is_local_node, currency):
+    if is_local_node:
+        key = "0x" + os.urandom(32).hex()
+        account = TempoAccount.from_key(key)
+        _fund_account(rpc_url, account.address, currency)
+        return account
+    return TempoAccount.from_env("TEMPO_TEST_RECIPIENT_KEY")

--- a/tests/test_client_integration.py
+++ b/tests/test_client_integration.py
@@ -142,9 +142,7 @@ class TestClientServerIntegration:
 
     async def test_wrong_auth_scheme_returns_402(self, server_transport):
         async with httpx.AsyncClient(transport=server_transport, base_url="http://test") as client:
-            response = await client.get(
-                "/paid", headers={"authorization": "Bearer some-jwt-token"}
-            )
+            response = await client.get("/paid", headers={"authorization": "Bearer some-jwt-token"})
             assert response.status_code == 402
             assert response.headers["www-authenticate"].startswith("Payment ")
 
@@ -207,9 +205,7 @@ class TestClientServerIntegration:
         assert balance_after < balance_before
         assert balance_before - balance_after >= 1_000_000
 
-    async def test_e2e_charge_with_fee_payer(
-        self, rpc_url, funded_payer, fee_payer_transport
-    ):
+    async def test_e2e_charge_with_fee_payer(self, rpc_url, funded_payer, fee_payer_transport):
         method = tempo(
             account=funded_payer,
             rpc_url=rpc_url,
@@ -268,7 +264,10 @@ class TestClientServerIntegration:
         _fund_account(rpc_url, fee_payer_account.address, currency)
 
         transport = _make_transport(
-            rpc_url, funded_recipient.address, currency, chain_id,
+            rpc_url,
+            funded_recipient.address,
+            currency,
+            chain_id,
             fee_payer=fee_payer_account,
         )
 

--- a/tests/test_client_integration.py
+++ b/tests/test_client_integration.py
@@ -6,17 +6,19 @@ Requires TEMPO_RPC_URL to be set. Run with:
 
 from __future__ import annotations
 
+import os
 from datetime import UTC, datetime, timedelta
 
 import httpx
 import pytest
 
-from mpp import Challenge
+from mpp import Challenge, Receipt
 from mpp.client import PaymentTransport
-from mpp.methods.tempo import tempo
+from mpp.methods.tempo import TempoAccount, tempo
 from mpp.methods.tempo.intents import ChargeIntent
 from mpp.server.verify import verify_or_challenge
 from tests import INTEGRATION, TEST_SECRET
+from tests.conftest import _fund_account, _tip20_balance
 
 pytestmark = [pytest.mark.integration, INTEGRATION]
 
@@ -56,16 +58,21 @@ class RealVerifyTransport(httpx.AsyncBaseTransport):
         pass
 
 
-@pytest.fixture
-def server_transport(rpc_url, funded_recipient, currency, chain_id):
+def _make_transport(rpc_url, recipient_address, currency, chain_id, *, fee_payer=None):
     intent = ChargeIntent(rpc_url=rpc_url)
+    if fee_payer is not None:
+        tempo(
+            rpc_url=rpc_url,
+            fee_payer=fee_payer,
+            intents={"charge": intent},
+        )
     request_params = {
         "amount": "1000000",
         "currency": currency,
-        "recipient": funded_recipient.address,
+        "recipient": recipient_address,
         "expires": (datetime.now(UTC) + timedelta(hours=1)).isoformat().replace("+00:00", "Z"),
         "methodDetails": {
-            "feePayer": False,
+            "feePayer": fee_payer is not None,
             "chainId": chain_id,
         },
     }
@@ -73,6 +80,20 @@ def server_transport(rpc_url, funded_recipient, currency, chain_id):
         intent=intent,
         request_params=request_params,
         realm="test.local",
+    )
+
+
+@pytest.fixture
+def server_transport(rpc_url, funded_recipient, currency, chain_id):
+    return _make_transport(rpc_url, funded_recipient.address, currency, chain_id)
+
+
+@pytest.fixture
+def fee_payer_transport(rpc_url, funded_recipient, currency, chain_id):
+    fee_payer = TempoAccount.from_key("0x" + os.urandom(32).hex())
+    _fund_account(rpc_url, fee_payer.address, currency)
+    return _make_transport(
+        rpc_url, funded_recipient.address, currency, chain_id, fee_payer=fee_payer
     )
 
 
@@ -104,9 +125,171 @@ class TestClientServerIntegration:
             assert data["paid"] is True
             assert funded_payer.address.lower() in data["payer"].lower()
 
+            receipt_header = response.headers.get("payment-receipt")
+            assert receipt_header is not None
+            receipt = Receipt.from_payment_receipt(receipt_header)
+            assert receipt.status == "success"
+            assert receipt.method == "tempo"
+            assert receipt.reference.startswith("0x")
+            assert len(receipt.reference) >= 66
+
     async def test_payment_roundtrip_no_matching_method(self, server_transport):
         payment_transport = PaymentTransport(methods=[], inner=server_transport)
 
         async with httpx.AsyncClient(transport=payment_transport, base_url="http://test") as client:
             response = await client.get("/paid")
             assert response.status_code == 402
+
+    async def test_wrong_auth_scheme_returns_402(self, server_transport):
+        async with httpx.AsyncClient(transport=server_transport, base_url="http://test") as client:
+            response = await client.get(
+                "/paid", headers={"authorization": "Bearer some-jwt-token"}
+            )
+            assert response.status_code == 402
+            assert response.headers["www-authenticate"].startswith("Payment ")
+
+    async def test_malformed_credential_returns_402(self, server_transport):
+        async with httpx.AsyncClient(transport=server_transport, base_url="http://test") as client:
+            response = await client.get(
+                "/paid", headers={"authorization": "Payment !!not-valid-base64!!"}
+            )
+            assert response.status_code == 402
+            assert response.headers["www-authenticate"].startswith("Payment ")
+
+    async def test_multiple_sequential_payments(
+        self, rpc_url, funded_payer, funded_recipient, currency, chain_id
+    ):
+        transport = _make_transport(rpc_url, funded_recipient.address, currency, chain_id)
+
+        payer_a = funded_payer
+        payer_b = TempoAccount.from_key("0x" + os.urandom(32).hex())
+        _fund_account(rpc_url, payer_b.address, currency)
+
+        references = []
+        for payer in [payer_a, payer_b]:
+            method = tempo(
+                account=payer,
+                rpc_url=rpc_url,
+                intents={"charge": ChargeIntent()},
+            )
+            payment_transport = PaymentTransport(methods=[method], inner=transport)
+            async with httpx.AsyncClient(
+                transport=payment_transport, base_url="http://test"
+            ) as client:
+                response = await client.get("/paid")
+                assert response.status_code == 200
+                receipt = Receipt.from_payment_receipt(response.headers["payment-receipt"])
+                assert receipt.status == "success"
+                references.append(receipt.reference)
+
+        assert references[0] != references[1]
+
+    async def test_client_balance_decreases_after_payment(
+        self, rpc_url, funded_payer, server_transport, currency
+    ):
+        with httpx.Client(timeout=30) as c:
+            balance_before = _tip20_balance(rpc_url, currency, funded_payer.address, c)
+
+        method = tempo(
+            account=funded_payer,
+            rpc_url=rpc_url,
+            intents={"charge": ChargeIntent()},
+        )
+        payment_transport = PaymentTransport(methods=[method], inner=server_transport)
+
+        async with httpx.AsyncClient(transport=payment_transport, base_url="http://test") as client:
+            response = await client.get("/paid")
+            assert response.status_code == 200
+
+        with httpx.Client(timeout=30) as c:
+            balance_after = _tip20_balance(rpc_url, currency, funded_payer.address, c)
+
+        assert balance_after < balance_before
+        assert balance_before - balance_after >= 1_000_000
+
+    async def test_e2e_charge_with_fee_payer(
+        self, rpc_url, funded_payer, fee_payer_transport
+    ):
+        method = tempo(
+            account=funded_payer,
+            rpc_url=rpc_url,
+            intents={"charge": ChargeIntent()},
+        )
+        payment_transport = PaymentTransport(methods=[method], inner=fee_payer_transport)
+
+        async with httpx.AsyncClient(transport=payment_transport, base_url="http://test") as client:
+            response = await client.get("/paid")
+            assert response.status_code == 200
+            data = response.json()
+            assert data["paid"] is True
+
+            receipt = Receipt.from_payment_receipt(response.headers["payment-receipt"])
+            assert receipt.status == "success"
+            assert receipt.method == "tempo"
+            assert receipt.reference.startswith("0x")
+            assert len(receipt.reference) >= 66
+
+    async def test_fee_payer_no_signer_fails_verification(
+        self, rpc_url, funded_payer, funded_recipient, currency, chain_id
+    ):
+        intent = ChargeIntent(rpc_url=rpc_url)
+        request_params = {
+            "amount": "1000000",
+            "currency": currency,
+            "recipient": funded_recipient.address,
+            "expires": (datetime.now(UTC) + timedelta(hours=1)).isoformat().replace("+00:00", "Z"),
+            "methodDetails": {
+                "feePayer": True,
+                "chainId": chain_id,
+                "feePayerUrl": "http://127.0.0.1:1/nonexistent",
+            },
+        }
+
+        client_method = tempo(
+            account=funded_payer,
+            rpc_url=rpc_url,
+            intents={"charge": ChargeIntent()},
+        )
+        challenge = Challenge(
+            id="integ-no-signer",
+            method="tempo",
+            intent="charge",
+            request=request_params,
+        )
+        credential = await client_method.create_credential(challenge)
+
+        with pytest.raises(httpx.ConnectError):
+            await intent.verify(credential, request_params)
+
+    async def test_fee_payer_balance_accounting(
+        self, rpc_url, funded_payer, funded_recipient, currency, chain_id
+    ):
+        fee_payer_account = TempoAccount.from_key("0x" + os.urandom(32).hex())
+        _fund_account(rpc_url, fee_payer_account.address, currency)
+
+        transport = _make_transport(
+            rpc_url, funded_recipient.address, currency, chain_id,
+            fee_payer=fee_payer_account,
+        )
+
+        with httpx.Client(timeout=30) as c:
+            payer_before = _tip20_balance(rpc_url, currency, funded_payer.address, c)
+            recipient_before = _tip20_balance(rpc_url, currency, funded_recipient.address, c)
+
+        method = tempo(
+            account=funded_payer,
+            rpc_url=rpc_url,
+            intents={"charge": ChargeIntent()},
+        )
+        payment_transport = PaymentTransport(methods=[method], inner=transport)
+
+        async with httpx.AsyncClient(transport=payment_transport, base_url="http://test") as client:
+            response = await client.get("/paid")
+            assert response.status_code == 200
+
+        with httpx.Client(timeout=30) as c:
+            payer_after = _tip20_balance(rpc_url, currency, funded_payer.address, c)
+            recipient_after = _tip20_balance(rpc_url, currency, funded_recipient.address, c)
+
+        assert payer_before - payer_after == 1_000_000
+        assert recipient_after - recipient_before == 1_000_000

--- a/tests/test_client_integration.py
+++ b/tests/test_client_integration.py
@@ -1,0 +1,112 @@
+"""Integration tests for client→server payment roundtrip against a real node.
+
+Requires TEMPO_RPC_URL to be set. Run with:
+    TEMPO_RPC_URL=http://localhost:8545 pytest -m integration -v
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import httpx
+import pytest
+
+from mpp import Challenge
+from mpp.client import PaymentTransport
+from mpp.methods.tempo import tempo
+from mpp.methods.tempo.intents import ChargeIntent
+from mpp.server.verify import verify_or_challenge
+from tests import INTEGRATION, TEST_SECRET
+
+pytestmark = [pytest.mark.integration, INTEGRATION]
+
+
+class RealVerifyTransport(httpx.AsyncBaseTransport):
+    def __init__(self, intent, request_params, realm, secret_key=TEST_SECRET):
+        self.intent = intent
+        self.request_params = request_params
+        self.realm = realm
+        self.secret_key = secret_key
+
+    async def handle_async_request(self, request):
+        if request.url.path == "/free":
+            return httpx.Response(200, json={"free": True})
+
+        auth = request.headers.get("authorization")
+        result = await verify_or_challenge(
+            authorization=auth,
+            intent=self.intent,
+            request=self.request_params,
+            realm=self.realm,
+            secret_key=self.secret_key,
+        )
+
+        if isinstance(result, Challenge):
+            headers = {"www-authenticate": result.to_www_authenticate(self.realm)}
+            return httpx.Response(402, headers=headers)
+
+        credential, receipt = result
+        return httpx.Response(
+            200,
+            json={"paid": True, "payer": credential.source},
+            headers={"payment-receipt": receipt.to_payment_receipt()},
+        )
+
+    async def aclose(self) -> None:
+        pass
+
+
+@pytest.fixture
+def server_transport(rpc_url, funded_recipient, currency, chain_id):
+    intent = ChargeIntent(rpc_url=rpc_url)
+    request_params = {
+        "amount": "1000000",
+        "currency": currency,
+        "recipient": funded_recipient.address,
+        "expires": (datetime.now(UTC) + timedelta(hours=1)).isoformat().replace("+00:00", "Z"),
+        "methodDetails": {
+            "feePayer": False,
+            "chainId": chain_id,
+        },
+    }
+    return RealVerifyTransport(
+        intent=intent,
+        request_params=request_params,
+        realm="test.local",
+    )
+
+
+class TestClientServerIntegration:
+    async def test_free_endpoint_no_payment(self, server_transport):
+        async with httpx.AsyncClient(transport=server_transport, base_url="http://test") as client:
+            response = await client.get("/free")
+            assert response.status_code == 200
+            assert response.json() == {"free": True}
+
+    async def test_paid_endpoint_returns_402_without_auth(self, server_transport):
+        async with httpx.AsyncClient(transport=server_transport, base_url="http://test") as client:
+            response = await client.get("/paid")
+            assert response.status_code == 402
+            assert response.headers["www-authenticate"].startswith("Payment ")
+
+    async def test_full_payment_roundtrip(self, rpc_url, funded_payer, server_transport):
+        method = tempo(
+            account=funded_payer,
+            rpc_url=rpc_url,
+            intents={"charge": ChargeIntent()},
+        )
+        payment_transport = PaymentTransport(methods=[method], inner=server_transport)
+
+        async with httpx.AsyncClient(transport=payment_transport, base_url="http://test") as client:
+            response = await client.get("/paid")
+            assert response.status_code == 200
+            data = response.json()
+            assert data["paid"] is True
+            assert funded_payer.address.lower() in data["payer"].lower()
+
+    async def test_payment_roundtrip_no_matching_method(self, server_transport):
+        payment_transport = PaymentTransport(methods=[], inner=server_transport)
+
+        async with httpx.AsyncClient(transport=payment_transport, base_url="http://test") as client:
+            response = await client.get("/paid")
+            assert response.status_code == 402

--- a/tests/test_tempo_integration.py
+++ b/tests/test_tempo_integration.py
@@ -1,0 +1,216 @@
+"""Integration tests for Tempo charge intent against a real node.
+
+Requires TEMPO_RPC_URL to be set. Run with:
+    TEMPO_RPC_URL=http://localhost:8545 pytest -m integration -v
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+
+import httpx
+import pytest
+
+from mpp import Challenge
+from mpp.errors import VerificationError
+from mpp.methods.tempo import ChargeIntent, tempo
+from mpp.methods.tempo._rpc import get_tx_params
+from tests import INTEGRATION, make_credential
+
+pytestmark = [pytest.mark.integration, INTEGRATION]
+
+
+def _future_expires() -> str:
+    return (datetime.now(UTC) + timedelta(hours=1)).isoformat().replace("+00:00", "Z")
+
+
+async def _send_transfer(
+    rpc_url: str,
+    payer,
+    currency: str,
+    recipient_addr: str,
+    amount: int,
+) -> str:
+    from pytempo import Call, TempoTransaction
+
+    cid, nonce, gas_price = await get_tx_params(rpc_url, payer.address)
+
+    selector = "a9059cbb"
+    to_padded = recipient_addr[2:].lower().zfill(64)
+    amount_padded = hex(amount)[2:].zfill(64)
+    data = f"0x{selector}{to_padded}{amount_padded}"
+
+    tx = TempoTransaction.create(
+        chain_id=cid,
+        gas_limit=500_000,
+        max_fee_per_gas=gas_price,
+        max_priority_fee_per_gas=gas_price,
+        nonce=nonce,
+        nonce_key=0,
+        fee_token=currency,
+        calls=(Call.create(to=currency, value=0, data=data),),
+    )
+    signed = tx.sign(payer.private_key)
+    raw_tx = "0x" + signed.encode().hex()
+
+    async with httpx.AsyncClient(timeout=30) as client:
+        resp = await client.post(
+            rpc_url,
+            json={
+                "jsonrpc": "2.0",
+                "method": "eth_sendRawTransaction",
+                "params": [raw_tx],
+                "id": 1,
+            },
+        )
+        result = resp.json()
+        if "error" in result:
+            raise RuntimeError(f"RPC error: {result['error']}")
+        tx_hash = result["result"]
+
+    await _wait_for_receipt(rpc_url, tx_hash)
+    return tx_hash
+
+
+async def _wait_for_receipt(
+    rpc_url: str, tx_hash: str, max_attempts: int = 30, delay: float = 1.0
+) -> dict:
+    async with httpx.AsyncClient(timeout=30) as client:
+        for _ in range(max_attempts):
+            resp = await client.post(
+                rpc_url,
+                json={
+                    "jsonrpc": "2.0",
+                    "method": "eth_getTransactionReceipt",
+                    "params": [tx_hash],
+                    "id": 1,
+                },
+            )
+            result = resp.json().get("result")
+            if result is not None:
+                if result.get("status") != "0x1":
+                    raise RuntimeError(f"Transaction reverted: {tx_hash}")
+                return result
+            await asyncio.sleep(delay)
+    raise RuntimeError(f"Receipt not found after {max_attempts} attempts: {tx_hash}")
+
+
+class TestChargeIntegration:
+    async def test_create_credential_builds_real_tx(
+        self, rpc_url, funded_payer, funded_recipient, currency
+    ):
+        method = tempo(
+            account=funded_payer,
+            rpc_url=rpc_url,
+            intents={"charge": ChargeIntent()},
+        )
+        challenge = Challenge(
+            id="integ-create-cred",
+            method="tempo",
+            intent="charge",
+            request={
+                "amount": "1000000",
+                "currency": currency,
+                "recipient": funded_recipient.address,
+                "expires": _future_expires(),
+            },
+        )
+
+        credential = await method.create_credential(challenge)
+
+        assert credential.payload["type"] == "transaction"
+        assert credential.payload["signature"].startswith("0x76")
+        assert funded_payer.address in credential.source
+
+    async def test_verify_transaction_credential(
+        self, rpc_url, funded_payer, funded_recipient, currency, charge_intent, chain_id
+    ):
+        method = tempo(
+            account=funded_payer,
+            rpc_url=rpc_url,
+            intents={"charge": ChargeIntent()},
+        )
+        expires = _future_expires()
+        request_dict = {
+            "amount": "1000000",
+            "currency": currency,
+            "recipient": funded_recipient.address,
+            "expires": expires,
+            "methodDetails": {
+                "feePayer": False,
+                "chainId": chain_id,
+            },
+        }
+        challenge = Challenge(
+            id="integ-verify-tx",
+            method="tempo",
+            intent="charge",
+            request=request_dict,
+        )
+
+        credential = await method.create_credential(challenge)
+        receipt = await charge_intent.verify(credential, request_dict)
+
+        assert receipt.status == "success"
+        assert receipt.reference.startswith("0x")
+        assert len(receipt.reference) >= 66
+
+    async def test_verify_hash_credential(
+        self, rpc_url, funded_payer, funded_recipient, currency, charge_intent
+    ):
+        tx_hash = await _send_transfer(
+            rpc_url, funded_payer, currency, funded_recipient.address, 1000000
+        )
+
+        expires = _future_expires()
+        request_dict = {
+            "amount": "1000000",
+            "currency": currency,
+            "recipient": funded_recipient.address,
+            "expires": expires,
+        }
+        credential = make_credential(payload={"type": "hash", "hash": tx_hash})
+        receipt = await charge_intent.verify(credential, request_dict)
+
+        assert receipt.status == "success"
+        assert receipt.reference == tx_hash
+
+    async def test_verify_rejects_insufficient_transfer(
+        self, rpc_url, funded_payer, funded_recipient, currency, charge_intent
+    ):
+        tx_hash = await _send_transfer(
+            rpc_url, funded_payer, currency, funded_recipient.address, 100
+        )
+
+        expires = _future_expires()
+        request_dict = {
+            "amount": "1000000",
+            "currency": currency,
+            "recipient": funded_recipient.address,
+            "expires": expires,
+        }
+        credential = make_credential(payload={"type": "hash", "hash": tx_hash})
+
+        with pytest.raises(VerificationError):
+            await charge_intent.verify(credential, request_dict)
+
+    async def test_verify_rejects_wrong_recipient(
+        self, rpc_url, funded_payer, currency, charge_intent
+    ):
+        tx_hash = await _send_transfer(
+            rpc_url, funded_payer, currency, funded_payer.address, 1000000
+        )
+
+        wrong_recipient = "0x0000000000000000000000000000000000000001"
+        expires = _future_expires()
+        request_dict = {
+            "amount": "1000000",
+            "currency": currency,
+            "recipient": wrong_recipient,
+            "expires": expires,
+        }
+        credential = make_credential(payload={"type": "hash", "hash": tx_hash})
+
+        with pytest.raises(VerificationError):
+            await charge_intent.verify(credential, request_dict)

--- a/tests/test_tempo_integration.py
+++ b/tests/test_tempo_integration.py
@@ -14,9 +14,10 @@ import pytest
 
 from mpp import Challenge
 from mpp.errors import VerificationError
-from mpp.methods.tempo import ChargeIntent, tempo
+from mpp.methods.tempo import ChargeIntent, TempoAccount, tempo
 from mpp.methods.tempo._rpc import get_tx_params
 from tests import INTEGRATION, make_credential
+from tests.conftest import _fund_account
 
 pytestmark = [pytest.mark.integration, INTEGRATION]
 
@@ -214,3 +215,133 @@ class TestChargeIntegration:
 
         with pytest.raises(VerificationError):
             await charge_intent.verify(credential, request_dict)
+
+    async def test_verify_premium_charge(
+        self, rpc_url, funded_payer, funded_recipient, currency, charge_intent, chain_id
+    ):
+        method = tempo(
+            account=funded_payer,
+            rpc_url=rpc_url,
+            intents={"charge": ChargeIntent()},
+        )
+        expires = _future_expires()
+        request_dict = {
+            "amount": "1000000000",
+            "currency": currency,
+            "recipient": funded_recipient.address,
+            "expires": expires,
+            "methodDetails": {
+                "feePayer": False,
+                "chainId": chain_id,
+            },
+        }
+        challenge = Challenge(
+            id="integ-premium",
+            method="tempo",
+            intent="charge",
+            request=request_dict,
+        )
+
+        credential = await method.create_credential(challenge)
+        receipt = await charge_intent.verify(credential, request_dict)
+
+        assert receipt.status == "success"
+        assert receipt.method == "tempo"
+        assert receipt.reference.startswith("0x")
+        assert len(receipt.reference) >= 66
+
+    async def test_e2e_charge_with_fee_payer(
+        self, rpc_url, funded_payer, funded_recipient, currency, chain_id
+    ):
+        fee_payer_account = TempoAccount.from_key("0x" + __import__("os").urandom(32).hex())
+        _fund_account(rpc_url, fee_payer_account.address, currency)
+
+        intent = ChargeIntent(rpc_url=rpc_url)
+        tempo(
+            rpc_url=rpc_url,
+            fee_payer=fee_payer_account,
+            intents={"charge": intent},
+        )
+
+        client_method = tempo(
+            account=funded_payer,
+            rpc_url=rpc_url,
+            intents={"charge": ChargeIntent()},
+        )
+
+        expires = _future_expires()
+        request_dict = {
+            "amount": "1000000",
+            "currency": currency,
+            "recipient": funded_recipient.address,
+            "expires": expires,
+            "methodDetails": {
+                "feePayer": True,
+                "chainId": chain_id,
+            },
+        }
+        challenge = Challenge(
+            id="integ-fee-payer",
+            method="tempo",
+            intent="charge",
+            request=request_dict,
+        )
+
+        credential = await client_method.create_credential(challenge)
+        receipt = await intent.verify(credential, request_dict)
+
+        assert receipt.status == "success"
+        assert receipt.method == "tempo"
+        assert receipt.reference.startswith("0x")
+        assert len(receipt.reference) >= 66
+
+    async def test_fee_payer_wrong_recipient_rejected(
+        self, rpc_url, funded_payer, funded_recipient, currency, chain_id
+    ):
+        fee_payer_account = TempoAccount.from_key("0x" + __import__("os").urandom(32).hex())
+        _fund_account(rpc_url, fee_payer_account.address, currency)
+
+        intent = ChargeIntent(rpc_url=rpc_url)
+        tempo(
+            rpc_url=rpc_url,
+            fee_payer=fee_payer_account,
+            intents={"charge": intent},
+        )
+
+        wrong_recipient = "0x0000000000000000000000000000000000000001"
+
+        client_method = tempo(
+            account=funded_payer,
+            rpc_url=rpc_url,
+            intents={"charge": ChargeIntent()},
+        )
+        challenge = Challenge(
+            id="integ-fee-payer-wrong",
+            method="tempo",
+            intent="charge",
+            request={
+                "amount": "1000000",
+                "currency": currency,
+                "recipient": wrong_recipient,
+                "expires": _future_expires(),
+                "methodDetails": {
+                    "feePayer": True,
+                    "chainId": chain_id,
+                },
+            },
+        )
+        credential = await client_method.create_credential(challenge)
+
+        request_dict = {
+            "amount": "1000000",
+            "currency": currency,
+            "recipient": funded_recipient.address,
+            "expires": _future_expires(),
+            "methodDetails": {
+                "feePayer": True,
+                "chainId": chain_id,
+            },
+        }
+
+        with pytest.raises(VerificationError):
+            await intent.verify(credential, request_dict)


### PR DESCRIPTION
## Summary

Add integration tests that run against a local Tempo blockchain node, matching the coverage from mpp-rs.

## Test Coverage

**Tempo intent tests** (`test_tempo_integration.py` — 8 tests):
- Credential creation with real transaction building
- Transaction credential verification (sign → submit → verify)
- Hash credential verification (pre-sent tx hash)
- Rejection of insufficient transfer amounts
- Rejection of wrong recipient addresses
- Premium charge ($1000 amount tier)
- Fee payer E2E charge roundtrip (client signs 0x76, server co-signs)
- Fee payer wrong recipient rejected pre-broadcast

**Client↔server roundtrip tests** (`test_client_integration.py` — 11 tests):
- Full payment roundtrip via `PaymentTransport` + `verify_or_challenge()`
- Receipt header parsing (status, method, reference validation)
- Free endpoint passthrough (no payment required)
- 402 response when no auth provided
- 402 when wrong auth scheme (`Bearer`) is sent
- 402 when malformed credential (garbage base64) is sent
- 402 when no matching payment method configured
- Multiple sequential payments with unique receipts
- Client balance decreases after payment (`balanceOf` before/after)
- Fee payer E2E charge with receipt validation
- Fee payer with no signer configured fails verification
- Fee payer balance accounting (client pays exact amount, no gas)

## Infrastructure

- `docker-compose.yml` — local Tempo `--dev` node (multi-arch, 200ms blocks)
- `Makefile` targets: `make node`, `make node-stop`, `make test-integration`
- `conftest.py` — session-scoped account funding (faucet RPC with dev key fallback)
- Integration marker auto-skips when `TEMPO_RPC_URL` is unset

## Running

```bash
make node              # start local Tempo node
make test-integration  # run integration tests
make node-stop         # stop node
```