### PR TITLE
fix: validate transaction calls before co-signing as fee payer

### DIFF
--- a/.changelog/rich-suns-wave.md
+++ b/.changelog/rich-suns-wave.md
@@ -1,0 +1,5 @@
+---
+pympp: patch
+---
+
+Added call validation to the fee payer co-signing flow to prevent the server from sponsoring arbitrary transactions. The `_cosign_as_fee_payer` method now accepts an optional `request` parameter and validates that transaction calls target the expected currency contract with the correct recipient, amount, and memo before signing. Added comprehensive tests for the validation logic.

--- a/src/mpp/methods/tempo/client.py
+++ b/src/mpp/methods/tempo/client.py
@@ -6,6 +6,7 @@ Implements the charge (TempoMethod) client method.
 from __future__ import annotations
 
 import time
+import attrs
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
@@ -189,7 +190,6 @@ class TempoMethod:
         Raises:
             TransactionError: If the RPC's chain ID doesn't match expected.
         """
-        import attrs
         from pytempo import Call, TempoTransaction
 
         if self.account is None:

--- a/src/mpp/methods/tempo/intents.py
+++ b/src/mpp/methods/tempo/intents.py
@@ -9,6 +9,8 @@ import asyncio
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
+import attrs
+
 from mpp import Credential, Receipt
 from mpp.errors import VerificationError
 from mpp.methods.tempo._defaults import DEFAULT_FEE_PAYER_URL, PATH_USD, rpc_url_for_chain
@@ -307,7 +309,7 @@ class ChargeIntent:
 
         if request.methodDetails.feePayer:
             if self.fee_payer is not None:
-                raw_tx = self._cosign_as_fee_payer(raw_tx, request.currency)
+                raw_tx = self._cosign_as_fee_payer(raw_tx, request.currency, request=request)
             else:
                 fee_payer_url = request.methodDetails.feePayerUrl or DEFAULT_FEE_PAYER_URL
 
@@ -401,25 +403,30 @@ class ChargeIntent:
 
         return Receipt.success(tx_hash)
 
-    def _cosign_as_fee_payer(self, raw_tx: str, fee_token: str | None = None) -> str:
+    def _cosign_as_fee_payer(
+        self, raw_tx: str, fee_token: str | None = None, request: ChargeRequest | None = None
+    ) -> str:
         """Co-sign a client-signed transaction as fee payer.
 
-        Deserializes the client's transaction, sets the fee token, and
-        signs with domain ``0x78``. The resulting transaction contains
-        both the client's signature and the fee payer's signature.
+        Deserializes the client's transaction, validates it contains the
+        expected payment call, sets the fee token, and signs with domain
+        ``0x78``. The resulting transaction contains both the client's
+        signature and the fee payer's signature.
 
         Args:
             raw_tx: Hex-encoded client-signed transaction (0x76...).
             fee_token: TIP-20 token address for fee payment.
                 Defaults to pathUSD.
+            request: The charge request to validate against. When provided,
+                the transaction calls are checked to ensure they target the
+                expected currency with the correct transfer parameters.
 
         Returns:
             Hex-encoded co-signed transaction ready for broadcast.
 
         Raises:
-            VerificationError: If deserialization or signing fails.
+            VerificationError: If deserialization, validation, or signing fails.
         """
-        import attrs
         import rlp
         from pytempo import Call, TempoTransaction
         from pytempo.models import as_address
@@ -439,6 +446,12 @@ class ChargeIntent:
             return int.from_bytes(b, "big") if b else 0
 
         calls = tuple(Call(to=c[0], value=_int(c[1]), data=c[2]) for c in decoded[4])
+
+        # Validate the transaction calls match the expected payment before
+        # co-signing.  Without this check the server would sponsor arbitrary
+        # transactions submitted by any sender.
+        if request is not None:
+            self._validate_cosign_calls(calls, request)
 
         # Recover sender address from the sender's signature
         sender_sig = decoded[-1]  # last field
@@ -481,6 +494,78 @@ class ChargeIntent:
             raise VerificationError("Fee payer signing failed") from err
 
         return "0x" + cosigned.encode().hex()
+
+    def _validate_cosign_calls(self, calls: tuple, request: ChargeRequest) -> None:
+        """Validate that decoded transaction calls match the charge request.
+
+        Ensures the server only co-signs transactions that target the
+        expected currency contract with a valid transfer selector,
+        correct recipient, and correct amount.
+
+        Args:
+            calls: Decoded Call tuples from the transaction.
+            request: The charge request with expected parameters.
+
+        Raises:
+            VerificationError: If no call matches the expected payment.
+        """
+        expected_memo = request.methodDetails.memo
+
+        for call in calls:
+            call_to = call.to if isinstance(call.to, bytes) else bytes.fromhex(
+                call.to[2:] if isinstance(call.to, str) and call.to.startswith("0x") else str(call.to)
+            )
+            call_to_hex = "0x" + call_to.hex()
+
+            if call_to_hex.lower() != request.currency.lower():
+                continue
+
+            if call.value and int.from_bytes(call.value, "big") if isinstance(call.value, bytes) else (call.value or 0):
+                if isinstance(call.value, int) and call.value != 0:
+                    continue
+                elif isinstance(call.value, bytes) and int.from_bytes(call.value, "big") != 0:
+                    continue
+
+            call_data = call.data if isinstance(call.data, bytes) else bytes.fromhex(
+                call.data[2:] if isinstance(call.data, str) and call.data.startswith("0x") else str(call.data)
+            )
+            call_data_hex = call_data.hex()
+
+            if len(call_data_hex) < 8:
+                continue
+
+            selector = call_data_hex[:8].lower()
+
+            if expected_memo:
+                if selector != TRANSFER_WITH_MEMO_SELECTOR:
+                    continue
+            elif selector not in (TRANSFER_SELECTOR, TRANSFER_WITH_MEMO_SELECTOR):
+                continue
+
+            if len(call_data_hex) < 136:
+                continue
+            decoded_to = "0x" + call_data_hex[32:72]
+            decoded_amount = int(call_data_hex[72:136], 16)
+
+            if decoded_to.lower() != request.recipient.lower():
+                continue
+
+            if decoded_amount != int(request.amount):
+                continue
+
+            if expected_memo:
+                if len(call_data_hex) < 200:
+                    continue
+                decoded_memo = "0x" + call_data_hex[136:200]
+                memo_clean = expected_memo.lower()
+                if not memo_clean.startswith("0x"):
+                    memo_clean = "0x" + memo_clean
+                if decoded_memo.lower() != memo_clean:
+                    continue
+
+            return
+
+        raise VerificationError("Invalid transaction: no matching payment call found")
 
     def _validate_transaction_payload(self, signature: str, request: ChargeRequest) -> None:
         """Validate that a signed transaction contains the expected call.

--- a/tests/test_tempo.py
+++ b/tests/test_tempo.py
@@ -580,6 +580,203 @@ class TestSponsoredTransfer:
             )
 
 
+class TestCosignAsFeePayer:
+    """Tests for local fee payer co-signing."""
+
+    def _build_client_tx(
+        self,
+        currency: str = "0x20c0000000000000000000000000000000000000",
+        recipient: str = "0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
+        amount: int = 1000000,
+        chain_id: int = 42431,
+        with_memo: str | None = None,
+    ) -> str:
+        """Build a client-signed fee-payer-awaiting transaction."""
+        import attrs
+        from pytempo import Call, TempoTransaction
+
+        if with_memo:
+            selector = "95777d59"
+            to_padded = recipient[2:].lower().zfill(64)
+            amount_padded = hex(amount)[2:].zfill(64)
+            memo_clean = with_memo[2:] if with_memo.startswith("0x") else with_memo
+            transfer_data = f"0x{selector}{to_padded}{amount_padded}{memo_clean.lower()}"
+        else:
+            selector = "a9059cbb"
+            to_padded = recipient[2:].lower().zfill(64)
+            amount_padded = hex(amount)[2:].zfill(64)
+            transfer_data = f"0x{selector}{to_padded}{amount_padded}"
+
+        tx = TempoTransaction.create(
+            chain_id=chain_id,
+            gas_limit=100000,
+            max_fee_per_gas=1,
+            max_priority_fee_per_gas=1,
+            nonce=0,
+            nonce_key=(1 << 256) - 1,
+            fee_token=None,
+            awaiting_fee_payer=True,
+            valid_before=9999999999,
+            calls=(Call.create(to=currency, value=0, data=transfer_data),),
+        )
+
+        signed = tx.sign(TEST_PRIVATE_KEY)
+        signed = attrs.evolve(signed, fee_payer_signature=b"\x00")
+        return "0x" + signed.encode().hex()
+
+    def test_cosign_roundtrip(self) -> None:
+        """Should successfully co-sign a valid client transaction."""
+        fee_payer_key = "0x" + "ab" * 32
+        fee_payer = TempoAccount.from_key(fee_payer_key)
+
+        intent = ChargeIntent(rpc_url="https://rpc.test")
+        method = tempo(
+            fee_payer=fee_payer,
+            rpc_url="https://rpc.test",
+            intents={"charge": intent},
+        )
+
+        raw_tx = self._build_client_tx()
+        result = intent._cosign_as_fee_payer(raw_tx, "0x20c0000000000000000000000000000000000000")
+
+        assert result.startswith("0x76")
+        assert len(result) > len(raw_tx)
+
+    def test_cosign_rejects_wrong_tx_type(self) -> None:
+        """Should reject transactions that aren't type 0x76."""
+        fee_payer = TempoAccount.from_key("0x" + "ab" * 32)
+        intent = ChargeIntent(rpc_url="https://rpc.test")
+        tempo(fee_payer=fee_payer, rpc_url="https://rpc.test", intents={"charge": intent})
+
+        with pytest.raises(VerificationError, match="Failed to deserialize"):
+            intent._cosign_as_fee_payer("0x02abcdef", "0x20c0000000000000000000000000000000000000")
+
+    def test_cosign_rejects_malformed_hex(self) -> None:
+        """Should reject non-hex input."""
+        fee_payer = TempoAccount.from_key("0x" + "ab" * 32)
+        intent = ChargeIntent(rpc_url="https://rpc.test")
+        tempo(fee_payer=fee_payer, rpc_url="https://rpc.test", intents={"charge": intent})
+
+        with pytest.raises(VerificationError, match="Failed to deserialize"):
+            intent._cosign_as_fee_payer("0xZZZZ", "0x20c0000000000000000000000000000000000000")
+
+    def test_cosign_rejects_no_fee_payer(self) -> None:
+        """Should raise when no fee payer account is configured."""
+        intent = ChargeIntent(rpc_url="https://rpc.test")
+
+        with pytest.raises(VerificationError, match="No fee payer account configured"):
+            intent._cosign_as_fee_payer(
+                "0x76abcdef", "0x20c0000000000000000000000000000000000000"
+            )
+
+    def test_cosign_validates_call_target(self) -> None:
+        """Should reject tx targeting wrong currency when request is provided."""
+        fee_payer = TempoAccount.from_key("0x" + "ab" * 32)
+        intent = ChargeIntent(rpc_url="https://rpc.test")
+        tempo(fee_payer=fee_payer, rpc_url="https://rpc.test", intents={"charge": intent})
+
+        raw_tx = self._build_client_tx(
+            currency="0x20c0000000000000000000000000000000000000",
+            amount=1000000,
+        )
+
+        request = ChargeRequest(
+            amount="1000000",
+            currency="0xDEAD000000000000000000000000000000000000",
+            recipient="0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
+            expires="2030-01-20T12:00:00Z",
+        )
+
+        with pytest.raises(VerificationError, match="no matching payment call"):
+            intent._cosign_as_fee_payer(raw_tx, request.currency, request=request)
+
+    def test_cosign_validates_amount(self) -> None:
+        """Should reject tx with wrong amount when request is provided."""
+        fee_payer = TempoAccount.from_key("0x" + "ab" * 32)
+        intent = ChargeIntent(rpc_url="https://rpc.test")
+        tempo(fee_payer=fee_payer, rpc_url="https://rpc.test", intents={"charge": intent})
+
+        raw_tx = self._build_client_tx(amount=1000000)
+
+        request = ChargeRequest(
+            amount="9999999",
+            currency="0x20c0000000000000000000000000000000000000",
+            recipient="0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
+            expires="2030-01-20T12:00:00Z",
+        )
+
+        with pytest.raises(VerificationError, match="no matching payment call"):
+            intent._cosign_as_fee_payer(raw_tx, request.currency, request=request)
+
+    def test_cosign_validates_recipient(self) -> None:
+        """Should reject tx with wrong recipient when request is provided."""
+        fee_payer = TempoAccount.from_key("0x" + "ab" * 32)
+        intent = ChargeIntent(rpc_url="https://rpc.test")
+        tempo(fee_payer=fee_payer, rpc_url="https://rpc.test", intents={"charge": intent})
+
+        raw_tx = self._build_client_tx(
+            recipient="0x742d35Cc6634c0532925a3b844bC9e7595F8fE00"
+        )
+
+        request = ChargeRequest(
+            amount="1000000",
+            currency="0x20c0000000000000000000000000000000000000",
+            recipient="0xDEAD000000000000000000000000000000000000",
+            expires="2030-01-20T12:00:00Z",
+        )
+
+        with pytest.raises(VerificationError, match="no matching payment call"):
+            intent._cosign_as_fee_payer(raw_tx, request.currency, request=request)
+
+    def test_cosign_accepts_matching_request(self) -> None:
+        """Should succeed when tx matches request parameters."""
+        fee_payer = TempoAccount.from_key("0x" + "ab" * 32)
+        intent = ChargeIntent(rpc_url="https://rpc.test")
+        tempo(fee_payer=fee_payer, rpc_url="https://rpc.test", intents={"charge": intent})
+
+        raw_tx = self._build_client_tx(
+            currency="0x20c0000000000000000000000000000000000000",
+            recipient="0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
+            amount=1000000,
+        )
+
+        request = ChargeRequest(
+            amount="1000000",
+            currency="0x20c0000000000000000000000000000000000000",
+            recipient="0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
+            expires="2030-01-20T12:00:00Z",
+        )
+
+        result = intent._cosign_as_fee_payer(raw_tx, request.currency, request=request)
+        assert result.startswith("0x76")
+
+
+class TestFeePayerPropagation:
+    """Tests for fee_payer propagation through tempo() factory."""
+
+    def test_tempo_propagates_fee_payer(self) -> None:
+        """tempo() should propagate fee_payer to intents via _method backlink."""
+        fee_payer = TempoAccount.from_key("0x" + "ab" * 32)
+        intent = ChargeIntent()
+        method = tempo(
+            fee_payer=fee_payer,
+            rpc_url="https://rpc.test",
+            intents={"charge": intent},
+        )
+        assert intent.fee_payer is fee_payer
+
+    def test_fee_payer_none_by_default(self) -> None:
+        """ChargeIntent should have no fee_payer when tempo() is called without one."""
+        intent = ChargeIntent()
+        tempo(rpc_url="https://rpc.test", intents={"charge": intent})
+        assert intent.fee_payer is None
+
+    def test_fee_payer_none_standalone(self) -> None:
+        """ChargeIntent should have no fee_payer when used standalone."""
+        intent = ChargeIntent(rpc_url="https://rpc.test")
+        assert intent.fee_payer is None
+
+
 class TestSchemas:
     def test_charge_request_valid(self) -> None:
         """Should validate charge request with default methodDetails."""


### PR DESCRIPTION
Stacked on #62.

## Problem

`_cosign_as_fee_payer()` would co-sign any valid 0x76 transaction without verifying the call target, selector, amount, or recipient. An attacker could submit a sender-signed tx targeting any contract and the server would sponsor it.

## Changes

### Security fix
- Add `_validate_cosign_calls()` that checks decoded transaction calls match the charge request (currency, recipient, amount, selector, memo) **before** the server co-signs
- Pass the `ChargeRequest` through to `_cosign_as_fee_payer()`

### Cleanup
- Move `import attrs` to top-level in both `client.py` and `intents.py` (hard dependency, was imported inline)

### Tests (11 new)
- `TestCosignAsFeePayer`: roundtrip co-signing, wrong tx type rejection, malformed hex rejection, no fee payer configured, wrong currency/amount/recipient rejection, matching request acceptance
- `TestFeePayerPropagation`: fee_payer propagation via `_method` backlink, default None, standalone None