### PR TITLE
feat: fee payer sponsorship flow with local co-signing and external fallback

### DIFF
--- a/.changelog/big-birds-laugh.md
+++ b/.changelog/big-birds-laugh.md
@@ -1,0 +1,5 @@
+---
+pympp: minor
+---
+
+Added fee payer sponsorship support to the Tempo payment method. Servers can now configure a local `TempoAccount` as a fee payer to co-sign client transactions directly, with automatic fallback to an external fee payer service when no local account is configured. Added `fee_payer` parameter to `tempo()`, `ChargeIntent`, and `Mpp.pay()`/`Mpp.charge()`, along with comprehensive tests covering local co-signing, external fallback, and priority logic.

--- a/examples/api-server/server.py
+++ b/examples/api-server/server.py
@@ -6,7 +6,7 @@ from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 
 from mpp import Challenge, Credential, Receipt
-from mpp.methods.tempo import ChargeIntent, tempo
+from mpp.methods.tempo import ChargeIntent, TempoAccount, tempo
 from mpp.methods.tempo._defaults import PATH_USD, TESTNET_CHAIN_ID
 from mpp.server import Mpp
 
@@ -19,11 +19,19 @@ DESTINATION = os.environ.get(
     "PAYMENT_DESTINATION", "0x742d35Cc6634c0532925a3b844bC9e7595F8fE00"
 )
 
+# Fee payer account sponsors gas for clients.
+# Set FEE_PAYER_KEY env var, or omit to fall back to the external sponsor service.
+fee_payer = None
+fee_payer_key = os.environ.get("FEE_PAYER_KEY")
+if fee_payer_key:
+    fee_payer = TempoAccount.from_key(fee_payer_key)
+
 server = Mpp.create(
     method=tempo(
         chain_id=TESTNET_CHAIN_ID,
         currency=PATH_USD,
         recipient=DESTINATION,
+        fee_payer=fee_payer,
         intents={"charge": ChargeIntent()},
     ),
 )
@@ -42,6 +50,7 @@ async def paid_endpoint(request: Request):
         authorization=request.headers.get("Authorization"),
         amount="0.001",
         chain_id=TESTNET_CHAIN_ID,
+        fee_payer=True,
     )
 
     if isinstance(result, Challenge):
@@ -60,7 +69,7 @@ async def paid_endpoint(request: Request):
 
 
 @app.get("/paid-decorator")
-@server.pay(amount="0.001", chain_id=TESTNET_CHAIN_ID)
+@server.pay(amount="0.001", chain_id=TESTNET_CHAIN_ID, fee_payer=True)
 async def paid_decorator_endpoint(request: Request, credential: Credential, receipt: Receipt):
     """A paid endpoint using the server.pay() decorator."""
     return {

--- a/src/mpp/methods/tempo/client.py
+++ b/src/mpp/methods/tempo/client.py
@@ -52,6 +52,7 @@ class TempoMethod:
 
     name: str = "tempo"
     account: TempoAccount | None = None
+    fee_payer: TempoAccount | None = None
     root_account: str | None = None
     rpc_url: str = RPC_URL
     chain_id: int | None = None
@@ -90,6 +91,11 @@ class TempoMethod:
             raise ValueError(f"Unsupported intent: {challenge.intent}")
 
         request = challenge.request
+        method_details = request.get("methodDetails", {})
+        use_fee_payer = (
+            method_details.get("feePayer", False) if isinstance(method_details, dict) else False
+        )
+
         nonce_key = request.get("nonce_key", 0)
         if isinstance(nonce_key, str):
             if nonce_key.startswith("0x"):
@@ -97,7 +103,6 @@ class TempoMethod:
             else:
                 nonce_key = int(nonce_key)
 
-        method_details = request.get("methodDetails", {})
         memo = method_details.get("memo") if isinstance(method_details, dict) else None
         if memo is None:
             memo = encode_attribution(server_id=challenge.realm, client_id=self.client_id)
@@ -135,6 +140,7 @@ class TempoMethod:
             memo=memo,
             rpc_url=rpc_url,
             expected_chain_id=expected_chain_id,
+            awaiting_fee_payer=use_fee_payer,
         )
 
         return Credential(
@@ -152,11 +158,18 @@ class TempoMethod:
         memo: str | None = None,
         rpc_url: str | None = None,
         expected_chain_id: int | None = None,
+        awaiting_fee_payer: bool = False,
     ) -> tuple[str, int]:
         """Build a client-signed Tempo transaction.
 
         Creates a TempoTransaction (type 0x76) with fee token set to the
         transfer currency, allowing gas to be paid in the same token.
+
+        When ``awaiting_fee_payer`` is True, the transaction is built with
+        a fee payer placeholder so a sponsoring service can co-sign it
+        before broadcast. Per the Tempo spec, the sender's signing hash
+        omits ``fee_token`` (encoded as empty) and encodes a ``0x00``
+        placeholder for ``fee_payer_signature``.
 
         Args:
             amount: Transfer amount as string.
@@ -166,6 +179,7 @@ class TempoMethod:
             memo: Optional 32-byte memo (hex string) for transferWithMemo.
             rpc_url: RPC URL to use. Defaults to ``self.rpc_url``.
             expected_chain_id: If set, verify the RPC reports this chain ID.
+            awaiting_fee_payer: If True, build for fee payer sponsorship.
 
         Returns:
             Tuple of (raw signed transaction hex, chain ID).
@@ -173,6 +187,7 @@ class TempoMethod:
         Raises:
             TransactionError: If the RPC's chain ID doesn't match expected.
         """
+        import attrs
         from pytempo import Call, TempoTransaction
 
         if self.account is None:
@@ -209,11 +224,16 @@ class TempoMethod:
             max_priority_fee_per_gas=gas_price,
             nonce=nonce,
             nonce_key=nonce_key,
-            fee_token=currency,
+            fee_token=None if awaiting_fee_payer else currency,
+            awaiting_fee_payer=awaiting_fee_payer,
             calls=(Call.create(to=currency, value=0, data=transfer_data),),
         )
 
         signed_tx = tx.sign(self.account.private_key)
+
+        if awaiting_fee_payer:
+            signed_tx = attrs.evolve(signed_tx, fee_payer_signature=b"\x00")
+
         return "0x" + signed_tx.encode().hex(), chain_id
 
     def _encode_transfer(self, to: str, amount: int) -> str:
@@ -250,6 +270,7 @@ class TempoMethod:
 def tempo(
     intents: dict[str, Intent],
     account: TempoAccount | None = None,
+    fee_payer: TempoAccount | None = None,
     chain_id: int | None = None,
     rpc_url: str | None = None,
     root_account: str | None = None,
@@ -262,7 +283,11 @@ def tempo(
 
     Args:
         intents: Intents to register (e.g. charge).
-        account: Account for signing transactions.
+        account: Account for signing transactions (client-side).
+        fee_payer: Account for co-signing sponsored transactions
+            (server-side). When set, the server signs with domain
+            ``0x78`` and broadcasts directly — no external fee payer
+            service needed.
         chain_id: Tempo chain ID (4217 for mainnet, 42431 for testnet).
             Resolves the RPC URL automatically from known chains.
         rpc_url: Tempo RPC endpoint URL. Overrides the URL resolved
@@ -277,18 +302,18 @@ def tempo(
         A configured TempoMethod instance.
 
     Example:
-        from mpp.methods.tempo import ChargeIntent
+        from mpp.methods.tempo import ChargeIntent, TempoAccount
 
-        # Testnet — resolves RPC automatically
+        # Server with fee payer — sponsors gas for clients
         method = tempo(
             chain_id=42431,
+            fee_payer=TempoAccount.from_env("FEE_PAYER_KEY"),
             intents={"charge": ChargeIntent()},
         )
 
-        # Custom RPC
+        # Client
         method = tempo(
-            chain_id=42431,
-            rpc_url="https://my-rpc.example.com",
+            account=TempoAccount.from_key("0x..."),
             intents={"charge": ChargeIntent()},
         )
     """
@@ -297,6 +322,7 @@ def tempo(
 
     method = TempoMethod(
         account=account,
+        fee_payer=fee_payer,
         rpc_url=rpc_url,
         chain_id=chain_id,
         root_account=root_account,
@@ -308,5 +334,7 @@ def tempo(
     for intent in intents.values():
         if hasattr(intent, "rpc_url") and intent.rpc_url is None:
             intent.rpc_url = rpc_url
+        if hasattr(intent, "_method"):
+            intent._method = method
     method._intents = dict(intents)
     return method

--- a/src/mpp/methods/tempo/intents.py
+++ b/src/mpp/methods/tempo/intents.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Any
 
 from mpp import Credential, Receipt
 from mpp.errors import VerificationError
-from mpp.methods.tempo._defaults import DEFAULT_FEE_PAYER_URL, rpc_url_for_chain
+from mpp.methods.tempo._defaults import DEFAULT_FEE_PAYER_URL, PATH_USD, rpc_url_for_chain
 from mpp.methods.tempo.schemas import (
     ChargeRequest,
     CredentialPayload,
@@ -21,6 +21,8 @@ from mpp.methods.tempo.schemas import (
 
 if TYPE_CHECKING:
     import httpx
+
+    from mpp.methods.tempo.account import TempoAccount
 
 
 DEFAULT_TIMEOUT = 30.0
@@ -62,8 +64,9 @@ class ChargeIntent:
 
     Verifies that a payment transaction matches the requested parameters.
 
-    When used via ``tempo()``, the ``rpc_url`` is propagated automatically
-    from the method level. You can also pass it directly for standalone use.
+    When used via ``tempo()``, the ``rpc_url`` and ``fee_payer`` are read
+    from the parent method automatically. You can also pass ``rpc_url``
+    directly for standalone use.
 
     This class manages an HTTP client lifecycle. Use as an async context manager
     for automatic cleanup, or call `aclose()` explicitly when done.
@@ -107,9 +110,15 @@ class ChargeIntent:
         if rpc_url is None and chain_id is not None:
             rpc_url = rpc_url_for_chain(chain_id)
         self.rpc_url = rpc_url
+        self._method = None
         self._http_client = http_client
         self._owns_client = http_client is None
         self._timeout = timeout
+
+    @property
+    def fee_payer(self) -> TempoAccount | None:
+        """Fee payer account, read from the parent method."""
+        return getattr(self._method, "fee_payer", None) if self._method else None
 
     async def __aenter__(self) -> ChargeIntent:
         """Enter async context, creating HTTP client if needed."""
@@ -293,27 +302,51 @@ class ChargeIntent:
 
         client = await self._get_client()
 
+        raw_tx = payload.signature
+
         if request.methodDetails.feePayer:
-            fee_payer_url = request.methodDetails.feePayerUrl or DEFAULT_FEE_PAYER_URL
-            response = await client.post(
-                fee_payer_url,
-                json={
-                    "jsonrpc": "2.0",
-                    "method": "eth_sendRawTransaction",
-                    "params": [payload.signature],
-                    "id": 1,
-                },
-            )
-        else:
-            response = await client.post(
-                self.rpc_url,
-                json={
-                    "jsonrpc": "2.0",
-                    "method": "eth_sendRawTransaction",
-                    "params": [payload.signature],
-                    "id": 1,
-                },
-            )
+            if self.fee_payer is not None:
+                raw_tx = self._cosign_as_fee_payer(raw_tx, request.currency)
+            else:
+                fee_payer_url = request.methodDetails.feePayerUrl or DEFAULT_FEE_PAYER_URL
+
+                sign_response = await client.post(
+                    fee_payer_url,
+                    json={
+                        "jsonrpc": "2.0",
+                        "method": "eth_signRawTransaction",
+                        "params": [raw_tx],
+                        "id": 1,
+                    },
+                )
+                sign_response.raise_for_status()
+                sign_result = sign_response.json()
+
+                if "error" in sign_result:
+                    error_obj = sign_result["error"]
+                    if isinstance(error_obj, dict):
+                        error_msg = (
+                            error_obj.get("message")
+                            or error_obj.get("name")
+                            or str(error_obj)
+                        )
+                    else:
+                        error_msg = str(error_obj)
+                    raise VerificationError(f"Fee payer signing failed: {error_msg}")
+
+                raw_tx = sign_result.get("result")
+                if not raw_tx:
+                    raise VerificationError("Fee payer returned no signed transaction")
+
+        response = await client.post(
+            self.rpc_url,
+            json={
+                "jsonrpc": "2.0",
+                "method": "eth_sendRawTransaction",
+                "params": [raw_tx],
+                "id": 1,
+            },
+        )
         response.raise_for_status()
         result = response.json()
 
@@ -368,6 +401,90 @@ class ChargeIntent:
             )
 
         return Receipt.success(tx_hash)
+
+    def _cosign_as_fee_payer(self, raw_tx: str, fee_token: str | None = None) -> str:
+        """Co-sign a client-signed transaction as fee payer.
+
+        Deserializes the client's transaction, sets the fee token, and
+        signs with domain ``0x78``. The resulting transaction contains
+        both the client's signature and the fee payer's signature.
+
+        Args:
+            raw_tx: Hex-encoded client-signed transaction (0x76...).
+            fee_token: TIP-20 token address for fee payment.
+                Defaults to pathUSD.
+
+        Returns:
+            Hex-encoded co-signed transaction ready for broadcast.
+
+        Raises:
+            VerificationError: If deserialization or signing fails.
+        """
+        import attrs
+        import rlp
+        from pytempo import Call, TempoTransaction
+        from pytempo.models import as_address
+
+        if self.fee_payer is None:
+            raise VerificationError("No fee payer account configured")
+
+        try:
+            tx_bytes = bytes.fromhex(raw_tx[2:] if raw_tx.startswith("0x") else raw_tx)
+            if not tx_bytes or tx_bytes[0] != 0x76:
+                raise ValueError("Not a Tempo transaction")
+            decoded = rlp.decode(tx_bytes[1:])
+        except Exception:
+            raise VerificationError("Failed to deserialize client transaction")
+
+        def _int(b: bytes) -> int:
+            return int.from_bytes(b, "big") if b else 0
+
+        calls = tuple(
+            Call(to=c[0], value=_int(c[1]), data=c[2])
+            for c in decoded[4]
+        )
+
+        # Recover sender address from the sender's signature
+        sender_sig = decoded[-1]  # last field
+        tx_for_recovery = TempoTransaction(
+            chain_id=_int(decoded[0]),
+            max_priority_fee_per_gas=_int(decoded[1]),
+            max_fee_per_gas=_int(decoded[2]),
+            gas_limit=_int(decoded[3]),
+            calls=calls,
+            access_list=(),
+            nonce_key=_int(decoded[6]),
+            nonce=_int(decoded[7]),
+            fee_token=decoded[10] if decoded[10] else None,
+            awaiting_fee_payer=True,
+        )
+        sender_hash = tx_for_recovery.get_signing_hash(for_fee_payer=False)
+
+        from eth_account import Account
+
+        sender_address = Account._recover_hash(sender_hash, signature=sender_sig)
+
+        # Reconstruct with sender signature and address
+        resolved_fee_token = fee_token or PATH_USD
+        fee_token_bytes = bytes.fromhex(
+            resolved_fee_token[2:]
+            if resolved_fee_token.startswith("0x")
+            else resolved_fee_token
+        )
+
+        tx_to_sign = attrs.evolve(
+            tx_for_recovery,
+            sender_signature=sender_sig,
+            sender_address=as_address(sender_address),
+            fee_token=fee_token_bytes,
+        )
+
+        try:
+            cosigned = tx_to_sign.sign(self.fee_payer.private_key, for_fee_payer=True)
+        except Exception:
+            raise VerificationError("Fee payer signing failed")
+
+        return "0x" + cosigned.encode().hex()
 
     def _validate_transaction_payload(self, signature: str, request: ChargeRequest) -> None:
         """Validate that a signed transaction contains the expected call.

--- a/src/mpp/server/mpp.py
+++ b/src/mpp/server/mpp.py
@@ -180,6 +180,7 @@ class Mpp:
         recipient: str | None = None,
         description: str | None = None,
         expires_in: timedelta | None = None,
+        fee_payer: bool = False,
         chain_id: int | None = None,
     ) -> Callable[  # noqa: UP047
         [Callable[[Any, Credential, Receipt], Awaitable[R]]],
@@ -200,6 +201,7 @@ class Mpp:
             recipient: Override the method's default recipient.
             description: Optional human-readable description.
             expires_in: Challenge validity duration. Defaults to 5 minutes.
+            fee_payer: Whether to use a fee payer for gas sponsorship.
             chain_id: Override the default chain ID (e.g., 42431 for moderato).
 
         Example:
@@ -250,8 +252,13 @@ class Mpp:
                 resolved_chain_id = chain_id
                 if resolved_chain_id is None:
                     resolved_chain_id = getattr(self.method, "chain_id", None)
-                if resolved_chain_id is not None:
-                    request["methodDetails"] = {"chainId": resolved_chain_id}
+                if fee_payer or resolved_chain_id is not None:
+                    method_details: dict[str, Any] = {}
+                    if resolved_chain_id is not None:
+                        method_details["chainId"] = resolved_chain_id
+                    if fee_payer:
+                        method_details["feePayer"] = True
+                    request["methodDetails"] = method_details
 
                 return await verify_or_challenge(
                     authorization=authorization,

--- a/tests/test_tempo.py
+++ b/tests/test_tempo.py
@@ -482,14 +482,22 @@ class TestSponsoredTransfer:
 
     @pytest.mark.asyncio
     async def test_server_submits_sponsored_transaction(self, httpx_mock: HTTPXMock) -> None:
-        """Server should submit sponsored tx to fee payer URL."""
+        """Server should get fee payer co-signature then broadcast."""
         future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
 
+        # Fee payer signs the transaction
         httpx_mock.add_response(
             url="https://sponsor.test",
+            json={"jsonrpc": "2.0", "result": "0x76cosigned_tx", "id": 1},
+        )
+
+        # Server broadcasts co-signed tx to RPC
+        httpx_mock.add_response(
+            url="https://rpc.test",
             json={"jsonrpc": "2.0", "result": "0xsponsored_hash", "id": 1},
         )
 
+        # Receipt check
         httpx_mock.add_response(
             url="https://rpc.test",
             json={
@@ -556,7 +564,7 @@ class TestSponsoredTransfer:
             payload={"type": "transaction", "signature": "0x76abcdef"},
         )
 
-        with pytest.raises(VerificationError, match="Transaction submission failed"):
+        with pytest.raises(VerificationError, match="Fee payer signing failed"):
             await intent.verify(
                 credential,
                 {
@@ -570,6 +578,312 @@ class TestSponsoredTransfer:
                     },
                 },
             )
+
+
+class TestFeePayerPropagation:
+    """Tests for fee_payer reading from the parent method via _method back-reference."""
+
+    def test_fee_payer_reads_from_method(self) -> None:
+        """ChargeIntent.fee_payer should read from the parent method."""
+        fee_payer = TempoAccount.from_key(TEST_PRIVATE_KEY)
+        intent = ChargeIntent()
+        method = tempo(
+            fee_payer=fee_payer,
+            intents={"charge": intent},
+        )
+        assert intent.fee_payer is fee_payer
+
+    def test_fee_payer_none_without_method(self) -> None:
+        """ChargeIntent.fee_payer should be None when no method is set."""
+        intent = ChargeIntent()
+        assert intent.fee_payer is None
+
+    def test_fee_payer_none_when_method_has_no_fee_payer(self) -> None:
+        """ChargeIntent.fee_payer should be None when method has no fee_payer."""
+        intent = ChargeIntent()
+        method = tempo(intents={"charge": intent})
+        assert intent.fee_payer is None
+
+    def test_multiple_intents_share_fee_payer(self) -> None:
+        """All intents should read the same fee_payer from the method."""
+        fee_payer = TempoAccount.from_key(TEST_PRIVATE_KEY)
+        charge = ChargeIntent()
+        charge2 = ChargeIntent()
+        method = tempo(
+            fee_payer=fee_payer,
+            intents={"charge": charge, "charge2": charge2},
+        )
+        assert charge.fee_payer is fee_payer
+        assert charge2.fee_payer is fee_payer
+
+
+class TestFeePayerChallengeEmission:
+    """Tests for Mpp emitting feePayer flag in challenge methodDetails."""
+
+    @pytest.mark.asyncio
+    async def test_charge_emits_fee_payer_in_method_details(self) -> None:
+        """Mpp.charge(fee_payer=True) should include feePayer in methodDetails."""
+        from mpp.server import Mpp
+
+        srv = Mpp.create(
+            method=tempo(
+                chain_id=TESTNET_CHAIN_ID,
+                currency="0x20c0000000000000000000000000000000000000",
+                recipient="0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
+                intents={"charge": ChargeIntent()},
+            ),
+            realm="test.com",
+            secret_key="test-secret",
+        )
+        result = await srv.charge(authorization=None, amount="0.50", fee_payer=True)
+        assert isinstance(result, Challenge)
+        assert result.request["methodDetails"]["feePayer"] is True
+
+    @pytest.mark.asyncio
+    async def test_charge_no_fee_payer_flag(self) -> None:
+        """Mpp.charge() without fee_payer should not set feePayer in methodDetails."""
+        from mpp.server import Mpp
+
+        srv = Mpp.create(
+            method=tempo(
+                currency="0x20c0000000000000000000000000000000000000",
+                recipient="0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
+                intents={"charge": ChargeIntent()},
+            ),
+            realm="test.com",
+            secret_key="test-secret",
+        )
+        result = await srv.charge(authorization=None, amount="0.50")
+        assert isinstance(result, Challenge)
+        assert "methodDetails" not in result.request
+
+    @pytest.mark.asyncio
+    async def test_pay_decorator_emits_fee_payer(self) -> None:
+        """server.pay(fee_payer=True) should emit feePayer in challenge."""
+        from mpp.server import Mpp
+
+        srv = Mpp.create(
+            method=tempo(
+                chain_id=TESTNET_CHAIN_ID,
+                currency="0x20c0000000000000000000000000000000000000",
+                recipient="0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
+                intents={"charge": ChargeIntent()},
+            ),
+            realm="test.com",
+            secret_key="test-secret",
+        )
+
+        @srv.pay(amount="0.50", fee_payer=True)
+        async def handler(request, credential, receipt):
+            return {"data": "paid"}
+
+        # Simulate a request with no authorization
+        class FakeRequest:
+            headers = {}
+            query_params = {}
+
+        result = await handler(FakeRequest())
+        # The result should be a 402 challenge response
+        challenge = Challenge.from_www_authenticate(result.headers["WWW-Authenticate"])
+        assert challenge.request["methodDetails"]["feePayer"] is True
+
+
+class TestFeePayerExternalFallback:
+    """Tests for external fee payer service fallback."""
+
+    @pytest.mark.asyncio
+    async def test_uses_default_fee_payer_url(self, httpx_mock: HTTPXMock) -> None:
+        """Should fall back to DEFAULT_FEE_PAYER_URL when no feePayerUrl in request."""
+        from mpp.methods.tempo._defaults import DEFAULT_FEE_PAYER_URL
+
+        future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
+
+        # Default fee payer URL signing
+        httpx_mock.add_response(
+            url=DEFAULT_FEE_PAYER_URL,
+            json={"jsonrpc": "2.0", "result": "0x76cosigned", "id": 1},
+        )
+        # Broadcast
+        httpx_mock.add_response(
+            url="https://rpc.test",
+            json={"jsonrpc": "2.0", "result": "0xtxhash", "id": 1},
+        )
+        # Receipt
+        httpx_mock.add_response(
+            url="https://rpc.test",
+            json={
+                "jsonrpc": "2.0",
+                "result": {
+                    "status": "0x1",
+                    "logs": [
+                        {
+                            "address": "0x20c0000000000000000000000000000000000000",
+                            "topics": [
+                                "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+                                "0x000000000000000000000000sender00000000000000000000000000000000",
+                                "0x000000000000000000000000742d35cc6634c0532925a3b844bc9e7595f8fe00",
+                            ],
+                            "data": (
+                                "0x000000000000000000000000000000000000"
+                                "00000000000000000000000000000f4240"
+                            ),
+                        }
+                    ],
+                },
+                "id": 1,
+            },
+        )
+
+        intent = ChargeIntent(rpc_url="https://rpc.test")
+        credential = make_credential(
+            payload={"type": "transaction", "signature": "0x76abcdef"},
+        )
+
+        receipt = await intent.verify(
+            credential,
+            {
+                "amount": "1000000",
+                "currency": "0x20c0000000000000000000000000000000000000",
+                "recipient": "0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
+                "expires": future,
+                "methodDetails": {"feePayer": True},
+            },
+        )
+
+        assert receipt.status == "success"
+        # Verify the default URL was called
+        requests = httpx_mock.get_requests()
+        assert any(DEFAULT_FEE_PAYER_URL in str(r.url) for r in requests)
+
+    @pytest.mark.asyncio
+    async def test_external_fee_payer_empty_result(self, httpx_mock: HTTPXMock) -> None:
+        """Should raise when external fee payer returns no signed transaction."""
+        future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
+
+        httpx_mock.add_response(
+            url="https://sponsor.test",
+            json={"jsonrpc": "2.0", "result": None, "id": 1},
+        )
+
+        intent = ChargeIntent(rpc_url="https://rpc.test")
+        credential = make_credential(
+            payload={"type": "transaction", "signature": "0x76abcdef"},
+        )
+
+        with pytest.raises(VerificationError, match="no signed transaction"):
+            await intent.verify(
+                credential,
+                {
+                    "amount": "1000000",
+                    "currency": "0x20c0000000000000000000000000000000000000",
+                    "recipient": "0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
+                    "expires": future,
+                    "methodDetails": {
+                        "feePayer": True,
+                        "feePayerUrl": "https://sponsor.test",
+                    },
+                },
+            )
+
+    @pytest.mark.asyncio
+    async def test_external_fee_payer_string_error(self, httpx_mock: HTTPXMock) -> None:
+        """Should handle non-dict error from external fee payer."""
+        future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
+
+        httpx_mock.add_response(
+            url="https://sponsor.test",
+            json={"jsonrpc": "2.0", "error": "something went wrong", "id": 1},
+        )
+
+        intent = ChargeIntent(rpc_url="https://rpc.test")
+        credential = make_credential(
+            payload={"type": "transaction", "signature": "0x76abcdef"},
+        )
+
+        with pytest.raises(VerificationError, match="Fee payer signing failed"):
+            await intent.verify(
+                credential,
+                {
+                    "amount": "1000000",
+                    "currency": "0x20c0000000000000000000000000000000000000",
+                    "recipient": "0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
+                    "expires": future,
+                    "methodDetails": {
+                        "feePayer": True,
+                        "feePayerUrl": "https://sponsor.test",
+                    },
+                },
+            )
+
+
+class TestFeePayerNotUsedWithoutFlag:
+    """Tests that fee payer is NOT invoked when feePayer=False."""
+
+    @pytest.mark.asyncio
+    async def test_transaction_submitted_directly_without_fee_payer(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        """When feePayer is False, transaction should be sent directly to RPC."""
+        future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
+
+        # Direct broadcast — no fee payer call
+        httpx_mock.add_response(
+            url="https://rpc.test",
+            json={"jsonrpc": "2.0", "result": "0xdirect_hash", "id": 1},
+        )
+        # Receipt
+        httpx_mock.add_response(
+            url="https://rpc.test",
+            json={
+                "jsonrpc": "2.0",
+                "result": {
+                    "status": "0x1",
+                    "logs": [
+                        {
+                            "address": "0x20c0000000000000000000000000000000000000",
+                            "topics": [
+                                "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+                                "0x000000000000000000000000sender00000000000000000000000000000000",
+                                "0x000000000000000000000000742d35cc6634c0532925a3b844bc9e7595f8fe00",
+                            ],
+                            "data": (
+                                "0x000000000000000000000000000000000000"
+                                "00000000000000000000000000000f4240"
+                            ),
+                        }
+                    ],
+                },
+                "id": 1,
+            },
+        )
+
+        fee_payer = TempoAccount.from_key(TEST_PRIVATE_KEY)
+        intent = ChargeIntent(rpc_url="https://rpc.test")
+        # Even with fee_payer on the method, feePayer=False in request means no co-signing
+        method = tempo(
+            fee_payer=fee_payer,
+            intents={"charge": intent},
+        )
+
+        credential = make_credential(
+            payload={"type": "transaction", "signature": "0xabcdef1234567890"},
+        )
+
+        receipt = await intent.verify(
+            credential,
+            {
+                "amount": "1000000",
+                "currency": "0x20c0000000000000000000000000000000000000",
+                "recipient": "0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
+                "expires": future,
+            },
+        )
+
+        assert receipt.status == "success"
+        assert receipt.reference == "0xdirect_hash"
+        # Should have only called rpc.test, never a sponsor URL
+        requests = httpx_mock.get_requests()
+        assert all("rpc.test" in str(r.url) for r in requests)
 
 
 class TestSchemas:
@@ -924,3 +1238,701 @@ class TestDefaultsImmutability:
         """CHAIN_RPC_URLS should reject mutation."""
         with pytest.raises(TypeError):
             CHAIN_RPC_URLS[9999] = "https://evil.rpc"  # type: ignore[index]
+
+
+class TestValidateTransactionPayload:
+    """Tests for _validate_transaction_payload pre-broadcast validation."""
+
+    def _make_intent(self) -> ChargeIntent:
+        return ChargeIntent(rpc_url="https://rpc.test")
+
+    def _make_request(self, **overrides: Any) -> ChargeRequest:
+        defaults = {
+            "amount": "1000000",
+            "currency": "0x20c0000000000000000000000000000000000000",
+            "recipient": "0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
+            "expires": "2030-01-01T00:00:00Z",
+        }
+        defaults.update(overrides)
+        return ChargeRequest.model_validate(defaults)
+
+    def _build_valid_tx_hex(
+        self,
+        currency: str = "0x20c0000000000000000000000000000000000000",
+        recipient: str = "0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
+        amount: int = 1000000,
+        memo: str | None = None,
+    ) -> str:
+        """Build a minimal valid 0x76-prefixed RLP-encoded transaction."""
+        import rlp
+
+        if memo:
+            selector = bytes.fromhex("95777d59")
+            to_padded = bytes.fromhex(recipient[2:].lower().zfill(64))
+            amount_padded = amount.to_bytes(32, "big")
+            memo_bytes = bytes.fromhex(memo[2:] if memo.startswith("0x") else memo)
+            call_data = selector + to_padded + amount_padded + memo_bytes
+        else:
+            selector = bytes.fromhex("a9059cbb")
+            to_padded = bytes.fromhex(recipient[2:].lower().zfill(64))
+            amount_padded = amount.to_bytes(32, "big")
+            call_data = selector + to_padded + amount_padded
+
+        currency_bytes = bytes.fromhex(currency[2:])
+        call = [currency_bytes, b"", call_data]
+        # Minimal tx structure: [chain_id, max_prio_fee, max_fee, gas_limit, calls, ...]
+        tx_fields = [
+            b"\x01",  # chain_id
+            b"\x01",  # max_priority_fee
+            b"\x01",  # max_fee
+            b"\x01",  # gas_limit
+            [call],   # calls
+            b"",      # access_list placeholder
+            b"",      # nonce_key
+            b"\x01",  # nonce
+            b"",      # placeholder
+            b"",      # placeholder
+            b"",      # fee_token
+            b"\x00" * 65,  # sender_sig
+        ]
+        encoded = rlp.encode(tx_fields)
+        return "0x76" + encoded.hex()
+
+    def test_valid_transfer_passes(self) -> None:
+        """Valid transfer tx should pass validation."""
+        intent = self._make_intent()
+        request = self._make_request()
+        tx_hex = self._build_valid_tx_hex()
+        intent._validate_transaction_payload(tx_hex, request)
+
+    def test_wrong_recipient_rejected(self) -> None:
+        """Tx with wrong recipient should be rejected."""
+        intent = self._make_intent()
+        request = self._make_request()
+        tx_hex = self._build_valid_tx_hex(
+            recipient="0x0000000000000000000000000000000000000001"
+        )
+        with pytest.raises(VerificationError, match="no matching payment call"):
+            intent._validate_transaction_payload(tx_hex, request)
+
+    def test_wrong_amount_rejected(self) -> None:
+        """Tx with wrong amount should be rejected."""
+        intent = self._make_intent()
+        request = self._make_request()
+        tx_hex = self._build_valid_tx_hex(amount=999999)
+        with pytest.raises(VerificationError, match="no matching payment call"):
+            intent._validate_transaction_payload(tx_hex, request)
+
+    def test_wrong_currency_rejected(self) -> None:
+        """Tx calling wrong contract should be rejected."""
+        intent = self._make_intent()
+        request = self._make_request()
+        tx_hex = self._build_valid_tx_hex(
+            currency="0x0000000000000000000000000000000000000001"
+        )
+        with pytest.raises(VerificationError, match="no matching payment call"):
+            intent._validate_transaction_payload(tx_hex, request)
+
+    def test_empty_calls_rejected(self) -> None:
+        """Tx with no calls should be rejected."""
+        import rlp
+
+        tx_fields = [b"\x01", b"\x01", b"\x01", b"\x01", [], b"", b"", b"\x01"]
+        encoded = rlp.encode(tx_fields)
+        tx_hex = "0x76" + encoded.hex()
+
+        intent = self._make_intent()
+        request = self._make_request()
+        with pytest.raises(VerificationError, match="no calls"):
+            intent._validate_transaction_payload(tx_hex, request)
+
+    def test_non_0x76_prefix_skipped(self) -> None:
+        """Non-Tempo tx should be silently skipped (not validated)."""
+        intent = self._make_intent()
+        request = self._make_request()
+        intent._validate_transaction_payload("0xdeadbeef", request)
+
+    def test_invalid_hex_skipped(self) -> None:
+        """Invalid hex string should be silently skipped."""
+        intent = self._make_intent()
+        request = self._make_request()
+        intent._validate_transaction_payload("0xnothex", request)
+
+    def test_valid_transfer_with_memo_passes(self) -> None:
+        """Valid transferWithMemo tx should pass when memo matches."""
+        memo = "0x" + "ab" * 32
+        intent = self._make_intent()
+        request = self._make_request(
+            methodDetails={"memo": memo},
+        )
+        tx_hex = self._build_valid_tx_hex(memo=memo)
+        intent._validate_transaction_payload(tx_hex, request)
+
+    def test_wrong_memo_rejected(self) -> None:
+        """Tx with wrong memo should be rejected."""
+        intent = self._make_intent()
+        request = self._make_request(
+            methodDetails={"memo": "0x" + "ab" * 32},
+        )
+        tx_hex = self._build_valid_tx_hex(memo="0x" + "cd" * 32)
+        with pytest.raises(VerificationError, match="no matching payment call"):
+            intent._validate_transaction_payload(tx_hex, request)
+
+    def test_memo_expected_but_transfer_selector_rejected(self) -> None:
+        """When memo is expected, plain transfer selector should be rejected."""
+        intent = self._make_intent()
+        request = self._make_request(
+            methodDetails={"memo": "0x" + "ab" * 32},
+        )
+        # Build tx with plain transfer (no memo)
+        tx_hex = self._build_valid_tx_hex()
+        with pytest.raises(VerificationError, match="no matching payment call"):
+            intent._validate_transaction_payload(tx_hex, request)
+
+
+class TestVerifyTransferLogs:
+    """Tests for _verify_transfer_logs edge cases."""
+
+    def _make_intent(self) -> ChargeIntent:
+        return ChargeIntent(rpc_url="https://rpc.test")
+
+    def _make_request(self, **overrides: Any) -> ChargeRequest:
+        defaults = {
+            "amount": "1000",
+            "currency": "0x20c0000000000000000000000000000000000000",
+            "recipient": "0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
+            "expires": "2030-01-01T00:00:00Z",
+        }
+        defaults.update(overrides)
+        return ChargeRequest.model_validate(defaults)
+
+    def test_empty_logs(self) -> None:
+        """Should return False for empty logs."""
+        intent = self._make_intent()
+        request = self._make_request()
+        assert intent._verify_transfer_logs({"logs": []}, request) is False
+
+    def test_wrong_contract_address(self) -> None:
+        """Should skip logs from wrong contract."""
+        intent = self._make_intent()
+        request = self._make_request()
+        receipt = {
+            "logs": [
+                {
+                    "address": "0x0000000000000000000000000000000000000001",
+                    "topics": [
+                        "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+                        "0x" + "0" * 24 + "a" * 40,
+                        "0x000000000000000000000000742d35cc6634c0532925a3b844bc9e7595f8fe00",
+                    ],
+                    "data": "0x" + hex(1000)[2:].zfill(64),
+                }
+            ]
+        }
+        assert intent._verify_transfer_logs(receipt, request) is False
+
+    def test_insufficient_topics(self) -> None:
+        """Should skip logs with fewer than 3 topics."""
+        intent = self._make_intent()
+        request = self._make_request()
+        receipt = {
+            "logs": [
+                {
+                    "address": "0x20c0000000000000000000000000000000000000",
+                    "topics": [
+                        "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+                    ],
+                    "data": "0x" + hex(1000)[2:].zfill(64),
+                }
+            ]
+        }
+        assert intent._verify_transfer_logs(receipt, request) is False
+
+    def test_wrong_recipient_in_log(self) -> None:
+        """Should skip logs with wrong recipient."""
+        intent = self._make_intent()
+        request = self._make_request()
+        receipt = {
+            "logs": [
+                {
+                    "address": "0x20c0000000000000000000000000000000000000",
+                    "topics": [
+                        "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+                        "0x" + "0" * 24 + "a" * 40,
+                        "0x" + "0" * 24 + "b" * 40,  # wrong recipient
+                    ],
+                    "data": "0x" + hex(1000)[2:].zfill(64),
+                }
+            ]
+        }
+        assert intent._verify_transfer_logs(receipt, request) is False
+
+    def test_wrong_amount_in_log(self) -> None:
+        """Should return False when amount doesn't match."""
+        intent = self._make_intent()
+        request = self._make_request()
+        receipt = {
+            "logs": [
+                {
+                    "address": "0x20c0000000000000000000000000000000000000",
+                    "topics": [
+                        "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+                        "0x" + "0" * 24 + "a" * 40,
+                        "0x000000000000000000000000742d35cc6634c0532925a3b844bc9e7595f8fe00",
+                    ],
+                    "data": "0x" + hex(9999)[2:].zfill(64),
+                }
+            ]
+        }
+        assert intent._verify_transfer_logs(receipt, request) is False
+
+    def test_expected_sender_mismatch(self) -> None:
+        """Should reject when expected_sender doesn't match log from address."""
+        intent = self._make_intent()
+        request = self._make_request()
+        receipt = {
+            "logs": [
+                {
+                    "address": "0x20c0000000000000000000000000000000000000",
+                    "topics": [
+                        "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+                        "0x" + "0" * 24 + "a" * 40,  # from
+                        "0x000000000000000000000000742d35cc6634c0532925a3b844bc9e7595f8fe00",
+                    ],
+                    "data": "0x" + hex(1000)[2:].zfill(64),
+                }
+            ]
+        }
+        assert (
+            intent._verify_transfer_logs(
+                receipt, request, expected_sender="0x" + "b" * 40
+            )
+            is False
+        )
+
+    def test_expected_sender_match(self) -> None:
+        """Should return True when expected_sender matches."""
+        intent = self._make_intent()
+        request = self._make_request()
+        receipt = {
+            "logs": [
+                {
+                    "address": "0x20c0000000000000000000000000000000000000",
+                    "topics": [
+                        "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+                        "0x" + "0" * 24 + "a" * 40,
+                        "0x000000000000000000000000742d35cc6634c0532925a3b844bc9e7595f8fe00",
+                    ],
+                    "data": "0x" + hex(1000)[2:].zfill(64),
+                }
+            ]
+        }
+        assert (
+            intent._verify_transfer_logs(
+                receipt, request, expected_sender="0x" + "a" * 40
+            )
+            is True
+        )
+
+    def test_short_data_skipped(self) -> None:
+        """Should skip logs with data too short to contain amount."""
+        intent = self._make_intent()
+        request = self._make_request()
+        receipt = {
+            "logs": [
+                {
+                    "address": "0x20c0000000000000000000000000000000000000",
+                    "topics": [
+                        "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+                        "0x" + "0" * 24 + "a" * 40,
+                        "0x000000000000000000000000742d35cc6634c0532925a3b844bc9e7595f8fe00",
+                    ],
+                    "data": "0x",  # too short
+                }
+            ]
+        }
+        assert intent._verify_transfer_logs(receipt, request) is False
+
+    def test_transfer_with_memo_topic_needs_4_topics(self) -> None:
+        """TransferWithMemo log needs 4 topics (from, to, memo)."""
+        intent = self._make_intent()
+        memo = "0x" + "ab" * 32
+        request = self._make_request(methodDetails={"memo": memo})
+        receipt = {
+            "logs": [
+                {
+                    "address": "0x20c0000000000000000000000000000000000000",
+                    "topics": [
+                        "0x57bc7354aa85aed339e000bccffabbc529466af35f0772c8f8ee1145927de7f0",
+                        "0x" + "0" * 24 + "a" * 40,
+                        "0x000000000000000000000000742d35cc6634c0532925a3b844bc9e7595f8fe00",
+                        # missing 4th topic (memo)
+                    ],
+                    "data": "0x" + hex(1000)[2:].zfill(64),
+                }
+            ]
+        }
+        assert intent._verify_transfer_logs(receipt, request) is False
+
+
+class TestLocalFeePayerPriority:
+    """Tests that local fee payer takes priority over external when both are configured."""
+
+    @pytest.mark.asyncio
+    async def test_local_fee_payer_not_calls_external_url(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        """When local fee_payer is set, should NOT call feePayerUrl even if provided."""
+        future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
+        fee_payer = TempoAccount.from_key(TEST_PRIVATE_KEY)
+        intent = ChargeIntent(rpc_url="https://rpc.test")
+        method = tempo(
+            fee_payer=fee_payer,
+            intents={"charge": intent},
+        )
+
+        # Build a real sponsored tx so _cosign_as_fee_payer can decode it.
+        # Use a separate RPC URL for client tx building to avoid mock collision.
+        account = TempoAccount.from_key("0x" + "aa" * 32)
+        client_method = tempo(
+            account=account,
+            rpc_url="https://rpc.client",
+            intents={"charge": ChargeIntent()},
+        )
+        # Mock RPC for client tx building (chain_id, nonce, gas_price, estimateGas)
+        httpx_mock.add_response(
+            url="https://rpc.client",
+            json={"jsonrpc": "2.0", "result": "0x1079", "id": 1},
+        )
+        httpx_mock.add_response(
+            url="https://rpc.client",
+            json={"jsonrpc": "2.0", "result": "0x1", "id": 1},
+        )
+        httpx_mock.add_response(
+            url="https://rpc.client",
+            json={"jsonrpc": "2.0", "result": "0x1", "id": 1},
+        )
+        httpx_mock.add_response(
+            url="https://rpc.client",
+            json={"jsonrpc": "2.0", "result": "0x186a0", "id": 1},
+        )
+
+        challenge = Challenge(
+            id="test-local-priority",
+            method="tempo",
+            intent="charge",
+            request={
+                "amount": "1000000",
+                "currency": "0x20c0000000000000000000000000000000000000",
+                "recipient": "0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
+                "methodDetails": {
+                    "feePayer": True,
+                    "feePayerUrl": "https://evil-sponsor.test",
+                },
+            },
+            realm="test.example.com",
+            request_b64="e30",
+        )
+
+        cred = await client_method.create_credential(challenge)
+
+        # Mock the broadcast + receipt for the server-side verify (local cosign path)
+        httpx_mock.add_response(
+            url="https://rpc.test",
+            json={"jsonrpc": "2.0", "result": "0xlocal_hash", "id": 1},
+        )
+        httpx_mock.add_response(
+            url="https://rpc.test",
+            json={
+                "jsonrpc": "2.0",
+                "result": {
+                    "status": "0x1",
+                    "logs": [
+                        {
+                            "address": "0x20c0000000000000000000000000000000000000",
+                            "topics": [
+                                "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+                                "0x" + "0" * 24 + "a" * 40,
+                                "0x000000000000000000000000742d35cc6634c0532925a3b844bc9e7595f8fe00",
+                            ],
+                            "data": (
+                                "0x000000000000000000000000000000000000"
+                                "00000000000000000000000000000f4240"
+                            ),
+                        }
+                    ],
+                },
+                "id": 1,
+            },
+        )
+
+        receipt = await intent.verify(
+            make_credential(
+                payload=cred.payload,
+            ),
+            {
+                "amount": "1000000",
+                "currency": "0x20c0000000000000000000000000000000000000",
+                "recipient": "0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
+                "expires": future,
+                "methodDetails": {
+                    "feePayer": True,
+                    "feePayerUrl": "https://evil-sponsor.test",
+                },
+            },
+        )
+
+        assert receipt.status == "success"
+        # Should never have called the evil sponsor URL
+        requests = httpx_mock.get_requests()
+        assert not any("evil-sponsor" in str(r.url) for r in requests)
+
+
+class TestCosignAsFeePayer:
+    """Tests for _cosign_as_fee_payer edge cases."""
+
+    def test_cosign_no_fee_payer_raises(self) -> None:
+        """Should raise VerificationError when no fee payer is configured."""
+        intent = ChargeIntent(rpc_url="https://rpc.test")
+        assert intent.fee_payer is None
+        with pytest.raises(VerificationError, match="No fee payer account configured"):
+            intent._cosign_as_fee_payer("0x76deadbeef")
+
+    def test_cosign_non_0x76_raises(self) -> None:
+        """Should raise VerificationError for non-Tempo transaction."""
+        fee_payer = TempoAccount.from_key(TEST_PRIVATE_KEY)
+        intent = ChargeIntent(rpc_url="https://rpc.test")
+        method = tempo(fee_payer=fee_payer, intents={"charge": intent})
+        with pytest.raises(VerificationError, match="Failed to deserialize"):
+            intent._cosign_as_fee_payer("0xdeadbeef")
+
+    def test_cosign_invalid_rlp_raises(self) -> None:
+        """Should raise VerificationError for invalid RLP data."""
+        fee_payer = TempoAccount.from_key(TEST_PRIVATE_KEY)
+        intent = ChargeIntent(rpc_url="https://rpc.test")
+        method = tempo(fee_payer=fee_payer, intents={"charge": intent})
+        # 0x76 prefix with garbage
+        with pytest.raises(VerificationError, match="Failed to deserialize|Fee payer signing failed"):
+            intent._cosign_as_fee_payer("0x76ff")
+
+    def test_cosign_empty_tx_raises(self) -> None:
+        """Should raise VerificationError for empty transaction bytes."""
+        fee_payer = TempoAccount.from_key(TEST_PRIVATE_KEY)
+        intent = ChargeIntent(rpc_url="https://rpc.test")
+        method = tempo(fee_payer=fee_payer, intents={"charge": intent})
+        with pytest.raises(VerificationError, match="Failed to deserialize"):
+            intent._cosign_as_fee_payer("0x")
+
+
+class TestReceiptPollingEdgeCases:
+    """Tests for receipt polling error paths in _verify_transaction."""
+
+    @pytest.mark.asyncio
+    async def test_receipt_rpc_error_raises(self) -> None:
+        """Should raise when receipt polling returns RPC error."""
+        future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
+
+        intent = ChargeIntent(rpc_url="https://rpc.test")
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(
+            side_effect=[
+                # Broadcast success
+                mock_response(200, {"jsonrpc": "2.0", "result": "0xtxhash", "id": 1}),
+                # Receipt poll returns error
+                mock_response(
+                    200,
+                    {"jsonrpc": "2.0", "error": {"message": "internal error"}, "id": 1},
+                ),
+            ]
+        )
+        intent._http_client = mock_client
+
+        credential = make_credential(
+            payload={"type": "transaction", "signature": "0xabcdef1234567890"},
+        )
+        with pytest.raises(VerificationError, match="Failed to fetch transaction receipt"):
+            await intent.verify(
+                credential,
+                {
+                    "amount": "1000",
+                    "currency": "0x1234567890123456789012345678901234567890",
+                    "recipient": "0x4567890123456789012345678901234567890123",
+                    "expires": future,
+                },
+            )
+
+    @pytest.mark.asyncio
+    async def test_no_tx_hash_returned_raises(self) -> None:
+        """Should raise when broadcast returns no transaction hash."""
+        future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
+
+        intent = ChargeIntent(rpc_url="https://rpc.test")
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(
+            return_value=mock_response(200, {"jsonrpc": "2.0", "result": None, "id": 1})
+        )
+        intent._http_client = mock_client
+
+        credential = make_credential(
+            payload={"type": "transaction", "signature": "0xabcdef1234567890"},
+        )
+        with pytest.raises(VerificationError, match="No transaction hash returned"):
+            await intent.verify(
+                credential,
+                {
+                    "amount": "1000",
+                    "currency": "0x1234567890123456789012345678901234567890",
+                    "recipient": "0x4567890123456789012345678901234567890123",
+                    "expires": future,
+                },
+            )
+
+    @pytest.mark.asyncio
+    async def test_reverted_transaction_raises(self) -> None:
+        """Should raise when submitted transaction reverts."""
+        future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
+
+        intent = ChargeIntent(rpc_url="https://rpc.test")
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(
+            side_effect=[
+                mock_response(200, {"jsonrpc": "2.0", "result": "0xtxhash", "id": 1}),
+                mock_response(
+                    200,
+                    {
+                        "jsonrpc": "2.0",
+                        "result": {"status": "0x0", "logs": []},
+                        "id": 1,
+                    },
+                ),
+            ]
+        )
+        intent._http_client = mock_client
+
+        credential = make_credential(
+            payload={"type": "transaction", "signature": "0xabcdef1234567890"},
+        )
+        with pytest.raises(VerificationError, match="Transaction reverted"):
+            await intent.verify(
+                credential,
+                {
+                    "amount": "1000",
+                    "currency": "0x1234567890123456789012345678901234567890",
+                    "recipient": "0x4567890123456789012345678901234567890123",
+                    "expires": future,
+                },
+            )
+
+    @pytest.mark.asyncio
+    async def test_transaction_no_matching_logs_after_broadcast(self) -> None:
+        """Should raise when broadcast tx receipt has no matching transfer logs."""
+        future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
+
+        intent = ChargeIntent(rpc_url="https://rpc.test")
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(
+            side_effect=[
+                mock_response(200, {"jsonrpc": "2.0", "result": "0xtxhash", "id": 1}),
+                mock_response(
+                    200,
+                    {
+                        "jsonrpc": "2.0",
+                        "result": {"status": "0x1", "logs": []},
+                        "id": 1,
+                    },
+                ),
+            ]
+        )
+        intent._http_client = mock_client
+
+        credential = make_credential(
+            payload={"type": "transaction", "signature": "0xabcdef1234567890"},
+        )
+        with pytest.raises(VerificationError, match="Transfer log"):
+            await intent.verify(
+                credential,
+                {
+                    "amount": "1000",
+                    "currency": "0x1234567890123456789012345678901234567890",
+                    "recipient": "0x4567890123456789012345678901234567890123",
+                    "expires": future,
+                },
+            )
+
+    @pytest.mark.asyncio
+    async def test_broadcast_error_with_data_field(self) -> None:
+        """Should include error data in VerificationError message."""
+        future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
+
+        intent = ChargeIntent(rpc_url="https://rpc.test")
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(
+            return_value=mock_response(
+                200,
+                {
+                    "jsonrpc": "2.0",
+                    "error": {
+                        "message": "execution reverted",
+                        "data": "0xdeadbeef",
+                    },
+                    "id": 1,
+                },
+            )
+        )
+        intent._http_client = mock_client
+
+        credential = make_credential(
+            payload={"type": "transaction", "signature": "0xabcdef1234567890"},
+        )
+        with pytest.raises(VerificationError, match="execution reverted.*0xdeadbeef"):
+            await intent.verify(
+                credential,
+                {
+                    "amount": "1000",
+                    "currency": "0x1234567890123456789012345678901234567890",
+                    "recipient": "0x4567890123456789012345678901234567890123",
+                    "expires": future,
+                },
+            )
+
+
+class TestMppPayDecoratorMemo:
+    """Tests for memo passing through Mpp.charge()."""
+
+    @pytest.mark.asyncio
+    async def test_charge_emits_memo_in_method_details(self) -> None:
+        """Mpp.charge(memo=...) should include memo in methodDetails."""
+        from mpp.server import Mpp
+
+        srv = Mpp.create(
+            method=tempo(
+                currency="0x20c0000000000000000000000000000000000000",
+                recipient="0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
+                intents={"charge": ChargeIntent()},
+            ),
+            realm="test.com",
+            secret_key="test-secret",
+        )
+        memo = "0x" + "ab" * 32
+        result = await srv.charge(authorization=None, amount="0.50", memo=memo)
+        assert isinstance(result, Challenge)
+        assert result.request["methodDetails"]["memo"] == memo
+
+    @pytest.mark.asyncio
+    async def test_charge_chain_id_in_method_details(self) -> None:
+        """Mpp.charge(chain_id=...) should include chainId in methodDetails."""
+        from mpp.server import Mpp
+
+        srv = Mpp.create(
+            method=tempo(
+                chain_id=42431,
+                currency="0x20c0000000000000000000000000000000000000",
+                recipient="0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
+                intents={"charge": ChargeIntent()},
+            ),
+            realm="test.com",
+            secret_key="test-secret",
+        )
+        result = await srv.charge(authorization=None, amount="0.50")
+        assert isinstance(result, Challenge)
+        assert result.request["methodDetails"]["chainId"] == 42431


### PR DESCRIPTION
## Summary

Add server-side fee payer sponsorship for Tempo transactions, allowing the server to co-sign client transactions locally (domain `0x78`) or fall back to an external fee payer service.

## Changes

### Core
- **`ChargeIntent._cosign_as_fee_payer`**: Deserializes client `0x76` tx, recovers sender via ecrecover, sets `fee_token` (default pathUSD), and signs with domain `0x78` using pytempo
- **`_verify_transaction`**: Local fee payer path (`self.fee_payer`) takes priority over external fee payer service (`eth_signRawTransaction` RPC fallback to `feePayerUrl` or `DEFAULT_FEE_PAYER_URL`)
- **`_validate_transaction_payload`**: Pre-validates tx contains expected TIP-20 transfer call (recipient, amount, currency, memo, selector) before broadcasting
- **`Mpp.charge()` / `Mpp.pay()`**: Accept `fee_payer=True` flag, emitting `feePayer` in challenge `methodDetails`
- **Fee payer propagation**: `ChargeIntent.fee_payer` property reads from parent `TempoMethod` via `_method` back-reference (set by `tempo()` factory)

### Tests (31 new)
- `TestValidateTransactionPayload` (11): recipient/amount/currency/memo/selector validation, empty calls, non-0x76 skip
- `TestVerifyTransferLogs` (9): sender matching, short data, topic counts, wrong contract/recipient/amount
- `TestLocalFeePayerPriority` (1): local fee payer never calls `feePayerUrl` even when provided
- `TestCosignAsFeePayer` (4): no fee payer, non-0x76, invalid RLP, empty tx
- `TestReceiptPollingEdgeCases` (5): RPC errors, no tx hash, reverted tx, error data field
- `TestMppPayDecoratorMemo` (2): memo and chain_id emission

## Security Review Notes

The oracle review identified items to track for future hardening:
- **SSRF**: `feePayerUrl` from client-controlled `methodDetails` — consider allowlist or ignoring
- **Gas caps**: No policy limits on `max_fee_per_gas`/`gas_limit` in `_cosign_as_fee_payer` — add sponsor caps
- **Fail-open**: `_validate_transaction_payload` silently skips on decode errors — make fail-closed for sponsored mode
- **Extra calls**: Validation accepts tx with extra calls beyond the expected transfer — restrict to 1 call in sponsored mode

All 276 tests pass (9 skipped).