### PR TITLE
feat: implement full fee payer support

### DIFF
--- a/.changelog/lively-hills-draw.md
+++ b/.changelog/lively-hills-draw.md
@@ -1,0 +1,5 @@
+---
+pympp: minor
+---
+
+Added full fee payer support to the Tempo method, allowing servers to co-sign sponsored transactions locally using a configured `fee_payer` account instead of forwarding to an external service. Updated the `tempo()` factory and `ChargeIntent` to propagate the fee payer account, and introduced expiring nonce logic for replay protection on sponsored transactions.

--- a/src/mpp/methods/tempo/client.py
+++ b/src/mpp/methods/tempo/client.py
@@ -5,6 +5,7 @@ Implements the charge (TempoMethod) client method.
 
 from __future__ import annotations
 
+import time
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
@@ -19,6 +20,8 @@ if TYPE_CHECKING:
 
 
 DEFAULT_GAS_LIMIT = 100_000
+EXPIRING_NONCE_KEY = (1 << 256) - 1  # U256::MAX
+FEE_PAYER_VALID_BEFORE_SECS = 25
 
 
 class TransactionError(Exception):
@@ -52,6 +55,7 @@ class TempoMethod:
 
     name: str = "tempo"
     account: TempoAccount | None = None
+    fee_payer: TempoAccount | None = None
     root_account: str | None = None
     rpc_url: str = RPC_URL
     chain_id: int | None = None
@@ -90,6 +94,11 @@ class TempoMethod:
             raise ValueError(f"Unsupported intent: {challenge.intent}")
 
         request = challenge.request
+        method_details = request.get("methodDetails", {})
+        use_fee_payer = (
+            method_details.get("feePayer", False) if isinstance(method_details, dict) else False
+        )
+
         nonce_key = request.get("nonce_key", 0)
         if isinstance(nonce_key, str):
             if nonce_key.startswith("0x"):
@@ -97,7 +106,6 @@ class TempoMethod:
             else:
                 nonce_key = int(nonce_key)
 
-        method_details = request.get("methodDetails", {})
         memo = method_details.get("memo") if isinstance(method_details, dict) else None
         if memo is None:
             memo = encode_attribution(server_id=challenge.realm, client_id=self.client_id)
@@ -135,6 +143,7 @@ class TempoMethod:
             memo=memo,
             rpc_url=rpc_url,
             expected_chain_id=expected_chain_id,
+            awaiting_fee_payer=use_fee_payer,
         )
 
         return Credential(
@@ -152,11 +161,17 @@ class TempoMethod:
         memo: str | None = None,
         rpc_url: str | None = None,
         expected_chain_id: int | None = None,
+        awaiting_fee_payer: bool = False,
     ) -> tuple[str, int]:
         """Build a client-signed Tempo transaction.
 
         Creates a TempoTransaction (type 0x76) with fee token set to the
         transfer currency, allowing gas to be paid in the same token.
+
+        When ``awaiting_fee_payer`` is True, the transaction is built with
+        a fee payer placeholder so a sponsoring service can co-sign it
+        before broadcast. Uses expiring nonces (nonce_key=U256::MAX,
+        nonce=0) with a ``valid_before`` window for replay protection.
 
         Args:
             amount: Transfer amount as string.
@@ -166,6 +181,7 @@ class TempoMethod:
             memo: Optional 32-byte memo (hex string) for transferWithMemo.
             rpc_url: RPC URL to use. Defaults to ``self.rpc_url``.
             expected_chain_id: If set, verify the RPC reports this chain ID.
+            awaiting_fee_payer: If True, build for fee payer sponsorship.
 
         Returns:
             Tuple of (raw signed transaction hex, chain ID).
@@ -173,6 +189,7 @@ class TempoMethod:
         Raises:
             TransactionError: If the RPC's chain ID doesn't match expected.
         """
+        import attrs
         from pytempo import Call, TempoTransaction
 
         if self.account is None:
@@ -185,13 +202,24 @@ class TempoMethod:
         else:
             transfer_data = self._encode_transfer(recipient, int(amount))
 
-        chain_id, nonce, gas_price = await get_tx_params(resolved_rpc, self.account.address)
+        chain_id, on_chain_nonce, gas_price = await get_tx_params(
+            resolved_rpc, self.account.address
+        )
 
         if expected_chain_id is not None and chain_id != expected_chain_id:
             raise TransactionError(
                 f"Chain ID mismatch: RPC returned {chain_id}, "
                 f"expected {expected_chain_id} from challenge"
             )
+
+        if awaiting_fee_payer:
+            resolved_nonce_key = EXPIRING_NONCE_KEY
+            resolved_nonce = 0
+            valid_before = int(time.time()) + FEE_PAYER_VALID_BEFORE_SECS
+        else:
+            resolved_nonce_key = nonce_key
+            resolved_nonce = on_chain_nonce
+            valid_before = None
 
         gas_limit = DEFAULT_GAS_LIMIT
         try:
@@ -207,13 +235,19 @@ class TempoMethod:
             gas_limit=gas_limit,
             max_fee_per_gas=gas_price,
             max_priority_fee_per_gas=gas_price,
-            nonce=nonce,
-            nonce_key=nonce_key,
-            fee_token=currency,
+            nonce=resolved_nonce,
+            nonce_key=resolved_nonce_key,
+            fee_token=None if awaiting_fee_payer else currency,
+            awaiting_fee_payer=awaiting_fee_payer,
+            valid_before=valid_before,
             calls=(Call.create(to=currency, value=0, data=transfer_data),),
         )
 
         signed_tx = tx.sign(self.account.private_key)
+
+        if awaiting_fee_payer:
+            signed_tx = attrs.evolve(signed_tx, fee_payer_signature=b"\x00")
+
         return "0x" + signed_tx.encode().hex(), chain_id
 
     def _encode_transfer(self, to: str, amount: int) -> str:
@@ -250,6 +284,7 @@ class TempoMethod:
 def tempo(
     intents: dict[str, Intent],
     account: TempoAccount | None = None,
+    fee_payer: TempoAccount | None = None,
     chain_id: int | None = None,
     rpc_url: str | None = None,
     root_account: str | None = None,
@@ -262,7 +297,11 @@ def tempo(
 
     Args:
         intents: Intents to register (e.g. charge).
-        account: Account for signing transactions.
+        account: Account for signing transactions (client-side).
+        fee_payer: Account for co-signing sponsored transactions
+            (server-side). When set, the server signs with domain
+            ``0x78`` and broadcasts directly — no external fee payer
+            service needed.
         chain_id: Tempo chain ID (4217 for mainnet, 42431 for testnet).
             Resolves the RPC URL automatically from known chains.
         rpc_url: Tempo RPC endpoint URL. Overrides the URL resolved
@@ -277,18 +316,18 @@ def tempo(
         A configured TempoMethod instance.
 
     Example:
-        from mpp.methods.tempo import ChargeIntent
+        from mpp.methods.tempo import ChargeIntent, TempoAccount
 
-        # Testnet — resolves RPC automatically
+        # Server with fee payer — sponsors gas for clients
         method = tempo(
             chain_id=42431,
+            fee_payer=TempoAccount.from_env("FEE_PAYER_KEY"),
             intents={"charge": ChargeIntent()},
         )
 
-        # Custom RPC
+        # Client
         method = tempo(
-            chain_id=42431,
-            rpc_url="https://my-rpc.example.com",
+            account=TempoAccount.from_key("0x..."),
             intents={"charge": ChargeIntent()},
         )
     """
@@ -297,6 +336,7 @@ def tempo(
 
     method = TempoMethod(
         account=account,
+        fee_payer=fee_payer,
         rpc_url=rpc_url,
         chain_id=chain_id,
         root_account=root_account,
@@ -308,5 +348,7 @@ def tempo(
     for intent in intents.values():
         if hasattr(intent, "rpc_url") and intent.rpc_url is None:
             intent.rpc_url = rpc_url
+        if hasattr(intent, "_method"):
+            intent._method = method
     method._intents = dict(intents)
     return method

--- a/src/mpp/methods/tempo/client.py
+++ b/src/mpp/methods/tempo/client.py
@@ -6,9 +6,10 @@ Implements the charge (TempoMethod) client method.
 from __future__ import annotations
 
 import time
-import attrs
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
+
+import attrs
 
 from mpp import Challenge, Credential
 from mpp.methods.tempo._attribution import encode as encode_attribution

--- a/src/mpp/methods/tempo/client.py
+++ b/src/mpp/methods/tempo/client.py
@@ -6,6 +6,7 @@ Implements the charge (TempoMethod) client method.
 from __future__ import annotations
 
 import time
+import attrs
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
@@ -189,7 +190,6 @@ class TempoMethod:
         Raises:
             TransactionError: If the RPC's chain ID doesn't match expected.
         """
-        import attrs
         from pytempo import Call, TempoTransaction
 
         if self.account is None:

--- a/src/mpp/methods/tempo/intents.py
+++ b/src/mpp/methods/tempo/intents.py
@@ -9,6 +9,8 @@ import asyncio
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
+import attrs
+
 from mpp import Credential, Receipt
 from mpp.errors import VerificationError
 from mpp.methods.tempo._defaults import DEFAULT_FEE_PAYER_URL, PATH_USD, rpc_url_for_chain
@@ -307,7 +309,7 @@ class ChargeIntent:
 
         if request.methodDetails.feePayer:
             if self.fee_payer is not None:
-                raw_tx = self._cosign_as_fee_payer(raw_tx, request.currency)
+                raw_tx = self._cosign_as_fee_payer(raw_tx, request.currency, request=request)
             else:
                 fee_payer_url = request.methodDetails.feePayerUrl or DEFAULT_FEE_PAYER_URL
 
@@ -401,25 +403,30 @@ class ChargeIntent:
 
         return Receipt.success(tx_hash)
 
-    def _cosign_as_fee_payer(self, raw_tx: str, fee_token: str | None = None) -> str:
+    def _cosign_as_fee_payer(
+        self, raw_tx: str, fee_token: str | None = None, request: ChargeRequest | None = None
+    ) -> str:
         """Co-sign a client-signed transaction as fee payer.
 
-        Deserializes the client's transaction, sets the fee token, and
-        signs with domain ``0x78``. The resulting transaction contains
-        both the client's signature and the fee payer's signature.
+        Deserializes the client's transaction, validates it contains the
+        expected payment call, sets the fee token, and signs with domain
+        ``0x78``. The resulting transaction contains both the client's
+        signature and the fee payer's signature.
 
         Args:
             raw_tx: Hex-encoded client-signed transaction (0x76...).
             fee_token: TIP-20 token address for fee payment.
                 Defaults to pathUSD.
+            request: The charge request to validate against. When provided,
+                the transaction calls are checked to ensure they target the
+                expected currency with the correct transfer parameters.
 
         Returns:
             Hex-encoded co-signed transaction ready for broadcast.
 
         Raises:
-            VerificationError: If deserialization or signing fails.
+            VerificationError: If deserialization, validation, or signing fails.
         """
-        import attrs
         import rlp
         from pytempo import Call, TempoTransaction
         from pytempo.models import as_address
@@ -439,6 +446,12 @@ class ChargeIntent:
             return int.from_bytes(b, "big") if b else 0
 
         calls = tuple(Call(to=c[0], value=_int(c[1]), data=c[2]) for c in decoded[4])
+
+        # Validate the transaction calls match the expected payment before
+        # co-signing.  Without this check the server would sponsor arbitrary
+        # transactions submitted by any sender.
+        if request is not None:
+            self._validate_cosign_calls(calls, request)
 
         # Recover sender address from the sender's signature
         sender_sig = decoded[-1]  # last field
@@ -481,6 +494,78 @@ class ChargeIntent:
             raise VerificationError("Fee payer signing failed") from err
 
         return "0x" + cosigned.encode().hex()
+
+    def _validate_cosign_calls(self, calls: tuple, request: ChargeRequest) -> None:
+        """Validate that decoded transaction calls match the charge request.
+
+        Ensures the server only co-signs transactions that target the
+        expected currency contract with a valid transfer selector,
+        correct recipient, and correct amount.
+
+        Args:
+            calls: Decoded Call tuples from the transaction.
+            request: The charge request with expected parameters.
+
+        Raises:
+            VerificationError: If no call matches the expected payment.
+        """
+        expected_memo = request.methodDetails.memo
+
+        for call in calls:
+            call_to = call.to if isinstance(call.to, bytes) else bytes.fromhex(
+                call.to[2:] if isinstance(call.to, str) and call.to.startswith("0x") else str(call.to)
+            )
+            call_to_hex = "0x" + call_to.hex()
+
+            if call_to_hex.lower() != request.currency.lower():
+                continue
+
+            if call.value and int.from_bytes(call.value, "big") if isinstance(call.value, bytes) else (call.value or 0):
+                if isinstance(call.value, int) and call.value != 0:
+                    continue
+                elif isinstance(call.value, bytes) and int.from_bytes(call.value, "big") != 0:
+                    continue
+
+            call_data = call.data if isinstance(call.data, bytes) else bytes.fromhex(
+                call.data[2:] if isinstance(call.data, str) and call.data.startswith("0x") else str(call.data)
+            )
+            call_data_hex = call_data.hex()
+
+            if len(call_data_hex) < 8:
+                continue
+
+            selector = call_data_hex[:8].lower()
+
+            if expected_memo:
+                if selector != TRANSFER_WITH_MEMO_SELECTOR:
+                    continue
+            elif selector not in (TRANSFER_SELECTOR, TRANSFER_WITH_MEMO_SELECTOR):
+                continue
+
+            if len(call_data_hex) < 136:
+                continue
+            decoded_to = "0x" + call_data_hex[32:72]
+            decoded_amount = int(call_data_hex[72:136], 16)
+
+            if decoded_to.lower() != request.recipient.lower():
+                continue
+
+            if decoded_amount != int(request.amount):
+                continue
+
+            if expected_memo:
+                if len(call_data_hex) < 200:
+                    continue
+                decoded_memo = "0x" + call_data_hex[136:200]
+                memo_clean = expected_memo.lower()
+                if not memo_clean.startswith("0x"):
+                    memo_clean = "0x" + memo_clean
+                if decoded_memo.lower() != memo_clean:
+                    continue
+
+            return
+
+        raise VerificationError("Invalid transaction: no matching payment call found")
 
     def _validate_transaction_payload(self, signature: str, request: ChargeRequest) -> None:
         """Validate that a signed transaction contains the expected call.

--- a/src/mpp/methods/tempo/intents.py
+++ b/src/mpp/methods/tempo/intents.py
@@ -512,23 +512,31 @@ class ChargeIntent:
         expected_memo = request.methodDetails.memo
 
         for call in calls:
-            call_to = call.to if isinstance(call.to, bytes) else bytes.fromhex(
-                call.to[2:] if isinstance(call.to, str) and call.to.startswith("0x") else str(call.to)
-            )
+            if isinstance(call.to, bytes):
+                call_to = call.to
+            else:
+                raw = call.to
+                if isinstance(raw, str) and raw.startswith("0x"):
+                    raw = raw[2:]
+                call_to = bytes.fromhex(str(raw))
             call_to_hex = "0x" + call_to.hex()
 
             if call_to_hex.lower() != request.currency.lower():
                 continue
 
-            if call.value and int.from_bytes(call.value, "big") if isinstance(call.value, bytes) else (call.value or 0):
-                if isinstance(call.value, int) and call.value != 0:
-                    continue
-                elif isinstance(call.value, bytes) and int.from_bytes(call.value, "big") != 0:
-                    continue
+            val = call.value
+            if isinstance(val, bytes):
+                val = int.from_bytes(val, "big")
+            if val:
+                continue
 
-            call_data = call.data if isinstance(call.data, bytes) else bytes.fromhex(
-                call.data[2:] if isinstance(call.data, str) and call.data.startswith("0x") else str(call.data)
-            )
+            if isinstance(call.data, bytes):
+                call_data = call.data
+            else:
+                raw = call.data
+                if isinstance(raw, str) and raw.startswith("0x"):
+                    raw = raw[2:]
+                call_data = bytes.fromhex(str(raw))
             call_data_hex = call_data.hex()
 
             if len(call_data_hex) < 8:

--- a/src/mpp/methods/tempo/intents.py
+++ b/src/mpp/methods/tempo/intents.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Any
 
 from mpp import Credential, Receipt
 from mpp.errors import VerificationError
-from mpp.methods.tempo._defaults import DEFAULT_FEE_PAYER_URL, rpc_url_for_chain
+from mpp.methods.tempo._defaults import DEFAULT_FEE_PAYER_URL, PATH_USD, rpc_url_for_chain
 from mpp.methods.tempo.schemas import (
     ChargeRequest,
     CredentialPayload,
@@ -21,6 +21,8 @@ from mpp.methods.tempo.schemas import (
 
 if TYPE_CHECKING:
     import httpx
+
+    from mpp.methods.tempo.account import TempoAccount
 
 
 DEFAULT_TIMEOUT = 30.0
@@ -62,8 +64,9 @@ class ChargeIntent:
 
     Verifies that a payment transaction matches the requested parameters.
 
-    When used via ``tempo()``, the ``rpc_url`` is propagated automatically
-    from the method level. You can also pass it directly for standalone use.
+    When used via ``tempo()``, the ``rpc_url`` and ``fee_payer`` are read
+    from the parent method automatically. You can also pass ``rpc_url``
+    directly for standalone use.
 
     This class manages an HTTP client lifecycle. Use as an async context manager
     for automatic cleanup, or call `aclose()` explicitly when done.
@@ -107,9 +110,15 @@ class ChargeIntent:
         if rpc_url is None and chain_id is not None:
             rpc_url = rpc_url_for_chain(chain_id)
         self.rpc_url = rpc_url
+        self._method = None
         self._http_client = http_client
         self._owns_client = http_client is None
         self._timeout = timeout
+
+    @property
+    def fee_payer(self) -> TempoAccount | None:
+        """Fee payer account, read from the parent method."""
+        return getattr(self._method, "fee_payer", None) if self._method else None
 
     async def __aenter__(self) -> ChargeIntent:
         """Enter async context, creating HTTP client if needed."""
@@ -286,34 +295,57 @@ class ChargeIntent:
 
         Pre-validates the transaction contains the expected TIP-20 transfer call
         before broadcasting. For sponsored transactions (methodDetails.feePayer
-        = True), forwards to fee payer service. For regular transactions,
+        = True), co-signs locally if a fee payer account is configured, otherwise
+        forwards to an external fee payer service. For regular transactions,
         submits directly.
         """
         self._validate_transaction_payload(payload.signature, request)
 
         client = await self._get_client()
 
+        raw_tx = payload.signature
+
         if request.methodDetails.feePayer:
-            fee_payer_url = request.methodDetails.feePayerUrl or DEFAULT_FEE_PAYER_URL
-            response = await client.post(
-                fee_payer_url,
-                json={
-                    "jsonrpc": "2.0",
-                    "method": "eth_sendRawTransaction",
-                    "params": [payload.signature],
-                    "id": 1,
-                },
-            )
-        else:
-            response = await client.post(
-                self.rpc_url,
-                json={
-                    "jsonrpc": "2.0",
-                    "method": "eth_sendRawTransaction",
-                    "params": [payload.signature],
-                    "id": 1,
-                },
-            )
+            if self.fee_payer is not None:
+                raw_tx = self._cosign_as_fee_payer(raw_tx, request.currency)
+            else:
+                fee_payer_url = request.methodDetails.feePayerUrl or DEFAULT_FEE_PAYER_URL
+
+                sign_response = await client.post(
+                    fee_payer_url,
+                    json={
+                        "jsonrpc": "2.0",
+                        "method": "eth_signRawTransaction",
+                        "params": [raw_tx],
+                        "id": 1,
+                    },
+                )
+                sign_response.raise_for_status()
+                sign_result = sign_response.json()
+
+                if "error" in sign_result:
+                    error_obj = sign_result["error"]
+                    if isinstance(error_obj, dict):
+                        error_msg = (
+                            error_obj.get("message") or error_obj.get("name") or str(error_obj)
+                        )
+                    else:
+                        error_msg = str(error_obj)
+                    raise VerificationError(f"Fee payer signing failed: {error_msg}")
+
+                raw_tx = sign_result.get("result")
+                if not raw_tx:
+                    raise VerificationError("Fee payer returned no signed transaction")
+
+        response = await client.post(
+            self.rpc_url,
+            json={
+                "jsonrpc": "2.0",
+                "method": "eth_sendRawTransaction",
+                "params": [raw_tx],
+                "id": 1,
+            },
+        )
         response.raise_for_status()
         result = response.json()
 
@@ -368,6 +400,87 @@ class ChargeIntent:
             )
 
         return Receipt.success(tx_hash)
+
+    def _cosign_as_fee_payer(self, raw_tx: str, fee_token: str | None = None) -> str:
+        """Co-sign a client-signed transaction as fee payer.
+
+        Deserializes the client's transaction, sets the fee token, and
+        signs with domain ``0x78``. The resulting transaction contains
+        both the client's signature and the fee payer's signature.
+
+        Args:
+            raw_tx: Hex-encoded client-signed transaction (0x76...).
+            fee_token: TIP-20 token address for fee payment.
+                Defaults to pathUSD.
+
+        Returns:
+            Hex-encoded co-signed transaction ready for broadcast.
+
+        Raises:
+            VerificationError: If deserialization or signing fails.
+        """
+        import attrs
+        import rlp
+        from pytempo import Call, TempoTransaction
+        from pytempo.models import as_address
+
+        if self.fee_payer is None:
+            raise VerificationError("No fee payer account configured")
+
+        try:
+            all_bytes = bytes.fromhex(raw_tx[2:] if raw_tx.startswith("0x") else raw_tx)
+            if not all_bytes or all_bytes[0] != 0x76:
+                raise ValueError("Not a Tempo transaction")
+            decoded = rlp.decode(all_bytes[1:])
+        except Exception as err:
+            raise VerificationError("Failed to deserialize client transaction") from err
+
+        def _int(b: bytes) -> int:
+            return int.from_bytes(b, "big") if b else 0
+
+        calls = tuple(Call(to=c[0], value=_int(c[1]), data=c[2]) for c in decoded[4])
+
+        # Recover sender address from the sender's signature
+        sender_sig = decoded[-1]  # last field
+        tx_for_recovery = TempoTransaction(
+            chain_id=_int(decoded[0]),
+            max_priority_fee_per_gas=_int(decoded[1]),
+            max_fee_per_gas=_int(decoded[2]),
+            gas_limit=_int(decoded[3]),
+            calls=calls,
+            access_list=(),
+            nonce_key=_int(decoded[6]),
+            nonce=_int(decoded[7]),
+            valid_before=_int(decoded[8]) if decoded[8] else None,
+            valid_after=_int(decoded[9]) if decoded[9] else None,
+            fee_token=decoded[10] if decoded[10] else None,
+            awaiting_fee_payer=True,
+        )
+        sender_hash = tx_for_recovery.get_signing_hash(for_fee_payer=False)
+
+        from eth_account import Account
+
+        sender_address = Account._recover_hash(sender_hash, signature=sender_sig)
+
+        # Reconstruct with sender signature and address
+        resolved_fee_token = fee_token or PATH_USD
+        fee_token_bytes = bytes.fromhex(
+            resolved_fee_token[2:] if resolved_fee_token.startswith("0x") else resolved_fee_token
+        )
+
+        tx_to_sign = attrs.evolve(
+            tx_for_recovery,
+            sender_signature=sender_sig,
+            sender_address=as_address(sender_address),
+            fee_token=fee_token_bytes,
+        )
+
+        try:
+            cosigned = tx_to_sign.sign(self.fee_payer.private_key, for_fee_payer=True)
+        except Exception as err:
+            raise VerificationError("Fee payer signing failed") from err
+
+        return "0x" + cosigned.encode().hex()
 
     def _validate_transaction_payload(self, signature: str, request: ChargeRequest) -> None:
         """Validate that a signed transaction contains the expected call.

--- a/src/mpp/methods/tempo/intents.py
+++ b/src/mpp/methods/tempo/intents.py
@@ -29,31 +29,27 @@ if TYPE_CHECKING:
 
 DEFAULT_TIMEOUT = 30.0
 
-# Receipt polling configuration
-#
-# After submitting a transaction, we poll for the receipt since it won't be
-# available until the transaction is included in a block. Block times vary:
-# - Tempo mainnet: ~400ms
-# - Tempo testnet: ~2-4s (can be slower under load)
-#
-# For comparison, viem's waitForTransactionReceipt uses:
-# - 6 retries with exponential backoff (200ms, 400ms, 800ms, 1.6s, 3.2s, 6.4s)
-# - 180s total timeout
-#
-# We use a simpler fixed-delay approach that provides ~10s total wait time,
-# sufficient for testnet latency while keeping the implementation simple.
+# Receipt polling: 20 * 0.5s = ~10s, enough for testnet block times (~2-4s).
 MAX_RECEIPT_RETRY_ATTEMPTS = 20
 RECEIPT_RETRY_DELAY_SECONDS = 0.5
 
-# TIP-20 function selectors
-TRANSFER_SELECTOR = "a9059cbb"  # keccak256("transfer(address,uint256)")[:4]
-TRANSFER_WITH_MEMO_SELECTOR = "95777d59"  # transferWithMemo(address,uint256,bytes32)
+TRANSFER_SELECTOR = "a9059cbb"
+TRANSFER_WITH_MEMO_SELECTOR = "95777d59"
 
-# Event topic hashes
 TRANSFER_TOPIC = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
 TRANSFER_WITH_MEMO_TOPIC = "0x57bc7354aa85aed339e000bccffabbc529466af35f0772c8f8ee1145927de7f0"
 
 ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
+
+
+def _rpc_error_msg(result: dict) -> str:
+    """Extract error message from a JSON-RPC error response."""
+    error_obj = result["error"]
+    if isinstance(error_obj, dict):
+        msg = error_obj.get("message") or error_obj.get("name") or str(error_obj)
+        data = error_obj.get("data", "")
+        return f"{msg}: {data}" if data else msg
+    return str(error_obj)
 
 
 def _match_transfer_calldata(call_data_hex: str, request: ChargeRequest) -> bool:
@@ -361,14 +357,9 @@ class ChargeIntent:
                 sign_result = sign_response.json()
 
                 if "error" in sign_result:
-                    error_obj = sign_result["error"]
-                    if isinstance(error_obj, dict):
-                        error_msg = (
-                            error_obj.get("message") or error_obj.get("name") or str(error_obj)
-                        )
-                    else:
-                        error_msg = str(error_obj)
-                    raise VerificationError(f"Fee payer signing failed: {error_msg}")
+                    raise VerificationError(
+                        f"Fee payer signing failed: {_rpc_error_msg(sign_result)}"
+                    )
 
                 raw_tx = sign_result.get("result")
                 if not raw_tx:
@@ -387,15 +378,9 @@ class ChargeIntent:
         result = response.json()
 
         if "error" in result:
-            error_obj = result["error"]
-            if isinstance(error_obj, dict):
-                error_msg = error_obj.get("message") or error_obj.get("name") or str(error_obj)
-                error_data = error_obj.get("data", "")
-            else:
-                error_msg = str(error_obj)
-                error_data = ""
-            full_error = f"{error_msg}: {error_data}" if error_data else error_msg
-            raise VerificationError(f"Transaction submission failed: {full_error}")
+            raise VerificationError(
+                f"Transaction submission failed: {_rpc_error_msg(result)}"
+            )
 
         tx_hash = result.get("result")
         if not tx_hash:
@@ -468,7 +453,7 @@ class ChargeIntent:
         calls = tuple(Call(to=c[0], value=_int(c[1]), data=c[2]) for c in decoded[4])
 
         if request is not None:
-            self._validate_cosign_calls(calls, request)
+            self._validate_calls(calls, request)
 
         sender_sig = decoded[-1]
         tx_for_recovery = TempoTransaction(
@@ -491,16 +476,11 @@ class ChargeIntent:
 
         sender_address = Account._recover_hash(sender_hash, signature=sender_sig)
 
-        resolved_fee_token = fee_token or PATH_USD
-        fee_token_bytes = bytes.fromhex(
-            resolved_fee_token[2:] if resolved_fee_token.startswith("0x") else resolved_fee_token
-        )
-
         tx_to_sign = attrs.evolve(
             tx_for_recovery,
             sender_signature=sender_sig,
             sender_address=as_address(sender_address),
-            fee_token=fee_token_bytes,
+            fee_token=fee_token or PATH_USD,
         )
 
         try:
@@ -510,16 +490,8 @@ class ChargeIntent:
 
         return "0x" + cosigned.encode().hex()
 
-    def _validate_cosign_calls(self, calls: tuple, request: ChargeRequest) -> None:
-        """Validate that decoded transaction calls match the charge request.
-
-        Args:
-            calls: Decoded Call tuples from the transaction.
-            request: The charge request with expected parameters.
-
-        Raises:
-            VerificationError: If no call matches the expected payment.
-        """
+    def _validate_calls(self, calls: tuple, request: ChargeRequest) -> None:
+        """Validate that at least one call matches the expected transfer."""
         for call in calls:
             call_to = "0x" + bytes(call.to).hex()
             if call_to.lower() != request.currency.lower():
@@ -528,37 +500,24 @@ class ChargeIntent:
                 continue
             if _match_transfer_calldata(call.data.hex(), request):
                 return
-
         raise VerificationError("Invalid transaction: no matching payment call found")
 
     def _validate_transaction_payload(self, signature: str, request: ChargeRequest) -> None:
-        """Validate that a signed transaction contains the expected call.
-
-        Best-effort pre-broadcast check. If decoding fails we skip validation
-        and rely on post-broadcast log verification as the fallback.
-
-        Raises:
-            VerificationError: If the transaction decodes successfully but
-                doesn't match expected parameters.
-        """
+        """Best-effort pre-broadcast check. Silently skips if decoding fails."""
         try:
             import rlp
         except ImportError:
             return
-
         try:
             tx_bytes = bytes.fromhex(signature[2:] if signature.startswith("0x") else signature)
         except ValueError:
             return
-
         if not tx_bytes or tx_bytes[0] != 0x76:
             return
-
         try:
             decoded = rlp.decode(tx_bytes[1:])
         except Exception:
             return
-
         if not isinstance(decoded, list) or len(decoded) < 5:
             return
 
@@ -569,17 +528,15 @@ class ChargeIntent:
         for call_item in calls_data:
             if not isinstance(call_item, (list, tuple)) or len(call_item) < 3:
                 continue
-            call_to_bytes = call_item[0]
-            call_data_bytes = call_item[2]
+            call_to_bytes, call_data_bytes = call_item[0], call_item[2]
             if not call_to_bytes or not call_data_bytes:
                 continue
-
-            call_to = "0x" + call_to_bytes.hex() if isinstance(call_to_bytes, bytes) else str(call_to_bytes)
-            if call_to.lower() != request.currency.lower():
+            to_hex = call_to_bytes.hex() if isinstance(call_to_bytes, bytes) else str(call_to_bytes)
+            if ("0x" + to_hex).lower() != request.currency.lower():
                 continue
-
-            call_data = call_data_bytes.hex() if isinstance(call_data_bytes, bytes) else str(call_data_bytes)
-            if _match_transfer_calldata(call_data, request):
+            raw = call_data_bytes
+            data_hex = raw.hex() if isinstance(raw, bytes) else str(raw)
+            if _match_transfer_calldata(data_hex, request):
                 return
 
         raise VerificationError("Invalid transaction: no matching payment call found")

--- a/src/mpp/methods/tempo/intents.py
+++ b/src/mpp/methods/tempo/intents.py
@@ -56,6 +56,41 @@ TRANSFER_WITH_MEMO_TOPIC = "0x57bc7354aa85aed339e000bccffabbc529466af35f0772c8f8
 ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
 
 
+def _match_transfer_calldata(call_data_hex: str, request: ChargeRequest) -> bool:
+    """Check if ABI-encoded calldata matches the expected transfer parameters."""
+    if len(call_data_hex) < 136:
+        return False
+
+    selector = call_data_hex[:8].lower()
+    expected_memo = request.methodDetails.memo
+
+    if expected_memo:
+        if selector != TRANSFER_WITH_MEMO_SELECTOR:
+            return False
+    elif selector not in (TRANSFER_SELECTOR, TRANSFER_WITH_MEMO_SELECTOR):
+        return False
+
+    decoded_to = "0x" + call_data_hex[32:72]
+    decoded_amount = int(call_data_hex[72:136], 16)
+
+    if decoded_to.lower() != request.recipient.lower():
+        return False
+    if decoded_amount != int(request.amount):
+        return False
+
+    if expected_memo:
+        if len(call_data_hex) < 200:
+            return False
+        decoded_memo = "0x" + call_data_hex[136:200]
+        memo_clean = expected_memo.lower()
+        if not memo_clean.startswith("0x"):
+            memo_clean = "0x" + memo_clean
+        if decoded_memo.lower() != memo_clean:
+            return False
+
+    return True
+
+
 # ──────────────────────────────────────────────────────────────────
 # Charge intent
 # ──────────────────────────────────────────────────────────────────
@@ -408,24 +443,9 @@ class ChargeIntent:
     ) -> str:
         """Co-sign a client-signed transaction as fee payer.
 
-        Deserializes the client's transaction, validates it contains the
-        expected payment call, sets the fee token, and signs with domain
-        ``0x78``. The resulting transaction contains both the client's
-        signature and the fee payer's signature.
-
-        Args:
-            raw_tx: Hex-encoded client-signed transaction (0x76...).
-            fee_token: TIP-20 token address for fee payment.
-                Defaults to pathUSD.
-            request: The charge request to validate against. When provided,
-                the transaction calls are checked to ensure they target the
-                expected currency with the correct transfer parameters.
-
-        Returns:
-            Hex-encoded co-signed transaction ready for broadcast.
-
-        Raises:
-            VerificationError: If deserialization, validation, or signing fails.
+        Deserializes the client's 0x76 transaction, optionally validates the
+        payment calls against ``request``, sets the fee token, and signs with
+        domain 0x78. Returns the fully co-signed transaction hex.
         """
         import rlp
         from pytempo import Call, TempoTransaction
@@ -447,14 +467,10 @@ class ChargeIntent:
 
         calls = tuple(Call(to=c[0], value=_int(c[1]), data=c[2]) for c in decoded[4])
 
-        # Validate the transaction calls match the expected payment before
-        # co-signing.  Without this check the server would sponsor arbitrary
-        # transactions submitted by any sender.
         if request is not None:
             self._validate_cosign_calls(calls, request)
 
-        # Recover sender address from the sender's signature
-        sender_sig = decoded[-1]  # last field
+        sender_sig = decoded[-1]
         tx_for_recovery = TempoTransaction(
             chain_id=_int(decoded[0]),
             max_priority_fee_per_gas=_int(decoded[1]),
@@ -475,7 +491,6 @@ class ChargeIntent:
 
         sender_address = Account._recover_hash(sender_hash, signature=sender_sig)
 
-        # Reconstruct with sender signature and address
         resolved_fee_token = fee_token or PATH_USD
         fee_token_bytes = bytes.fromhex(
             resolved_fee_token[2:] if resolved_fee_token.startswith("0x") else resolved_fee_token
@@ -498,10 +513,6 @@ class ChargeIntent:
     def _validate_cosign_calls(self, calls: tuple, request: ChargeRequest) -> None:
         """Validate that decoded transaction calls match the charge request.
 
-        Ensures the server only co-signs transactions that target the
-        expected currency contract with a valid transfer selector,
-        correct recipient, and correct amount.
-
         Args:
             calls: Decoded Call tuples from the transaction.
             request: The charge request with expected parameters.
@@ -509,86 +520,22 @@ class ChargeIntent:
         Raises:
             VerificationError: If no call matches the expected payment.
         """
-        expected_memo = request.methodDetails.memo
-
         for call in calls:
-            if isinstance(call.to, bytes):
-                call_to = call.to
-            else:
-                raw = call.to
-                if isinstance(raw, str) and raw.startswith("0x"):
-                    raw = raw[2:]
-                call_to = bytes.fromhex(str(raw))
-            call_to_hex = "0x" + call_to.hex()
-
-            if call_to_hex.lower() != request.currency.lower():
+            call_to = "0x" + bytes(call.to).hex()
+            if call_to.lower() != request.currency.lower():
                 continue
-
-            val = call.value
-            if isinstance(val, bytes):
-                val = int.from_bytes(val, "big")
-            if val:
+            if call.value:
                 continue
-
-            if isinstance(call.data, bytes):
-                call_data = call.data
-            else:
-                raw = call.data
-                if isinstance(raw, str) and raw.startswith("0x"):
-                    raw = raw[2:]
-                call_data = bytes.fromhex(str(raw))
-            call_data_hex = call_data.hex()
-
-            if len(call_data_hex) < 8:
-                continue
-
-            selector = call_data_hex[:8].lower()
-
-            if expected_memo:
-                if selector != TRANSFER_WITH_MEMO_SELECTOR:
-                    continue
-            elif selector not in (TRANSFER_SELECTOR, TRANSFER_WITH_MEMO_SELECTOR):
-                continue
-
-            if len(call_data_hex) < 136:
-                continue
-            decoded_to = "0x" + call_data_hex[32:72]
-            decoded_amount = int(call_data_hex[72:136], 16)
-
-            if decoded_to.lower() != request.recipient.lower():
-                continue
-
-            if decoded_amount != int(request.amount):
-                continue
-
-            if expected_memo:
-                if len(call_data_hex) < 200:
-                    continue
-                decoded_memo = "0x" + call_data_hex[136:200]
-                memo_clean = expected_memo.lower()
-                if not memo_clean.startswith("0x"):
-                    memo_clean = "0x" + memo_clean
-                if decoded_memo.lower() != memo_clean:
-                    continue
-
-            return
+            if _match_transfer_calldata(call.data.hex(), request):
+                return
 
         raise VerificationError("Invalid transaction: no matching payment call found")
 
     def _validate_transaction_payload(self, signature: str, request: ChargeRequest) -> None:
         """Validate that a signed transaction contains the expected call.
 
-        Deserializes the transaction and checks that it contains a call to the
-        expected currency contract with the correct function selector and
-        parameters.
-
-        This is a security enhancement to reject malicious transactions before
-        broadcasting. If decoding fails, we skip validation and rely on
-        post-broadcast log verification as the fallback.
-
-        Args:
-            signature: The signed transaction hex (0x76-prefixed for Tempo).
-            request: The charge request with expected parameters.
+        Best-effort pre-broadcast check. If decoding fails we skip validation
+        and rely on post-broadcast log verification as the fallback.
 
         Raises:
             VerificationError: If the transaction decodes successfully but
@@ -619,64 +566,20 @@ class ChargeIntent:
         if not calls_data:
             raise VerificationError("Transaction contains no calls")
 
-        expected_memo = request.methodDetails.memo
-
         for call_item in calls_data:
             if not isinstance(call_item, (list, tuple)) or len(call_item) < 3:
                 continue
-
             call_to_bytes = call_item[0]
             call_data_bytes = call_item[2]
-
             if not call_to_bytes or not call_data_bytes:
                 continue
 
-            call_to = (
-                "0x" + call_to_bytes.hex()
-                if isinstance(call_to_bytes, bytes)
-                else str(call_to_bytes)
-            )
-            call_data = (
-                call_data_bytes.hex()
-                if isinstance(call_data_bytes, bytes)
-                else str(call_data_bytes)
-            )
-
+            call_to = "0x" + call_to_bytes.hex() if isinstance(call_to_bytes, bytes) else str(call_to_bytes)
             if call_to.lower() != request.currency.lower():
                 continue
 
-            if len(call_data) < 8:
-                continue
-
-            selector = call_data[:8].lower()
-
-            if expected_memo:
-                if selector != TRANSFER_WITH_MEMO_SELECTOR:
-                    continue
-            elif selector not in (TRANSFER_SELECTOR, TRANSFER_WITH_MEMO_SELECTOR):
-                continue
-
-            if len(call_data) < 136:
-                continue
-            decoded_to = "0x" + call_data[32:72]
-            decoded_amount = int(call_data[72:136], 16)
-
-            if decoded_to.lower() != request.recipient.lower():
-                continue
-
-            if decoded_amount != int(request.amount):
-                continue
-
-            if expected_memo:
-                if len(call_data) < 200:
-                    continue
-                decoded_memo = "0x" + call_data[136:200]
-                memo_clean = expected_memo.lower()
-                if not memo_clean.startswith("0x"):
-                    memo_clean = "0x" + memo_clean
-                if decoded_memo.lower() != memo_clean:
-                    continue
-
-            return
+            call_data = call_data_bytes.hex() if isinstance(call_data_bytes, bytes) else str(call_data_bytes)
+            if _match_transfer_calldata(call_data, request):
+                return
 
         raise VerificationError("Invalid transaction: no matching payment call found")

--- a/src/mpp/methods/tempo/intents.py
+++ b/src/mpp/methods/tempo/intents.py
@@ -378,9 +378,7 @@ class ChargeIntent:
         result = response.json()
 
         if "error" in result:
-            raise VerificationError(
-                f"Transaction submission failed: {_rpc_error_msg(result)}"
-            )
+            raise VerificationError(f"Transaction submission failed: {_rpc_error_msg(result)}")
 
         tx_hash = result.get("result")
         if not tx_hash:

--- a/tests/test_tempo.py
+++ b/tests/test_tempo.py
@@ -665,9 +665,7 @@ class TestCosignAsFeePayer:
         intent = ChargeIntent(rpc_url="https://rpc.test")
 
         with pytest.raises(VerificationError, match="No fee payer account configured"):
-            intent._cosign_as_fee_payer(
-                "0x76abcdef", "0x20c0000000000000000000000000000000000000"
-            )
+            intent._cosign_as_fee_payer("0x76abcdef", "0x20c0000000000000000000000000000000000000")
 
     def test_cosign_validates_call_target(self) -> None:
         """Should reject tx targeting wrong currency when request is provided."""
@@ -714,9 +712,7 @@ class TestCosignAsFeePayer:
         intent = ChargeIntent(rpc_url="https://rpc.test")
         tempo(fee_payer=fee_payer, rpc_url="https://rpc.test", intents={"charge": intent})
 
-        raw_tx = self._build_client_tx(
-            recipient="0x742d35Cc6634c0532925a3b844bC9e7595F8fE00"
-        )
+        raw_tx = self._build_client_tx(recipient="0x742d35Cc6634c0532925a3b844bC9e7595F8fE00")
 
         request = ChargeRequest(
             amount="1000000",

--- a/tests/test_tempo.py
+++ b/tests/test_tempo.py
@@ -482,14 +482,22 @@ class TestSponsoredTransfer:
 
     @pytest.mark.asyncio
     async def test_server_submits_sponsored_transaction(self, httpx_mock: HTTPXMock) -> None:
-        """Server should submit sponsored tx to fee payer URL."""
+        """Server should submit sponsored tx via external fee payer service."""
         future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
 
+        # External fee payer signs and returns co-signed tx
         httpx_mock.add_response(
             url="https://sponsor.test",
+            json={"jsonrpc": "2.0", "result": "0x76cosigned", "id": 1},
+        )
+
+        # eth_sendRawTransaction to RPC
+        httpx_mock.add_response(
+            url="https://rpc.test",
             json={"jsonrpc": "2.0", "result": "0xsponsored_hash", "id": 1},
         )
 
+        # eth_getTransactionReceipt
         httpx_mock.add_response(
             url="https://rpc.test",
             json={
@@ -539,7 +547,7 @@ class TestSponsoredTransfer:
 
     @pytest.mark.asyncio
     async def test_server_fee_payer_error(self, httpx_mock: HTTPXMock) -> None:
-        """Server should raise VerificationError when fee payer fails."""
+        """Server should raise VerificationError when external fee payer fails."""
         future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
 
         httpx_mock.add_response(
@@ -556,7 +564,7 @@ class TestSponsoredTransfer:
             payload={"type": "transaction", "signature": "0x76abcdef"},
         )
 
-        with pytest.raises(VerificationError, match="Transaction submission failed"):
+        with pytest.raises(VerificationError, match="Fee payer signing failed"):
             await intent.verify(
                 credential,
                 {

--- a/tests/test_tempo.py
+++ b/tests/test_tempo.py
@@ -630,7 +630,7 @@ class TestCosignAsFeePayer:
         fee_payer = TempoAccount.from_key(fee_payer_key)
 
         intent = ChargeIntent(rpc_url="https://rpc.test")
-        method = tempo(
+        tempo(
             fee_payer=fee_payer,
             rpc_url="https://rpc.test",
             intents={"charge": intent},
@@ -758,7 +758,7 @@ class TestFeePayerPropagation:
         """tempo() should propagate fee_payer to intents via _method backlink."""
         fee_payer = TempoAccount.from_key("0x" + "ab" * 32)
         intent = ChargeIntent()
-        method = tempo(
+        tempo(
             fee_payer=fee_payer,
             rpc_url="https://rpc.test",
             intents={"charge": intent},

--- a/tests/test_tempo.py
+++ b/tests/test_tempo.py
@@ -580,6 +580,203 @@ class TestSponsoredTransfer:
             )
 
 
+class TestCosignAsFeePayer:
+    """Tests for local fee payer co-signing."""
+
+    def _build_client_tx(
+        self,
+        currency: str = "0x20c0000000000000000000000000000000000000",
+        recipient: str = "0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
+        amount: int = 1000000,
+        chain_id: int = 42431,
+        with_memo: str | None = None,
+    ) -> str:
+        """Build a client-signed fee-payer-awaiting transaction."""
+        import attrs
+        from pytempo import Call, TempoTransaction
+
+        if with_memo:
+            selector = "95777d59"
+            to_padded = recipient[2:].lower().zfill(64)
+            amount_padded = hex(amount)[2:].zfill(64)
+            memo_clean = with_memo[2:] if with_memo.startswith("0x") else with_memo
+            transfer_data = f"0x{selector}{to_padded}{amount_padded}{memo_clean.lower()}"
+        else:
+            selector = "a9059cbb"
+            to_padded = recipient[2:].lower().zfill(64)
+            amount_padded = hex(amount)[2:].zfill(64)
+            transfer_data = f"0x{selector}{to_padded}{amount_padded}"
+
+        tx = TempoTransaction.create(
+            chain_id=chain_id,
+            gas_limit=100000,
+            max_fee_per_gas=1,
+            max_priority_fee_per_gas=1,
+            nonce=0,
+            nonce_key=(1 << 256) - 1,
+            fee_token=None,
+            awaiting_fee_payer=True,
+            valid_before=9999999999,
+            calls=(Call.create(to=currency, value=0, data=transfer_data),),
+        )
+
+        signed = tx.sign(TEST_PRIVATE_KEY)
+        signed = attrs.evolve(signed, fee_payer_signature=b"\x00")
+        return "0x" + signed.encode().hex()
+
+    def test_cosign_roundtrip(self) -> None:
+        """Should successfully co-sign a valid client transaction."""
+        fee_payer_key = "0x" + "ab" * 32
+        fee_payer = TempoAccount.from_key(fee_payer_key)
+
+        intent = ChargeIntent(rpc_url="https://rpc.test")
+        method = tempo(
+            fee_payer=fee_payer,
+            rpc_url="https://rpc.test",
+            intents={"charge": intent},
+        )
+
+        raw_tx = self._build_client_tx()
+        result = intent._cosign_as_fee_payer(raw_tx, "0x20c0000000000000000000000000000000000000")
+
+        assert result.startswith("0x76")
+        assert len(result) > len(raw_tx)
+
+    def test_cosign_rejects_wrong_tx_type(self) -> None:
+        """Should reject transactions that aren't type 0x76."""
+        fee_payer = TempoAccount.from_key("0x" + "ab" * 32)
+        intent = ChargeIntent(rpc_url="https://rpc.test")
+        tempo(fee_payer=fee_payer, rpc_url="https://rpc.test", intents={"charge": intent})
+
+        with pytest.raises(VerificationError, match="Failed to deserialize"):
+            intent._cosign_as_fee_payer("0x02abcdef", "0x20c0000000000000000000000000000000000000")
+
+    def test_cosign_rejects_malformed_hex(self) -> None:
+        """Should reject non-hex input."""
+        fee_payer = TempoAccount.from_key("0x" + "ab" * 32)
+        intent = ChargeIntent(rpc_url="https://rpc.test")
+        tempo(fee_payer=fee_payer, rpc_url="https://rpc.test", intents={"charge": intent})
+
+        with pytest.raises(VerificationError, match="Failed to deserialize"):
+            intent._cosign_as_fee_payer("0xZZZZ", "0x20c0000000000000000000000000000000000000")
+
+    def test_cosign_rejects_no_fee_payer(self) -> None:
+        """Should raise when no fee payer account is configured."""
+        intent = ChargeIntent(rpc_url="https://rpc.test")
+
+        with pytest.raises(VerificationError, match="No fee payer account configured"):
+            intent._cosign_as_fee_payer(
+                "0x76abcdef", "0x20c0000000000000000000000000000000000000"
+            )
+
+    def test_cosign_validates_call_target(self) -> None:
+        """Should reject tx targeting wrong currency when request is provided."""
+        fee_payer = TempoAccount.from_key("0x" + "ab" * 32)
+        intent = ChargeIntent(rpc_url="https://rpc.test")
+        tempo(fee_payer=fee_payer, rpc_url="https://rpc.test", intents={"charge": intent})
+
+        raw_tx = self._build_client_tx(
+            currency="0x20c0000000000000000000000000000000000000",
+            amount=1000000,
+        )
+
+        request = ChargeRequest(
+            amount="1000000",
+            currency="0xDEAD000000000000000000000000000000000000",
+            recipient="0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
+            expires="2030-01-20T12:00:00Z",
+        )
+
+        with pytest.raises(VerificationError, match="no matching payment call"):
+            intent._cosign_as_fee_payer(raw_tx, request.currency, request=request)
+
+    def test_cosign_validates_amount(self) -> None:
+        """Should reject tx with wrong amount when request is provided."""
+        fee_payer = TempoAccount.from_key("0x" + "ab" * 32)
+        intent = ChargeIntent(rpc_url="https://rpc.test")
+        tempo(fee_payer=fee_payer, rpc_url="https://rpc.test", intents={"charge": intent})
+
+        raw_tx = self._build_client_tx(amount=1000000)
+
+        request = ChargeRequest(
+            amount="9999999",
+            currency="0x20c0000000000000000000000000000000000000",
+            recipient="0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
+            expires="2030-01-20T12:00:00Z",
+        )
+
+        with pytest.raises(VerificationError, match="no matching payment call"):
+            intent._cosign_as_fee_payer(raw_tx, request.currency, request=request)
+
+    def test_cosign_validates_recipient(self) -> None:
+        """Should reject tx with wrong recipient when request is provided."""
+        fee_payer = TempoAccount.from_key("0x" + "ab" * 32)
+        intent = ChargeIntent(rpc_url="https://rpc.test")
+        tempo(fee_payer=fee_payer, rpc_url="https://rpc.test", intents={"charge": intent})
+
+        raw_tx = self._build_client_tx(
+            recipient="0x742d35Cc6634c0532925a3b844bC9e7595F8fE00"
+        )
+
+        request = ChargeRequest(
+            amount="1000000",
+            currency="0x20c0000000000000000000000000000000000000",
+            recipient="0xDEAD000000000000000000000000000000000000",
+            expires="2030-01-20T12:00:00Z",
+        )
+
+        with pytest.raises(VerificationError, match="no matching payment call"):
+            intent._cosign_as_fee_payer(raw_tx, request.currency, request=request)
+
+    def test_cosign_accepts_matching_request(self) -> None:
+        """Should succeed when tx matches request parameters."""
+        fee_payer = TempoAccount.from_key("0x" + "ab" * 32)
+        intent = ChargeIntent(rpc_url="https://rpc.test")
+        tempo(fee_payer=fee_payer, rpc_url="https://rpc.test", intents={"charge": intent})
+
+        raw_tx = self._build_client_tx(
+            currency="0x20c0000000000000000000000000000000000000",
+            recipient="0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
+            amount=1000000,
+        )
+
+        request = ChargeRequest(
+            amount="1000000",
+            currency="0x20c0000000000000000000000000000000000000",
+            recipient="0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
+            expires="2030-01-20T12:00:00Z",
+        )
+
+        result = intent._cosign_as_fee_payer(raw_tx, request.currency, request=request)
+        assert result.startswith("0x76")
+
+
+class TestFeePayerPropagation:
+    """Tests for fee_payer propagation through tempo() factory."""
+
+    def test_tempo_propagates_fee_payer(self) -> None:
+        """tempo() should propagate fee_payer to intents via _method backlink."""
+        fee_payer = TempoAccount.from_key("0x" + "ab" * 32)
+        intent = ChargeIntent()
+        method = tempo(
+            fee_payer=fee_payer,
+            rpc_url="https://rpc.test",
+            intents={"charge": intent},
+        )
+        assert intent.fee_payer is fee_payer
+
+    def test_fee_payer_none_by_default(self) -> None:
+        """ChargeIntent should have no fee_payer when tempo() is called without one."""
+        intent = ChargeIntent()
+        tempo(rpc_url="https://rpc.test", intents={"charge": intent})
+        assert intent.fee_payer is None
+
+    def test_fee_payer_none_standalone(self) -> None:
+        """ChargeIntent should have no fee_payer when used standalone."""
+        intent = ChargeIntent(rpc_url="https://rpc.test")
+        assert intent.fee_payer is None
+
+
 class TestSchemas:
     def test_charge_request_valid(self) -> None:
         """Should validate charge request with default methodDetails."""


### PR DESCRIPTION
Port of https://github.com/tempoxyz/mpp-rs/pull/71 to pympp.

## Changes

### Client side (`client.py`)
- When `feePayer: true` in challenge, use expiring nonces (`nonce_key=U256::MAX`, `nonce=0`) with `valid_before=now+25s` for replay protection
- Set `fee_token=None` and add placeholder `fee_payer_signature` (`0x00`)
- No on-chain nonce fetch needed in fee payer mode

### Server side (`intents.py`)
- Add `_cosign_as_fee_payer()` method: decodes 0x76 tx, recovers sender via ecrecover, sets `fee_token`, co-signs with domain `0x78`
- `_verify_transaction()` co-signs locally when `fee_payer` account is configured on the method, falls back to external fee payer service otherwise

### Factory (`client.py` `tempo()`)
- Add `fee_payer` parameter to `tempo()` and `TempoMethod`
- Wire up `_method` backlink so `ChargeIntent` can access `fee_payer` account

## Testing

- All 234 unit tests pass
- Tested live against `mpp.sh/api/ping/paid` ✅
- Tested pympp client → pympp example server (no fee payer) ✅
- Tested pympp client → pympp server with fee payer co-signing on testnet ✅

## Usage

```python
# Server with local fee payer co-signing
server = Mpp.create(
    method=tempo(
        chain_id=42431,
        fee_payer=TempoAccount.from_env("FEE_PAYER_KEY"),
        currency=PATH_USD,
        recipient="0x...",
        intents={"charge": ChargeIntent()},
    ),
)

# Client (no changes needed — auto-detects feePayer from challenge)
method = tempo(
    account=TempoAccount.from_key("0x..."),
    intents={"charge": ChargeIntent()},
)
```