### PR TITLE
test: add additional test coverage

### DIFF
--- a/.changelog/aged-snails-eat.md
+++ b/.changelog/aged-snails-eat.md
@@ -1,0 +1,5 @@
+---
+pympp: minor
+---
+
+Added extensive test coverage for memo-based transfers, including unit tests for `_match_transfer_calldata` and `_verify_transfer_logs` with memo fields, integration tests for end-to-end charge flows with server-specified memos, and new test modules for body digest computation, error types, expires helpers, and keychain signature handling.

--- a/tests/test_body_digest.py
+++ b/tests/test_body_digest.py
@@ -42,6 +42,29 @@ class TestCompute:
         assert digest.startswith("sha-256=")
         assert compute(b"") == digest
 
+    def test_known_sha256_vector(self) -> None:
+        """Empty string digest should match the known SHA-256 of empty bytes."""
+        assert compute("") == "sha-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU="
+
+    def test_large_body(self) -> None:
+        """1MB body should compute and roundtrip-verify successfully."""
+        body = b"x" * 1_000_000
+        assert verify(compute(body), body) is True
+
+    def test_unicode_body(self) -> None:
+        """Unicode string and its UTF-8 encoding should produce the same digest."""
+        text = "héllo wörld 🌍"
+        assert compute(text) == compute(text.encode("utf-8"))
+
+    def test_digest_is_valid_base64(self) -> None:
+        """Digest payload should decode as valid base64 to exactly 32 bytes."""
+        import base64
+
+        digest = compute("some data")
+        payload = digest.removeprefix("sha-256=")
+        raw = base64.b64decode(payload)
+        assert len(raw) == 32
+
 
 class TestVerify:
     def test_matching_digest_returns_true(self) -> None:
@@ -74,3 +97,11 @@ class TestVerify:
         """Tampered digest value should fail verification."""
         body = "test"
         assert verify("sha-256=AAAA", body) is False
+
+    def test_wrong_algorithm_prefix(self) -> None:
+        """Digest with wrong algorithm prefix should fail verification."""
+        assert verify("sha-512=AAAA", "test") is False
+
+    def test_empty_digest_string(self) -> None:
+        """Empty digest string should fail verification."""
+        assert verify("", "test") is False

--- a/tests/test_body_digest.py
+++ b/tests/test_body_digest.py
@@ -1,0 +1,76 @@
+"""Tests for body digest computation and verification."""
+
+from mpp._body_digest import compute, verify
+
+
+class TestCompute:
+    def test_dict_body(self) -> None:
+        """Should compute digest for dict (JSON-serialized with compact separators)."""
+        digest = compute({"key": "value"})
+        assert digest.startswith("sha-256=")
+        assert len(digest) > len("sha-256=")
+
+    def test_str_body(self) -> None:
+        """Should compute digest for string body."""
+        digest = compute("hello world")
+        assert digest.startswith("sha-256=")
+
+    def test_bytes_body(self) -> None:
+        """Should compute digest for bytes body."""
+        digest = compute(b"raw bytes")
+        assert digest.startswith("sha-256=")
+
+    def test_str_and_bytes_equivalent(self) -> None:
+        """String and its UTF-8 encoding should produce the same digest."""
+        text = "hello world"
+        assert compute(text) == compute(text.encode("utf-8"))
+
+    def test_dict_compact_serialization(self) -> None:
+        """Dict should be serialized with compact separators (no spaces)."""
+        # A dict with spaces in a regular json.dumps would differ
+        digest_dict = compute({"a": 1})
+        digest_str = compute('{"a":1}')
+        assert digest_dict == digest_str
+
+    def test_different_bodies_different_digests(self) -> None:
+        """Different bodies should produce different digests."""
+        assert compute("foo") != compute("bar")
+
+    def test_empty_body(self) -> None:
+        """Empty body should still produce a valid digest."""
+        digest = compute("")
+        assert digest.startswith("sha-256=")
+        assert compute(b"") == digest
+
+
+class TestVerify:
+    def test_matching_digest_returns_true(self) -> None:
+        """Should return True when digest matches body."""
+        body = {"amount": "1000", "currency": "USD"}
+        digest = compute(body)
+        assert verify(digest, body) is True
+
+    def test_mismatched_digest_returns_false(self) -> None:
+        """Should return False when digest doesn't match body."""
+        digest = compute("original body")
+        assert verify(digest, "different body") is False
+
+    def test_roundtrip_str(self) -> None:
+        """Compute then verify should always succeed for strings."""
+        body = "test body content"
+        assert verify(compute(body), body) is True
+
+    def test_roundtrip_bytes(self) -> None:
+        """Compute then verify should always succeed for bytes."""
+        body = b"\x00\x01\x02"
+        assert verify(compute(body), body) is True
+
+    def test_roundtrip_dict(self) -> None:
+        """Compute then verify should always succeed for dicts."""
+        body = {"nested": {"key": [1, 2, 3]}}
+        assert verify(compute(body), body) is True
+
+    def test_tampered_digest(self) -> None:
+        """Tampered digest value should fail verification."""
+        body = "test"
+        assert verify("sha-256=AAAA", body) is False

--- a/tests/test_client_integration.py
+++ b/tests/test_client_integration.py
@@ -257,6 +257,46 @@ class TestClientServerIntegration:
         with pytest.raises(httpx.ConnectError):
             await intent.verify(credential, request_params)
 
+    async def test_e2e_charge_with_memo(
+        self, rpc_url, funded_payer, funded_recipient, currency, chain_id
+    ):
+        """Full roundtrip with server-specified memo."""
+        memo = "0x" + "de" * 32
+
+        intent = ChargeIntent(rpc_url=rpc_url)
+        request_params = {
+            "amount": "1000000",
+            "currency": currency,
+            "recipient": funded_recipient.address,
+            "expires": (datetime.now(UTC) + timedelta(hours=1)).isoformat().replace("+00:00", "Z"),
+            "methodDetails": {
+                "feePayer": False,
+                "chainId": chain_id,
+                "memo": memo,
+            },
+        }
+        transport = RealVerifyTransport(
+            intent=intent,
+            request_params=request_params,
+            realm="test.local",
+        )
+
+        method = tempo(
+            account=funded_payer,
+            rpc_url=rpc_url,
+            intents={"charge": ChargeIntent()},
+        )
+        payment_transport = PaymentTransport(methods=[method], inner=transport)
+
+        async with httpx.AsyncClient(transport=payment_transport, base_url="http://test") as client:
+            response = await client.get("/paid")
+            assert response.status_code == 200
+            data = response.json()
+            assert data["paid"] is True
+
+            receipt = Receipt.from_payment_receipt(response.headers["payment-receipt"])
+            assert receipt.status == "success"
+
     async def test_fee_payer_balance_accounting(
         self, rpc_url, funded_payer, funded_recipient, currency, chain_id
     ):

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,5 +1,7 @@
 """Tests for payment error types and RFC 9457 Problem Details."""
 
+import pytest
+
 from mpp.errors import (
     BadRequestError,
     InvalidChallengeError,
@@ -23,6 +25,7 @@ class TestToProblemDetails:
         assert details["type"] == "https://paymentauth.org/problems/payment-error"
         assert details["title"] == "Payment Error"
         assert details["status"] == 402
+        assert isinstance(details["status"], int)
         assert details["detail"] == "something went wrong"
 
     def test_includes_challenge_id_when_provided(self) -> None:
@@ -37,43 +40,55 @@ class TestToProblemDetails:
         details = err.to_problem_details()
         assert "challengeId" not in details
 
+    def test_problem_details_keys_are_exact(self) -> None:
+        """Problem Details keys should be exactly the expected set."""
+        err = PaymentError("test")
+
+        without = err.to_problem_details()
+        assert set(without.keys()) == {"type", "title", "status", "detail"}
+
+        with_cid = err.to_problem_details(challenge_id="ch-1")
+        assert set(with_cid.keys()) == {"type", "title", "status", "detail", "challengeId"}
+
 
 class TestAutoSlug:
-    def test_invalid_payload_slug(self) -> None:
-        """InvalidPayloadError type should end in /invalid-payload."""
-        assert InvalidPayloadError.type.endswith("/invalid-payload")
-
-    def test_malformed_credential_slug(self) -> None:
-        assert MalformedCredentialError.type.endswith("/malformed-credential")
-
-    def test_invalid_challenge_slug(self) -> None:
-        assert InvalidChallengeError.type.endswith("/invalid-challenge")
-
-    def test_verification_failed_slug(self) -> None:
-        assert VerificationFailedError.type.endswith("/verification-failed")
-
-    def test_payment_expired_slug(self) -> None:
-        assert PaymentExpiredError.type.endswith("/payment-expired")
-
-    def test_payment_insufficient_slug(self) -> None:
-        assert PaymentInsufficientError.type.endswith("/payment-insufficient")
-
-    def test_payment_action_required_slug(self) -> None:
-        assert PaymentActionRequiredError.type.endswith("/payment-action-required")
-
-    def test_payment_required_slug(self) -> None:
-        assert PaymentRequiredError.type.endswith("/payment-required")
+    @pytest.mark.parametrize(
+        "cls, expected_suffix",
+        [
+            (InvalidPayloadError, "/invalid-payload"),
+            (MalformedCredentialError, "/malformed-credential"),
+            (InvalidChallengeError, "/invalid-challenge"),
+            (VerificationFailedError, "/verification-failed"),
+            (PaymentExpiredError, "/payment-expired"),
+            (PaymentInsufficientError, "/payment-insufficient"),
+            (PaymentActionRequiredError, "/payment-action-required"),
+            (PaymentRequiredError, "/payment-required"),
+        ],
+        ids=lambda cls: cls.__name__ if isinstance(cls, type) else cls,
+    )
+    def test_auto_slug(self, cls: type, expected_suffix: str) -> None:
+        assert cls.type.endswith(expected_suffix)
 
 
 class TestAutoTitle:
-    def test_invalid_payload_title(self) -> None:
-        assert InvalidPayloadError.title == "Invalid Payload"
-
-    def test_malformed_credential_title(self) -> None:
-        assert MalformedCredentialError.title == "Malformed Credential"
-
-    def test_payment_expired_title(self) -> None:
-        assert PaymentExpiredError.title == "Payment Expired"
+    @pytest.mark.parametrize(
+        "cls, expected_title",
+        [
+            (InvalidPayloadError, "Invalid Payload"),
+            (MalformedCredentialError, "Malformed Credential"),
+            (InvalidChallengeError, "Invalid Challenge"),
+            (VerificationFailedError, "Verification Failed"),
+            (PaymentExpiredError, "Payment Expired"),
+            (PaymentInsufficientError, "Payment Insufficient"),
+            (PaymentMethodUnsupportedError, "Method Unsupported"),
+            (PaymentActionRequiredError, "Payment Action Required"),
+            (PaymentRequiredError, "Payment Required"),
+            (BadRequestError, "Bad Request"),
+        ],
+        ids=lambda cls: cls.__name__ if isinstance(cls, type) else cls,
+    )
+    def test_auto_title(self, cls: type, expected_title: str) -> None:
+        assert cls.title == expected_title
 
 
 class TestSubclassInstantiation:
@@ -171,6 +186,7 @@ class TestSubclassProblemDetails:
         details = err.to_problem_details(challenge_id="ch-1")
         assert details["type"].endswith("/invalid-payload")
         assert details["status"] == 402
+        assert isinstance(details["status"], int)
         assert details["challengeId"] == "ch-1"
         assert "bad" in details["detail"]
 
@@ -179,3 +195,4 @@ class TestSubclassProblemDetails:
         err = BadRequestError(reason="invalid")
         details = err.to_problem_details()
         assert details["status"] == 400
+        assert isinstance(details["status"], int)

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,181 @@
+"""Tests for payment error types and RFC 9457 Problem Details."""
+
+from mpp.errors import (
+    BadRequestError,
+    InvalidChallengeError,
+    InvalidPayloadError,
+    MalformedCredentialError,
+    PaymentActionRequiredError,
+    PaymentError,
+    PaymentExpiredError,
+    PaymentInsufficientError,
+    PaymentMethodUnsupportedError,
+    PaymentRequiredError,
+    VerificationFailedError,
+)
+
+
+class TestToProblemDetails:
+    def test_base_error_includes_required_fields(self) -> None:
+        """to_problem_details() should include type, title, status, detail."""
+        err = PaymentError("something went wrong")
+        details = err.to_problem_details()
+        assert details["type"] == "https://paymentauth.org/problems/payment-error"
+        assert details["title"] == "Payment Error"
+        assert details["status"] == 402
+        assert details["detail"] == "something went wrong"
+
+    def test_includes_challenge_id_when_provided(self) -> None:
+        """to_problem_details(challenge_id=...) should include challengeId."""
+        err = PaymentError("test")
+        details = err.to_problem_details(challenge_id="ch-123")
+        assert details["challengeId"] == "ch-123"
+
+    def test_excludes_challenge_id_when_none(self) -> None:
+        """to_problem_details() without challenge_id should not have challengeId key."""
+        err = PaymentError("test")
+        details = err.to_problem_details()
+        assert "challengeId" not in details
+
+
+class TestAutoSlug:
+    def test_invalid_payload_slug(self) -> None:
+        """InvalidPayloadError type should end in /invalid-payload."""
+        assert InvalidPayloadError.type.endswith("/invalid-payload")
+
+    def test_malformed_credential_slug(self) -> None:
+        assert MalformedCredentialError.type.endswith("/malformed-credential")
+
+    def test_invalid_challenge_slug(self) -> None:
+        assert InvalidChallengeError.type.endswith("/invalid-challenge")
+
+    def test_verification_failed_slug(self) -> None:
+        assert VerificationFailedError.type.endswith("/verification-failed")
+
+    def test_payment_expired_slug(self) -> None:
+        assert PaymentExpiredError.type.endswith("/payment-expired")
+
+    def test_payment_insufficient_slug(self) -> None:
+        assert PaymentInsufficientError.type.endswith("/payment-insufficient")
+
+    def test_payment_action_required_slug(self) -> None:
+        assert PaymentActionRequiredError.type.endswith("/payment-action-required")
+
+    def test_payment_required_slug(self) -> None:
+        assert PaymentRequiredError.type.endswith("/payment-required")
+
+
+class TestAutoTitle:
+    def test_invalid_payload_title(self) -> None:
+        assert InvalidPayloadError.title == "Invalid Payload"
+
+    def test_malformed_credential_title(self) -> None:
+        assert MalformedCredentialError.title == "Malformed Credential"
+
+    def test_payment_expired_title(self) -> None:
+        assert PaymentExpiredError.title == "Payment Expired"
+
+
+class TestSubclassInstantiation:
+    def test_payment_required_with_args(self) -> None:
+        err = PaymentRequiredError(realm="api.example.com", description="Monthly quota")
+        assert "api.example.com" in str(err)
+        assert "Monthly quota" in str(err)
+
+    def test_payment_required_no_args(self) -> None:
+        err = PaymentRequiredError()
+        assert "Payment is required" in str(err)
+
+    def test_malformed_credential_with_reason(self) -> None:
+        err = MalformedCredentialError(reason="bad base64")
+        assert "bad base64" in str(err)
+
+    def test_malformed_credential_no_reason(self) -> None:
+        err = MalformedCredentialError()
+        assert "malformed" in str(err).lower()
+
+    def test_invalid_challenge_with_id_and_reason(self) -> None:
+        err = InvalidChallengeError(challenge_id="ch-99", reason="expired")
+        assert "ch-99" in str(err)
+        assert "expired" in str(err)
+
+    def test_invalid_challenge_no_args(self) -> None:
+        err = InvalidChallengeError()
+        assert "invalid" in str(err).lower()
+
+    def test_verification_failed_with_reason(self) -> None:
+        err = VerificationFailedError(reason="wrong amount")
+        assert "wrong amount" in str(err)
+
+    def test_verification_failed_no_reason(self) -> None:
+        err = VerificationFailedError()
+        assert "verification failed" in str(err).lower()
+
+    def test_payment_expired_with_timestamp(self) -> None:
+        err = PaymentExpiredError(expires="2024-01-01T00:00:00Z")
+        assert "2024-01-01" in str(err)
+
+    def test_payment_expired_no_args(self) -> None:
+        err = PaymentExpiredError()
+        assert "expired" in str(err).lower()
+
+    def test_invalid_payload_with_reason(self) -> None:
+        err = InvalidPayloadError(reason="missing hash")
+        assert "missing hash" in str(err)
+
+    def test_invalid_payload_no_reason(self) -> None:
+        err = InvalidPayloadError()
+        assert "invalid" in str(err).lower()
+
+    def test_bad_request_with_reason(self) -> None:
+        err = BadRequestError(reason="missing field")
+        assert err.status == 400
+        assert "missing field" in str(err)
+
+    def test_bad_request_no_reason(self) -> None:
+        err = BadRequestError()
+        assert "Bad request" in str(err)
+
+    def test_payment_insufficient_with_reason(self) -> None:
+        err = PaymentInsufficientError(reason="need 100, got 50")
+        assert "need 100" in str(err)
+
+    def test_payment_insufficient_no_reason(self) -> None:
+        err = PaymentInsufficientError()
+        assert "insufficient" in str(err).lower()
+
+    def test_method_unsupported_with_method(self) -> None:
+        err = PaymentMethodUnsupportedError(method="stripe")
+        assert err.status == 400
+        assert "stripe" in str(err)
+        assert err.type.endswith("/method-unsupported")
+        assert err.title == "Method Unsupported"
+
+    def test_method_unsupported_no_args(self) -> None:
+        err = PaymentMethodUnsupportedError()
+        assert "not supported" in str(err)
+
+    def test_payment_action_required_with_reason(self) -> None:
+        err = PaymentActionRequiredError(reason="3DS needed")
+        assert "3DS needed" in str(err)
+
+    def test_payment_action_required_no_reason(self) -> None:
+        err = PaymentActionRequiredError()
+        assert "requires action" in str(err)
+
+
+class TestSubclassProblemDetails:
+    def test_subclass_problem_details_has_correct_type(self) -> None:
+        """Subclass to_problem_details() should use auto-generated type URI."""
+        err = InvalidPayloadError(reason="bad")
+        details = err.to_problem_details(challenge_id="ch-1")
+        assert details["type"].endswith("/invalid-payload")
+        assert details["status"] == 402
+        assert details["challengeId"] == "ch-1"
+        assert "bad" in details["detail"]
+
+    def test_bad_request_status_in_problem_details(self) -> None:
+        """BadRequestError should have status 400 in problem details."""
+        err = BadRequestError(reason="invalid")
+        details = err.to_problem_details()
+        assert details["status"] == 400

--- a/tests/test_expires.py
+++ b/tests/test_expires.py
@@ -26,12 +26,20 @@ def _parse(iso: str) -> datetime:
 
 
 class TestExpiresHelpers:
-    @pytest.mark.parametrize("fn,n,delta", HELPERS, ids=lambda x: x.__name__ if callable(x) else repr(x))
+    @pytest.mark.parametrize(
+        "fn,n,delta",
+        HELPERS,
+        ids=lambda x: x.__name__ if callable(x) else repr(x),
+    )
     def test_format(self, fn, n, delta) -> None:
         """Each helper should produce valid ISO 8601 with 3-digit ms and Z suffix."""
         assert ISO_PATTERN.match(fn(n))
 
-    @pytest.mark.parametrize("fn,n,delta", HELPERS, ids=lambda x: x.__name__ if callable(x) else repr(x))
+    @pytest.mark.parametrize(
+        "fn,n,delta",
+        HELPERS,
+        ids=lambda x: x.__name__ if callable(x) else repr(x),
+    )
     def test_value(self, fn, n, delta) -> None:
         """Result should be tightly bracketed: before + delta <= result <= after + delta.
 
@@ -45,7 +53,11 @@ class TestExpiresHelpers:
         ms_truncation = timedelta(milliseconds=1)
         assert before + delta - ms_truncation <= result <= after + delta
 
-    @pytest.mark.parametrize("fn,n,delta", HELPERS, ids=lambda x: x.__name__ if callable(x) else repr(x))
+    @pytest.mark.parametrize(
+        "fn,n,delta",
+        HELPERS,
+        ids=lambda x: x.__name__ if callable(x) else repr(x),
+    )
     def test_result_is_utc(self, fn, n, delta) -> None:
         """Parsed result should always be timezone-aware and in UTC."""
         result = _parse(fn(n))

--- a/tests/test_expires.py
+++ b/tests/test_expires.py
@@ -3,9 +3,21 @@
 import re
 from datetime import UTC, datetime, timedelta
 
+import pytest
+
 from mpp._expires import days, hours, minutes, months, seconds, weeks, years
 
 ISO_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$")
+
+HELPERS = [
+    (seconds, 30, timedelta(seconds=30)),
+    (minutes, 5, timedelta(minutes=5)),
+    (hours, 2, timedelta(hours=2)),
+    (days, 7, timedelta(days=7)),
+    (weeks, 2, timedelta(weeks=2)),
+    (months, 1, timedelta(days=30)),
+    (years, 1, timedelta(days=365)),
+]
 
 
 def _parse(iso: str) -> datetime:
@@ -14,73 +26,31 @@ def _parse(iso: str) -> datetime:
 
 
 class TestExpiresHelpers:
-    def test_seconds_format(self) -> None:
-        """seconds() should produce valid ISO 8601 with 3-digit ms and Z suffix."""
-        result = seconds(30)
-        assert ISO_PATTERN.match(result)
+    @pytest.mark.parametrize("fn,n,delta", HELPERS, ids=lambda x: x.__name__ if callable(x) else repr(x))
+    def test_format(self, fn, n, delta) -> None:
+        """Each helper should produce valid ISO 8601 with 3-digit ms and Z suffix."""
+        assert ISO_PATTERN.match(fn(n))
 
-    def test_seconds_value(self) -> None:
-        """seconds(30) should be ~30s from now."""
+    @pytest.mark.parametrize("fn,n,delta", HELPERS, ids=lambda x: x.__name__ if callable(x) else repr(x))
+    def test_value(self, fn, n, delta) -> None:
+        """Result should be tightly bracketed: before + delta <= result <= after + delta.
+
+        The lower bound is adjusted by 1 ms because _to_iso truncates
+        microseconds to milliseconds (floor), so the serialized timestamp
+        can be up to 999 µs less than the actual instant.
+        """
         before = datetime.now(UTC)
-        result = _parse(seconds(30))
-        after = datetime.now(UTC) + timedelta(seconds=30)
-        assert before + timedelta(seconds=29) <= result <= after + timedelta(seconds=1)
+        result = _parse(fn(n))
+        after = datetime.now(UTC)
+        ms_truncation = timedelta(milliseconds=1)
+        assert before + delta - ms_truncation <= result <= after + delta
 
-    def test_minutes_format(self) -> None:
-        result = minutes(5)
-        assert ISO_PATTERN.match(result)
-
-    def test_minutes_value(self) -> None:
-        before = datetime.now(UTC)
-        result = _parse(minutes(5))
-        assert result > before + timedelta(minutes=4)
-
-    def test_hours_format(self) -> None:
-        result = hours(1)
-        assert ISO_PATTERN.match(result)
-
-    def test_hours_value(self) -> None:
-        before = datetime.now(UTC)
-        result = _parse(hours(2))
-        assert result > before + timedelta(hours=1)
-
-    def test_days_format(self) -> None:
-        result = days(1)
-        assert ISO_PATTERN.match(result)
-
-    def test_days_value(self) -> None:
-        before = datetime.now(UTC)
-        result = _parse(days(7))
-        assert result > before + timedelta(days=6)
-
-    def test_weeks_format(self) -> None:
-        result = weeks(1)
-        assert ISO_PATTERN.match(result)
-
-    def test_weeks_value(self) -> None:
-        before = datetime.now(UTC)
-        result = _parse(weeks(2))
-        assert result > before + timedelta(weeks=1)
-
-    def test_months_format(self) -> None:
-        result = months(1)
-        assert ISO_PATTERN.match(result)
-
-    def test_months_value(self) -> None:
-        """months(1) should be ~30 days from now."""
-        before = datetime.now(UTC)
-        result = _parse(months(1))
-        assert result > before + timedelta(days=29)
-
-    def test_years_format(self) -> None:
-        result = years(1)
-        assert ISO_PATTERN.match(result)
-
-    def test_years_value(self) -> None:
-        """years(1) should be ~365 days from now."""
-        before = datetime.now(UTC)
-        result = _parse(years(1))
-        assert result > before + timedelta(days=364)
+    @pytest.mark.parametrize("fn,n,delta", HELPERS, ids=lambda x: x.__name__ if callable(x) else repr(x))
+    def test_result_is_utc(self, fn, n, delta) -> None:
+        """Parsed result should always be timezone-aware and in UTC."""
+        result = _parse(fn(n))
+        assert result.tzinfo is not None
+        assert result.utcoffset() == timedelta(0)
 
     def test_all_end_with_z(self) -> None:
         """All helpers should produce timestamps ending with Z."""

--- a/tests/test_expires.py
+++ b/tests/test_expires.py
@@ -1,0 +1,95 @@
+"""Tests for expires helper functions."""
+
+import re
+from datetime import UTC, datetime, timedelta
+
+from mpp._expires import days, hours, minutes, months, seconds, weeks, years
+
+ISO_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$")
+
+
+def _parse(iso: str) -> datetime:
+    """Parse an ISO 8601 string with Z suffix."""
+    return datetime.fromisoformat(iso.replace("Z", "+00:00"))
+
+
+class TestExpiresHelpers:
+    def test_seconds_format(self) -> None:
+        """seconds() should produce valid ISO 8601 with 3-digit ms and Z suffix."""
+        result = seconds(30)
+        assert ISO_PATTERN.match(result)
+
+    def test_seconds_value(self) -> None:
+        """seconds(30) should be ~30s from now."""
+        before = datetime.now(UTC)
+        result = _parse(seconds(30))
+        after = datetime.now(UTC) + timedelta(seconds=30)
+        assert before + timedelta(seconds=29) <= result <= after + timedelta(seconds=1)
+
+    def test_minutes_format(self) -> None:
+        result = minutes(5)
+        assert ISO_PATTERN.match(result)
+
+    def test_minutes_value(self) -> None:
+        before = datetime.now(UTC)
+        result = _parse(minutes(5))
+        assert result > before + timedelta(minutes=4)
+
+    def test_hours_format(self) -> None:
+        result = hours(1)
+        assert ISO_PATTERN.match(result)
+
+    def test_hours_value(self) -> None:
+        before = datetime.now(UTC)
+        result = _parse(hours(2))
+        assert result > before + timedelta(hours=1)
+
+    def test_days_format(self) -> None:
+        result = days(1)
+        assert ISO_PATTERN.match(result)
+
+    def test_days_value(self) -> None:
+        before = datetime.now(UTC)
+        result = _parse(days(7))
+        assert result > before + timedelta(days=6)
+
+    def test_weeks_format(self) -> None:
+        result = weeks(1)
+        assert ISO_PATTERN.match(result)
+
+    def test_weeks_value(self) -> None:
+        before = datetime.now(UTC)
+        result = _parse(weeks(2))
+        assert result > before + timedelta(weeks=1)
+
+    def test_months_format(self) -> None:
+        result = months(1)
+        assert ISO_PATTERN.match(result)
+
+    def test_months_value(self) -> None:
+        """months(1) should be ~30 days from now."""
+        before = datetime.now(UTC)
+        result = _parse(months(1))
+        assert result > before + timedelta(days=29)
+
+    def test_years_format(self) -> None:
+        result = years(1)
+        assert ISO_PATTERN.match(result)
+
+    def test_years_value(self) -> None:
+        """years(1) should be ~365 days from now."""
+        before = datetime.now(UTC)
+        result = _parse(years(1))
+        assert result > before + timedelta(days=364)
+
+    def test_all_end_with_z(self) -> None:
+        """All helpers should produce timestamps ending with Z."""
+        for fn in [seconds, minutes, hours, days, weeks, months, years]:
+            assert fn(1).endswith("Z")
+
+    def test_all_have_3_digit_ms(self) -> None:
+        """All helpers should have exactly 3-digit milliseconds."""
+        for fn in [seconds, minutes, hours, days, weeks, months, years]:
+            result = fn(1)
+            ms_part = result.split(".")[1].rstrip("Z")
+            assert len(ms_part) == 3

--- a/tests/test_keychain.py
+++ b/tests/test_keychain.py
@@ -64,7 +64,9 @@ class TestBuildKeychainSignature:
         msg_hash = b"\x00" * 32
 
         with pytest.raises(ValueError):
-            build_keychain_signature(msg_hash, access_key, "0xZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ")
+            build_keychain_signature(
+                msg_hash, access_key, "0xZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ"
+            )
 
     def test_invalid_root_address_odd_length_hex(self) -> None:
         """Should raise on root address with odd-length hex string."""

--- a/tests/test_keychain.py
+++ b/tests/test_keychain.py
@@ -1,0 +1,66 @@
+"""Tests for Tempo keychain signature handling."""
+
+import pytest
+
+from mpp.methods.tempo import TempoAccount
+from mpp.methods.tempo.keychain import (
+    KEYCHAIN_SIGNATURE_LENGTH,
+    KEYCHAIN_SIGNATURE_TYPE,
+    build_keychain_signature,
+)
+
+TEST_KEY = "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+
+class TestBuildKeychainSignature:
+    def test_happy_path_format(self) -> None:
+        """Should produce 86-byte signature: 0x03 || root_address || inner_sig."""
+        access_key = TempoAccount.from_key(TEST_KEY)
+        root_account = "0x742d35Cc6634c0532925a3b844bC9e7595F8fE00"
+        msg_hash = b"\xab" * 32
+
+        sig = build_keychain_signature(msg_hash, access_key, root_account)
+
+        assert len(sig) == KEYCHAIN_SIGNATURE_LENGTH
+        assert sig[0] == KEYCHAIN_SIGNATURE_TYPE
+        assert sig[1:21] == bytes.fromhex(root_account[2:])
+        assert len(sig[21:]) == 65
+
+    def test_inner_signature_is_deterministic(self) -> None:
+        """Same hash + key should produce same inner signature."""
+        access_key = TempoAccount.from_key(TEST_KEY)
+        root_account = "0x742d35Cc6634c0532925a3b844bC9e7595F8fE00"
+        msg_hash = b"\x01" * 32
+
+        sig1 = build_keychain_signature(msg_hash, access_key, root_account)
+        sig2 = build_keychain_signature(msg_hash, access_key, root_account)
+
+        assert sig1 == sig2
+
+    def test_different_root_accounts_produce_different_sigs(self) -> None:
+        """Different root addresses should produce different signatures."""
+        access_key = TempoAccount.from_key(TEST_KEY)
+        msg_hash = b"\x00" * 32
+
+        sig1 = build_keychain_signature(msg_hash, access_key, "0x" + "aa" * 20)
+        sig2 = build_keychain_signature(msg_hash, access_key, "0x" + "bb" * 20)
+
+        assert sig1[1:21] != sig2[1:21]
+        # Inner sig is the same since msg_hash and key are the same
+        assert sig1[21:] == sig2[21:]
+
+    def test_invalid_root_address_too_short(self) -> None:
+        """Should raise on root address with too few hex chars."""
+        access_key = TempoAccount.from_key(TEST_KEY)
+        msg_hash = b"\x00" * 32
+
+        with pytest.raises((ValueError, AssertionError)):
+            build_keychain_signature(msg_hash, access_key, "0xdead")
+
+    def test_invalid_root_address_not_hex(self) -> None:
+        """Should raise on root address with invalid hex."""
+        access_key = TempoAccount.from_key(TEST_KEY)
+        msg_hash = b"\x00" * 32
+
+        with pytest.raises(ValueError):
+            build_keychain_signature(msg_hash, access_key, "0xZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ")

--- a/tests/test_keychain.py
+++ b/tests/test_keychain.py
@@ -54,7 +54,8 @@ class TestBuildKeychainSignature:
         access_key = TempoAccount.from_key(TEST_KEY)
         msg_hash = b"\x00" * 32
 
-        with pytest.raises((ValueError, AssertionError)):
+        # Production code uses `assert` for length validation after building the signature
+        with pytest.raises(AssertionError):
             build_keychain_signature(msg_hash, access_key, "0xdead")
 
     def test_invalid_root_address_not_hex(self) -> None:
@@ -64,3 +65,11 @@ class TestBuildKeychainSignature:
 
         with pytest.raises(ValueError):
             build_keychain_signature(msg_hash, access_key, "0xZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ")
+
+    def test_invalid_root_address_odd_length_hex(self) -> None:
+        """Should raise on root address with odd-length hex string."""
+        access_key = TempoAccount.from_key(TEST_KEY)
+        msg_hash = b"\x00" * 32
+
+        with pytest.raises(ValueError):
+            build_keychain_signature(msg_hash, access_key, "0x" + "a" * 39)

--- a/tests/test_tempo.py
+++ b/tests/test_tempo.py
@@ -1240,53 +1240,59 @@ class TestVerifyTransferLogsWithMemo:
         """TransferWithMemo log with correct memo should be accepted."""
         intent = ChargeIntent(rpc_url="https://rpc.test")
         request = self._make_request(memo=self.MEMO)
-        receipt = self._make_receipt([
-            {
-                "address": self.CURRENCY,
-                "topics": [
-                    TRANSFER_WITH_MEMO_TOPIC,
-                    "0x" + "0" * 24 + "abcd" * 10,
-                    "0x" + "0" * 24 + self.RECIPIENT[2:].lower(),
-                    self.MEMO,
-                ],
-                "data": "0x" + hex(self.AMOUNT)[2:].zfill(64),
-            }
-        ])
+        receipt = self._make_receipt(
+            [
+                {
+                    "address": self.CURRENCY,
+                    "topics": [
+                        TRANSFER_WITH_MEMO_TOPIC,
+                        "0x" + "0" * 24 + "abcd" * 10,
+                        "0x" + "0" * 24 + self.RECIPIENT[2:].lower(),
+                        self.MEMO,
+                    ],
+                    "data": "0x" + hex(self.AMOUNT)[2:].zfill(64),
+                }
+            ]
+        )
         assert intent._verify_transfer_logs(receipt, request) is True
 
     def test_memo_log_wrong_memo_rejected(self) -> None:
         """TransferWithMemo log with wrong memo should be rejected."""
         intent = ChargeIntent(rpc_url="https://rpc.test")
         request = self._make_request(memo=self.MEMO)
-        receipt = self._make_receipt([
-            {
-                "address": self.CURRENCY,
-                "topics": [
-                    TRANSFER_WITH_MEMO_TOPIC,
-                    "0x" + "0" * 24 + "abcd" * 10,
-                    "0x" + "0" * 24 + self.RECIPIENT[2:].lower(),
-                    "0x" + "cc" * 32,
-                ],
-                "data": "0x" + hex(self.AMOUNT)[2:].zfill(64),
-            }
-        ])
+        receipt = self._make_receipt(
+            [
+                {
+                    "address": self.CURRENCY,
+                    "topics": [
+                        TRANSFER_WITH_MEMO_TOPIC,
+                        "0x" + "0" * 24 + "abcd" * 10,
+                        "0x" + "0" * 24 + self.RECIPIENT[2:].lower(),
+                        "0x" + "cc" * 32,
+                    ],
+                    "data": "0x" + hex(self.AMOUNT)[2:].zfill(64),
+                }
+            ]
+        )
         assert intent._verify_transfer_logs(receipt, request) is False
 
     def test_memo_log_too_few_topics_rejected(self) -> None:
         """TransferWithMemo log with < 4 topics should be skipped."""
         intent = ChargeIntent(rpc_url="https://rpc.test")
         request = self._make_request(memo=self.MEMO)
-        receipt = self._make_receipt([
-            {
-                "address": self.CURRENCY,
-                "topics": [
-                    TRANSFER_WITH_MEMO_TOPIC,
-                    "0x" + "0" * 24 + "abcd" * 10,
-                    "0x" + "0" * 24 + self.RECIPIENT[2:].lower(),
-                ],
-                "data": "0x" + hex(self.AMOUNT)[2:].zfill(64),
-            }
-        ])
+        receipt = self._make_receipt(
+            [
+                {
+                    "address": self.CURRENCY,
+                    "topics": [
+                        TRANSFER_WITH_MEMO_TOPIC,
+                        "0x" + "0" * 24 + "abcd" * 10,
+                        "0x" + "0" * 24 + self.RECIPIENT[2:].lower(),
+                    ],
+                    "data": "0x" + hex(self.AMOUNT)[2:].zfill(64),
+                }
+            ]
+        )
         assert intent._verify_transfer_logs(receipt, request) is False
 
     def test_no_memo_requires_transfer_topic(self) -> None:
@@ -1295,31 +1301,35 @@ class TestVerifyTransferLogsWithMemo:
         request = self._make_request(memo=None)
 
         # TRANSFER_WITH_MEMO_TOPIC should be skipped when no memo expected
-        receipt_memo_topic = self._make_receipt([
-            {
-                "address": self.CURRENCY,
-                "topics": [
-                    TRANSFER_WITH_MEMO_TOPIC,
-                    "0x" + "0" * 24 + "abcd" * 10,
-                    "0x" + "0" * 24 + self.RECIPIENT[2:].lower(),
-                ],
-                "data": "0x" + hex(self.AMOUNT)[2:].zfill(64),
-            }
-        ])
+        receipt_memo_topic = self._make_receipt(
+            [
+                {
+                    "address": self.CURRENCY,
+                    "topics": [
+                        TRANSFER_WITH_MEMO_TOPIC,
+                        "0x" + "0" * 24 + "abcd" * 10,
+                        "0x" + "0" * 24 + self.RECIPIENT[2:].lower(),
+                    ],
+                    "data": "0x" + hex(self.AMOUNT)[2:].zfill(64),
+                }
+            ]
+        )
         assert intent._verify_transfer_logs(receipt_memo_topic, request) is False
 
         # TRANSFER_TOPIC should be accepted
-        receipt_plain = self._make_receipt([
-            {
-                "address": self.CURRENCY,
-                "topics": [
-                    TRANSFER_TOPIC,
-                    "0x" + "0" * 24 + "abcd" * 10,
-                    "0x" + "0" * 24 + self.RECIPIENT[2:].lower(),
-                ],
-                "data": "0x" + hex(self.AMOUNT)[2:].zfill(64),
-            }
-        ])
+        receipt_plain = self._make_receipt(
+            [
+                {
+                    "address": self.CURRENCY,
+                    "topics": [
+                        TRANSFER_TOPIC,
+                        "0x" + "0" * 24 + "abcd" * 10,
+                        "0x" + "0" * 24 + self.RECIPIENT[2:].lower(),
+                    ],
+                    "data": "0x" + hex(self.AMOUNT)[2:].zfill(64),
+                }
+            ]
+        )
         assert intent._verify_transfer_logs(receipt_plain, request) is True
 
 

--- a/tests/test_tempo.py
+++ b/tests/test_tempo.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, patch
 
 import httpx
 import pytest
+import rlp
 from pytest_httpx import HTTPXMock
 
 from mpp import Challenge
@@ -19,7 +20,15 @@ from mpp.methods.tempo import (
 )
 from mpp.methods.tempo._defaults import CHAIN_RPC_URLS
 from mpp.methods.tempo.client import TempoMethod
-from mpp.methods.tempo.intents import ChargeIntent
+from mpp.methods.tempo.intents import (
+    TRANSFER_SELECTOR,
+    TRANSFER_TOPIC,
+    TRANSFER_WITH_MEMO_SELECTOR,
+    TRANSFER_WITH_MEMO_TOPIC,
+    ChargeIntent,
+    _match_transfer_calldata,
+    _rpc_error_msg,
+)
 from mpp.methods.tempo.schemas import (
     ChargeRequest,
     HashCredentialPayload,
@@ -1138,16 +1147,12 @@ class TestMatchTransferCalldataWithMemo:
 
     def test_memo_requires_transfer_with_memo_selector(self) -> None:
         """When memo is set, plain transfer selector should be rejected."""
-        from mpp.methods.tempo.intents import TRANSFER_SELECTOR, _match_transfer_calldata
-
         request = self._make_request(memo=self.MEMO)
         calldata = self._build_calldata(TRANSFER_SELECTOR, self.RECIPIENT, self.AMOUNT, self.MEMO)
         assert _match_transfer_calldata(calldata, request) is False
 
     def test_memo_accepts_correct_selector(self) -> None:
         """When memo is set, transferWithMemo selector should be accepted."""
-        from mpp.methods.tempo.intents import TRANSFER_WITH_MEMO_SELECTOR, _match_transfer_calldata
-
         request = self._make_request(memo=self.MEMO)
         calldata = self._build_calldata(
             TRANSFER_WITH_MEMO_SELECTOR, self.RECIPIENT, self.AMOUNT, self.MEMO
@@ -1156,8 +1161,6 @@ class TestMatchTransferCalldataWithMemo:
 
     def test_memo_wrong_memo_value(self) -> None:
         """Wrong memo value should be rejected."""
-        from mpp.methods.tempo.intents import TRANSFER_WITH_MEMO_SELECTOR, _match_transfer_calldata
-
         request = self._make_request(memo=self.MEMO)
         wrong_memo = "0x" + "cc" * 32
         calldata = self._build_calldata(
@@ -1167,8 +1170,6 @@ class TestMatchTransferCalldataWithMemo:
 
     def test_memo_short_calldata_rejected(self) -> None:
         """Calldata shorter than 200 hex chars should be rejected when memo expected."""
-        from mpp.methods.tempo.intents import TRANSFER_WITH_MEMO_SELECTOR, _match_transfer_calldata
-
         request = self._make_request(memo=self.MEMO)
         # Only selector + to + amount = 136 chars, no memo
         to_padded = self.RECIPIENT[2:].lower().zfill(64)
@@ -1178,8 +1179,6 @@ class TestMatchTransferCalldataWithMemo:
 
     def test_memo_normalization_no_0x_prefix(self) -> None:
         """Memo without 0x prefix should be normalized and matched."""
-        from mpp.methods.tempo.intents import TRANSFER_WITH_MEMO_SELECTOR, _match_transfer_calldata
-
         memo_no_prefix = "ab" * 32
         request = self._make_request(memo=memo_no_prefix)
         calldata = self._build_calldata(
@@ -1189,12 +1188,6 @@ class TestMatchTransferCalldataWithMemo:
 
     def test_no_memo_accepts_either_selector(self) -> None:
         """When no memo, both transfer and transferWithMemo selectors should be accepted."""
-        from mpp.methods.tempo.intents import (
-            TRANSFER_SELECTOR,
-            TRANSFER_WITH_MEMO_SELECTOR,
-            _match_transfer_calldata,
-        )
-
         request = self._make_request(memo=None)
         calldata_plain = self._build_calldata(TRANSFER_SELECTOR, self.RECIPIENT, self.AMOUNT)
         calldata_memo = self._build_calldata(
@@ -1205,10 +1198,22 @@ class TestMatchTransferCalldataWithMemo:
 
     def test_short_calldata_rejected(self) -> None:
         """Calldata shorter than 136 chars should always be rejected."""
-        from mpp.methods.tempo.intents import _match_transfer_calldata
-
         request = self._make_request()
         assert _match_transfer_calldata("a9059cbb", request) is False
+
+    def test_wrong_selector_rejected(self) -> None:
+        """A completely bogus selector should be rejected."""
+        request = self._make_request()
+        calldata = self._build_calldata("deadbeef", self.RECIPIENT, self.AMOUNT)
+        assert _match_transfer_calldata(calldata, request) is False
+
+    def test_uppercase_hex_normalization(self) -> None:
+        """Uppercase hex in recipient/amount should still match (case-insensitive)."""
+        request = self._make_request()
+        to_padded = self.RECIPIENT[2:].upper().zfill(64)
+        amount_padded = hex(self.AMOUNT)[2:].upper().zfill(64)
+        calldata = f"{TRANSFER_SELECTOR}{to_padded}{amount_padded}"
+        assert _match_transfer_calldata(calldata, request) is True
 
 
 class TestVerifyTransferLogsWithMemo:
@@ -1233,8 +1238,6 @@ class TestVerifyTransferLogsWithMemo:
 
     def test_memo_log_accepted(self) -> None:
         """TransferWithMemo log with correct memo should be accepted."""
-        from mpp.methods.tempo.intents import TRANSFER_WITH_MEMO_TOPIC
-
         intent = ChargeIntent(rpc_url="https://rpc.test")
         request = self._make_request(memo=self.MEMO)
         receipt = self._make_receipt([
@@ -1253,8 +1256,6 @@ class TestVerifyTransferLogsWithMemo:
 
     def test_memo_log_wrong_memo_rejected(self) -> None:
         """TransferWithMemo log with wrong memo should be rejected."""
-        from mpp.methods.tempo.intents import TRANSFER_WITH_MEMO_TOPIC
-
         intent = ChargeIntent(rpc_url="https://rpc.test")
         request = self._make_request(memo=self.MEMO)
         receipt = self._make_receipt([
@@ -1273,8 +1274,6 @@ class TestVerifyTransferLogsWithMemo:
 
     def test_memo_log_too_few_topics_rejected(self) -> None:
         """TransferWithMemo log with < 4 topics should be skipped."""
-        from mpp.methods.tempo.intents import TRANSFER_WITH_MEMO_TOPIC
-
         intent = ChargeIntent(rpc_url="https://rpc.test")
         request = self._make_request(memo=self.MEMO)
         receipt = self._make_receipt([
@@ -1292,8 +1291,6 @@ class TestVerifyTransferLogsWithMemo:
 
     def test_no_memo_requires_transfer_topic(self) -> None:
         """When no memo expected, only TRANSFER_TOPIC should be accepted."""
-        from mpp.methods.tempo.intents import TRANSFER_TOPIC, TRANSFER_WITH_MEMO_TOPIC
-
         intent = ChargeIntent(rpc_url="https://rpc.test")
         request = self._make_request(memo=None)
 
@@ -1355,8 +1352,6 @@ class TestValidateTransactionPayload:
 
     def test_empty_calls_raises(self) -> None:
         """Transaction with no calls should raise VerificationError."""
-        import rlp
-
         intent = ChargeIntent(rpc_url="https://rpc.test")
         request = self._make_request()
 
@@ -1370,8 +1365,6 @@ class TestValidateTransactionPayload:
 
     def test_valid_tx_with_matching_call_passes(self) -> None:
         """Transaction with a matching transfer call should not raise."""
-        import rlp
-
         intent = ChargeIntent(rpc_url="https://rpc.test")
         request = self._make_request()
 
@@ -1390,8 +1383,6 @@ class TestValidateTransactionPayload:
 
     def test_no_matching_call_raises(self) -> None:
         """Transaction with no matching call should raise VerificationError."""
-        import rlp
-
         intent = ChargeIntent(rpc_url="https://rpc.test")
         request = self._make_request()
 
@@ -1415,30 +1406,22 @@ class TestRpcErrorMsg:
     """Tests for _rpc_error_msg helper."""
 
     def test_dict_error_with_message_and_data(self) -> None:
-        from mpp.methods.tempo.intents import _rpc_error_msg
-
         result = {"error": {"message": "insufficient funds", "data": "0xdead"}}
         msg = _rpc_error_msg(result)
         assert "insufficient funds" in msg
         assert "0xdead" in msg
 
     def test_dict_error_message_only(self) -> None:
-        from mpp.methods.tempo.intents import _rpc_error_msg
-
         result = {"error": {"message": "nonce too low"}}
         msg = _rpc_error_msg(result)
         assert msg == "nonce too low"
 
     def test_dict_error_name_fallback(self) -> None:
-        from mpp.methods.tempo.intents import _rpc_error_msg
-
         result = {"error": {"name": "SomeError"}}
         msg = _rpc_error_msg(result)
         assert "SomeError" in msg
 
     def test_string_error(self) -> None:
-        from mpp.methods.tempo.intents import _rpc_error_msg
-
         result = {"error": "something broke"}
         msg = _rpc_error_msg(result)
         assert msg == "something broke"

--- a/tests/test_tempo.py
+++ b/tests/test_tempo.py
@@ -1113,6 +1113,337 @@ class TestChainIdPropagation:
             await method.create_credential(challenge)
 
 
+class TestMatchTransferCalldataWithMemo:
+    """Tests for _match_transfer_calldata with memo field."""
+
+    CURRENCY = "0x20c0000000000000000000000000000000000000"
+    RECIPIENT = "0x742d35Cc6634c0532925a3b844bC9e7595F8fE00"
+    AMOUNT = 1000000
+    MEMO = "0x" + "ab" * 32
+
+    def _make_request(self, memo: str | None = None) -> ChargeRequest:
+        return ChargeRequest(
+            amount=str(self.AMOUNT),
+            currency=self.CURRENCY,
+            recipient=self.RECIPIENT,
+            expires="2030-01-20T12:00:00Z",
+            methodDetails=MethodDetails(memo=memo),
+        )
+
+    def _build_calldata(self, selector: str, recipient: str, amount: int, memo: str = "") -> str:
+        to_padded = recipient[2:].lower().zfill(64)
+        amount_padded = hex(amount)[2:].zfill(64)
+        memo_part = memo[2:] if memo.startswith("0x") else memo
+        return f"{selector}{to_padded}{amount_padded}{memo_part}"
+
+    def test_memo_requires_transfer_with_memo_selector(self) -> None:
+        """When memo is set, plain transfer selector should be rejected."""
+        from mpp.methods.tempo.intents import TRANSFER_SELECTOR, _match_transfer_calldata
+
+        request = self._make_request(memo=self.MEMO)
+        calldata = self._build_calldata(TRANSFER_SELECTOR, self.RECIPIENT, self.AMOUNT, self.MEMO)
+        assert _match_transfer_calldata(calldata, request) is False
+
+    def test_memo_accepts_correct_selector(self) -> None:
+        """When memo is set, transferWithMemo selector should be accepted."""
+        from mpp.methods.tempo.intents import TRANSFER_WITH_MEMO_SELECTOR, _match_transfer_calldata
+
+        request = self._make_request(memo=self.MEMO)
+        calldata = self._build_calldata(
+            TRANSFER_WITH_MEMO_SELECTOR, self.RECIPIENT, self.AMOUNT, self.MEMO
+        )
+        assert _match_transfer_calldata(calldata, request) is True
+
+    def test_memo_wrong_memo_value(self) -> None:
+        """Wrong memo value should be rejected."""
+        from mpp.methods.tempo.intents import TRANSFER_WITH_MEMO_SELECTOR, _match_transfer_calldata
+
+        request = self._make_request(memo=self.MEMO)
+        wrong_memo = "0x" + "cc" * 32
+        calldata = self._build_calldata(
+            TRANSFER_WITH_MEMO_SELECTOR, self.RECIPIENT, self.AMOUNT, wrong_memo
+        )
+        assert _match_transfer_calldata(calldata, request) is False
+
+    def test_memo_short_calldata_rejected(self) -> None:
+        """Calldata shorter than 200 hex chars should be rejected when memo expected."""
+        from mpp.methods.tempo.intents import TRANSFER_WITH_MEMO_SELECTOR, _match_transfer_calldata
+
+        request = self._make_request(memo=self.MEMO)
+        # Only selector + to + amount = 136 chars, no memo
+        to_padded = self.RECIPIENT[2:].lower().zfill(64)
+        amount_padded = hex(self.AMOUNT)[2:].zfill(64)
+        calldata = f"{TRANSFER_WITH_MEMO_SELECTOR}{to_padded}{amount_padded}"
+        assert _match_transfer_calldata(calldata, request) is False
+
+    def test_memo_normalization_no_0x_prefix(self) -> None:
+        """Memo without 0x prefix should be normalized and matched."""
+        from mpp.methods.tempo.intents import TRANSFER_WITH_MEMO_SELECTOR, _match_transfer_calldata
+
+        memo_no_prefix = "ab" * 32
+        request = self._make_request(memo=memo_no_prefix)
+        calldata = self._build_calldata(
+            TRANSFER_WITH_MEMO_SELECTOR, self.RECIPIENT, self.AMOUNT, "0x" + memo_no_prefix
+        )
+        assert _match_transfer_calldata(calldata, request) is True
+
+    def test_no_memo_accepts_either_selector(self) -> None:
+        """When no memo, both transfer and transferWithMemo selectors should be accepted."""
+        from mpp.methods.tempo.intents import (
+            TRANSFER_SELECTOR,
+            TRANSFER_WITH_MEMO_SELECTOR,
+            _match_transfer_calldata,
+        )
+
+        request = self._make_request(memo=None)
+        calldata_plain = self._build_calldata(TRANSFER_SELECTOR, self.RECIPIENT, self.AMOUNT)
+        calldata_memo = self._build_calldata(
+            TRANSFER_WITH_MEMO_SELECTOR, self.RECIPIENT, self.AMOUNT
+        )
+        assert _match_transfer_calldata(calldata_plain, request) is True
+        assert _match_transfer_calldata(calldata_memo, request) is True
+
+    def test_short_calldata_rejected(self) -> None:
+        """Calldata shorter than 136 chars should always be rejected."""
+        from mpp.methods.tempo.intents import _match_transfer_calldata
+
+        request = self._make_request()
+        assert _match_transfer_calldata("a9059cbb", request) is False
+
+
+class TestVerifyTransferLogsWithMemo:
+    """Tests for _verify_transfer_logs with memo field."""
+
+    CURRENCY = "0x20c0000000000000000000000000000000000000"
+    RECIPIENT = "0x742d35Cc6634c0532925a3b844bC9e7595F8fE00"
+    AMOUNT = 1000000
+    MEMO = "0x" + "ab" * 32
+
+    def _make_receipt(self, logs: list) -> dict:
+        return {"status": "0x1", "logs": logs}
+
+    def _make_request(self, memo: str | None = None) -> ChargeRequest:
+        return ChargeRequest(
+            amount=str(self.AMOUNT),
+            currency=self.CURRENCY,
+            recipient=self.RECIPIENT,
+            expires="2030-01-20T12:00:00Z",
+            methodDetails=MethodDetails(memo=memo),
+        )
+
+    def test_memo_log_accepted(self) -> None:
+        """TransferWithMemo log with correct memo should be accepted."""
+        from mpp.methods.tempo.intents import TRANSFER_WITH_MEMO_TOPIC
+
+        intent = ChargeIntent(rpc_url="https://rpc.test")
+        request = self._make_request(memo=self.MEMO)
+        receipt = self._make_receipt([
+            {
+                "address": self.CURRENCY,
+                "topics": [
+                    TRANSFER_WITH_MEMO_TOPIC,
+                    "0x" + "0" * 24 + "abcd" * 10,
+                    "0x" + "0" * 24 + self.RECIPIENT[2:].lower(),
+                    self.MEMO,
+                ],
+                "data": "0x" + hex(self.AMOUNT)[2:].zfill(64),
+            }
+        ])
+        assert intent._verify_transfer_logs(receipt, request) is True
+
+    def test_memo_log_wrong_memo_rejected(self) -> None:
+        """TransferWithMemo log with wrong memo should be rejected."""
+        from mpp.methods.tempo.intents import TRANSFER_WITH_MEMO_TOPIC
+
+        intent = ChargeIntent(rpc_url="https://rpc.test")
+        request = self._make_request(memo=self.MEMO)
+        receipt = self._make_receipt([
+            {
+                "address": self.CURRENCY,
+                "topics": [
+                    TRANSFER_WITH_MEMO_TOPIC,
+                    "0x" + "0" * 24 + "abcd" * 10,
+                    "0x" + "0" * 24 + self.RECIPIENT[2:].lower(),
+                    "0x" + "cc" * 32,
+                ],
+                "data": "0x" + hex(self.AMOUNT)[2:].zfill(64),
+            }
+        ])
+        assert intent._verify_transfer_logs(receipt, request) is False
+
+    def test_memo_log_too_few_topics_rejected(self) -> None:
+        """TransferWithMemo log with < 4 topics should be skipped."""
+        from mpp.methods.tempo.intents import TRANSFER_WITH_MEMO_TOPIC
+
+        intent = ChargeIntent(rpc_url="https://rpc.test")
+        request = self._make_request(memo=self.MEMO)
+        receipt = self._make_receipt([
+            {
+                "address": self.CURRENCY,
+                "topics": [
+                    TRANSFER_WITH_MEMO_TOPIC,
+                    "0x" + "0" * 24 + "abcd" * 10,
+                    "0x" + "0" * 24 + self.RECIPIENT[2:].lower(),
+                ],
+                "data": "0x" + hex(self.AMOUNT)[2:].zfill(64),
+            }
+        ])
+        assert intent._verify_transfer_logs(receipt, request) is False
+
+    def test_no_memo_requires_transfer_topic(self) -> None:
+        """When no memo expected, only TRANSFER_TOPIC should be accepted."""
+        from mpp.methods.tempo.intents import TRANSFER_TOPIC, TRANSFER_WITH_MEMO_TOPIC
+
+        intent = ChargeIntent(rpc_url="https://rpc.test")
+        request = self._make_request(memo=None)
+
+        # TRANSFER_WITH_MEMO_TOPIC should be skipped when no memo expected
+        receipt_memo_topic = self._make_receipt([
+            {
+                "address": self.CURRENCY,
+                "topics": [
+                    TRANSFER_WITH_MEMO_TOPIC,
+                    "0x" + "0" * 24 + "abcd" * 10,
+                    "0x" + "0" * 24 + self.RECIPIENT[2:].lower(),
+                ],
+                "data": "0x" + hex(self.AMOUNT)[2:].zfill(64),
+            }
+        ])
+        assert intent._verify_transfer_logs(receipt_memo_topic, request) is False
+
+        # TRANSFER_TOPIC should be accepted
+        receipt_plain = self._make_receipt([
+            {
+                "address": self.CURRENCY,
+                "topics": [
+                    TRANSFER_TOPIC,
+                    "0x" + "0" * 24 + "abcd" * 10,
+                    "0x" + "0" * 24 + self.RECIPIENT[2:].lower(),
+                ],
+                "data": "0x" + hex(self.AMOUNT)[2:].zfill(64),
+            }
+        ])
+        assert intent._verify_transfer_logs(receipt_plain, request) is True
+
+
+class TestValidateTransactionPayload:
+    """Tests for _validate_transaction_payload."""
+
+    CURRENCY = "0x20c0000000000000000000000000000000000000"
+    RECIPIENT = "0x742d35Cc6634c0532925a3b844bC9e7595F8fE00"
+
+    def _make_request(self) -> ChargeRequest:
+        return ChargeRequest(
+            amount="1000000",
+            currency=self.CURRENCY,
+            recipient=self.RECIPIENT,
+            expires="2030-01-20T12:00:00Z",
+        )
+
+    def test_non_tempo_tx_returns_silently(self) -> None:
+        """Non-0x76 prefix transaction should be silently skipped."""
+        intent = ChargeIntent(rpc_url="https://rpc.test")
+        request = self._make_request()
+        # 0x02 is a standard EIP-1559 tx prefix
+        intent._validate_transaction_payload("0x02abcdef", request)
+
+    def test_invalid_hex_returns_silently(self) -> None:
+        """Non-hex signature should be silently skipped."""
+        intent = ChargeIntent(rpc_url="https://rpc.test")
+        request = self._make_request()
+        intent._validate_transaction_payload("0xZZZZ", request)
+
+    def test_empty_calls_raises(self) -> None:
+        """Transaction with no calls should raise VerificationError."""
+        import rlp
+
+        intent = ChargeIntent(rpc_url="https://rpc.test")
+        request = self._make_request()
+
+        # Build minimal RLP: [chain_id, mpfpg, mfpg, gas, calls=[], ...]
+        decoded = [b"\x01", b"\x01", b"\x01", b"\x01", [], b"", b"", b"\x00", b"", b"", b""]
+        payload = b"\x76" + rlp.encode(decoded)
+        sig = "0x" + payload.hex()
+
+        with pytest.raises(VerificationError, match="no calls"):
+            intent._validate_transaction_payload(sig, request)
+
+    def test_valid_tx_with_matching_call_passes(self) -> None:
+        """Transaction with a matching transfer call should not raise."""
+        import rlp
+
+        intent = ChargeIntent(rpc_url="https://rpc.test")
+        request = self._make_request()
+
+        selector = bytes.fromhex("a9059cbb")
+        to_padded = bytes.fromhex(self.RECIPIENT[2:].lower().zfill(64))
+        amount_padded = bytes.fromhex(hex(1000000)[2:].zfill(64))
+        call_data = selector + to_padded + amount_padded
+
+        currency_bytes = bytes.fromhex(self.CURRENCY[2:])
+        call = [currency_bytes, b"", call_data]
+        decoded = [b"\x01", b"\x01", b"\x01", b"\x01", [call], b"", b"", b"\x00", b"", b"", b""]
+        payload = b"\x76" + rlp.encode(decoded)
+        sig = "0x" + payload.hex()
+
+        intent._validate_transaction_payload(sig, request)
+
+    def test_no_matching_call_raises(self) -> None:
+        """Transaction with no matching call should raise VerificationError."""
+        import rlp
+
+        intent = ChargeIntent(rpc_url="https://rpc.test")
+        request = self._make_request()
+
+        # Call targeting wrong currency
+        wrong_currency = bytes.fromhex("dead" + "00" * 18)
+        selector = bytes.fromhex("a9059cbb")
+        to_padded = bytes.fromhex(self.RECIPIENT[2:].lower().zfill(64))
+        amount_padded = bytes.fromhex(hex(1000000)[2:].zfill(64))
+        call_data = selector + to_padded + amount_padded
+
+        call = [wrong_currency, b"", call_data]
+        decoded = [b"\x01", b"\x01", b"\x01", b"\x01", [call], b"", b"", b"\x00", b"", b"", b""]
+        payload = b"\x76" + rlp.encode(decoded)
+        sig = "0x" + payload.hex()
+
+        with pytest.raises(VerificationError, match="no matching payment call"):
+            intent._validate_transaction_payload(sig, request)
+
+
+class TestRpcErrorMsg:
+    """Tests for _rpc_error_msg helper."""
+
+    def test_dict_error_with_message_and_data(self) -> None:
+        from mpp.methods.tempo.intents import _rpc_error_msg
+
+        result = {"error": {"message": "insufficient funds", "data": "0xdead"}}
+        msg = _rpc_error_msg(result)
+        assert "insufficient funds" in msg
+        assert "0xdead" in msg
+
+    def test_dict_error_message_only(self) -> None:
+        from mpp.methods.tempo.intents import _rpc_error_msg
+
+        result = {"error": {"message": "nonce too low"}}
+        msg = _rpc_error_msg(result)
+        assert msg == "nonce too low"
+
+    def test_dict_error_name_fallback(self) -> None:
+        from mpp.methods.tempo.intents import _rpc_error_msg
+
+        result = {"error": {"name": "SomeError"}}
+        msg = _rpc_error_msg(result)
+        assert "SomeError" in msg
+
+    def test_string_error(self) -> None:
+        from mpp.methods.tempo.intents import _rpc_error_msg
+
+        result = {"error": "something broke"}
+        msg = _rpc_error_msg(result)
+        assert msg == "something broke"
+
+
 class TestDefaultsImmutability:
     """Tests for read-only defaults dicts."""
 

--- a/tests/test_tempo_integration.py
+++ b/tests/test_tempo_integration.py
@@ -295,6 +295,138 @@ class TestChargeIntegration:
         assert receipt.reference.startswith("0x")
         assert len(receipt.reference) >= 66
 
+    async def test_verify_with_server_memo(
+        self, rpc_url, funded_payer, funded_recipient, currency, charge_intent, chain_id
+    ):
+        """When server specifies memo, client should use transferWithMemo and server should verify."""
+        memo = "0x" + "ab" * 32
+
+        method = tempo(
+            account=funded_payer,
+            rpc_url=rpc_url,
+            intents={"charge": ChargeIntent()},
+        )
+        expires = _future_expires()
+        request_dict = {
+            "amount": "1000000",
+            "currency": currency,
+            "recipient": funded_recipient.address,
+            "expires": expires,
+            "methodDetails": {
+                "feePayer": False,
+                "chainId": chain_id,
+                "memo": memo,
+            },
+        }
+        challenge = Challenge(
+            id="integ-memo",
+            method="tempo",
+            intent="charge",
+            request=request_dict,
+        )
+
+        credential = await method.create_credential(challenge)
+        receipt = await charge_intent.verify(credential, request_dict)
+
+        assert receipt.status == "success"
+        assert receipt.reference.startswith("0x")
+
+    async def test_verify_rejects_wrong_memo(
+        self, rpc_url, funded_payer, funded_recipient, currency, charge_intent, chain_id
+    ):
+        """Server should reject when tx has wrong memo."""
+        client_memo = "0x" + "ab" * 32
+        server_memo = "0x" + "cd" * 32
+
+        method = tempo(
+            account=funded_payer,
+            rpc_url=rpc_url,
+            intents={"charge": ChargeIntent()},
+        )
+        expires = _future_expires()
+
+        # Client builds tx with client_memo
+        challenge = Challenge(
+            id="integ-wrong-memo",
+            method="tempo",
+            intent="charge",
+            request={
+                "amount": "1000000",
+                "currency": currency,
+                "recipient": funded_recipient.address,
+                "expires": expires,
+                "methodDetails": {
+                    "feePayer": False,
+                    "chainId": chain_id,
+                    "memo": client_memo,
+                },
+            },
+        )
+        credential = await method.create_credential(challenge)
+
+        # Server verifies with server_memo — should reject
+        server_request = {
+            "amount": "1000000",
+            "currency": currency,
+            "recipient": funded_recipient.address,
+            "expires": expires,
+            "methodDetails": {
+                "feePayer": False,
+                "chainId": chain_id,
+                "memo": server_memo,
+            },
+        }
+        with pytest.raises(VerificationError):
+            await charge_intent.verify(credential, server_request)
+
+    async def test_default_memo_accepted_when_server_omits_memo(
+        self, rpc_url, funded_payer, funded_recipient, currency, charge_intent, chain_id
+    ):
+        """Client defaults memo via encode_attribution; server without memo should still verify.
+
+        The client always adds a memo (via encode_attribution) when the server
+        doesn't specify one. The server's _verify_transfer_logs without memo
+        requires TRANSFER_TOPIC, but the tx emits TRANSFER_WITH_MEMO_TOPIC.
+        This test documents the actual behavior.
+        """
+        method = tempo(
+            account=funded_payer,
+            rpc_url=rpc_url,
+            intents={"charge": ChargeIntent()},
+        )
+        expires = _future_expires()
+        # Server request has NO memo — client will default one via encode_attribution
+        request_dict = {
+            "amount": "1000000",
+            "currency": currency,
+            "recipient": funded_recipient.address,
+            "expires": expires,
+            "methodDetails": {
+                "feePayer": False,
+                "chainId": chain_id,
+            },
+        }
+        challenge = Challenge(
+            id="integ-default-memo",
+            method="tempo",
+            intent="charge",
+            request=request_dict,
+            realm="test.local",
+        )
+
+        credential = await method.create_credential(challenge)
+
+        # The server verifies with no memo in request — _verify_transfer_logs
+        # requires TRANSFER_TOPIC but the tx emits TRANSFER_WITH_MEMO_TOPIC.
+        # This documents the current behavior (it may pass or fail depending
+        # on whether the node emits both topics or just the memo topic).
+        try:
+            receipt = await charge_intent.verify(credential, request_dict)
+            assert receipt.status == "success"
+        except VerificationError:
+            # Expected: memo mismatch between client default and server expectation
+            pass
+
     async def test_fee_payer_wrong_recipient_rejected(
         self, rpc_url, funded_payer, funded_recipient, currency, chain_id
     ):

--- a/tests/test_tempo_integration.py
+++ b/tests/test_tempo_integration.py
@@ -376,18 +376,19 @@ class TestChargeIntegration:
                 "memo": server_memo,
             },
         }
-        with pytest.raises(VerificationError):
+        with pytest.raises(VerificationError, match="Transfer log"):
             await charge_intent.verify(credential, server_request)
 
     async def test_default_memo_accepted_when_server_omits_memo(
         self, rpc_url, funded_payer, funded_recipient, currency, charge_intent, chain_id
     ):
-        """Client defaults memo via encode_attribution; server without memo should still verify.
+        """Verification fails when client defaults a memo but server omits one.
 
-        The client always adds a memo (via encode_attribution) when the server
-        doesn't specify one. The server's _verify_transfer_logs without memo
-        requires TRANSFER_TOPIC, but the tx emits TRANSFER_WITH_MEMO_TOPIC.
-        This test documents the actual behavior.
+        Known incompatibility: the client always adds a memo (via
+        encode_attribution) when the server doesn't specify one, so the tx
+        emits TRANSFER_WITH_MEMO_TOPIC. The server's _verify_transfer_logs
+        without memo requires TRANSFER_TOPIC, causing a topic mismatch and
+        verification failure.
         """
         method = tempo(
             account=funded_payer,
@@ -416,16 +417,10 @@ class TestChargeIntegration:
 
         credential = await method.create_credential(challenge)
 
-        # The server verifies with no memo in request — _verify_transfer_logs
-        # requires TRANSFER_TOPIC but the tx emits TRANSFER_WITH_MEMO_TOPIC.
-        # This documents the current behavior (it may pass or fail depending
-        # on whether the node emits both topics or just the memo topic).
-        try:
-            receipt = await charge_intent.verify(credential, request_dict)
-            assert receipt.status == "success"
-        except VerificationError:
-            # Expected: memo mismatch between client default and server expectation
-            pass
+        # Verification must fail: server looks for TRANSFER_TOPIC but the tx
+        # emits TRANSFER_WITH_MEMO_TOPIC due to the client-defaulted memo.
+        with pytest.raises(VerificationError, match="Transfer log"):
+            await charge_intent.verify(credential, request_dict)
 
     async def test_fee_payer_wrong_recipient_rejected(
         self, rpc_url, funded_payer, funded_recipient, currency, chain_id

--- a/tests/test_tempo_integration.py
+++ b/tests/test_tempo_integration.py
@@ -298,7 +298,8 @@ class TestChargeIntegration:
     async def test_verify_with_server_memo(
         self, rpc_url, funded_payer, funded_recipient, currency, charge_intent, chain_id
     ):
-        """When server specifies memo, client should use transferWithMemo and server should verify."""
+        """When server specifies memo, client should use
+        transferWithMemo and server should verify."""
         memo = "0x" + "ab" * 32
 
         method = tempo(


### PR DESCRIPTION
## Summary

Adds comprehensive test coverage for previously untested or under-tested modules

### New unit test files
| File | Module | Coverage |
|------|--------|----------|
| `test_keychain.py` | `keychain.py` | 0% → **100%** |
| `test_body_digest.py` | `_body_digest.py` | 47% → **100%** |
| `test_expires.py` | `_expires.py` | 53% → **100%** |
| `test_errors.py` | `errors.py` | 75% → **100%** |

### Added to `test_tempo.py` (intents.py 74% → 90%)
- `_match_transfer_calldata` with memo: selector gating, normalization, short calldata
- `_verify_transfer_logs` with memo: topic matching, wrong memo, <4 topics
- `_validate_transaction_payload`: empty calls, no match, non-Tempo silent skip
- `_rpc_error_msg`: dict with data, string error, name fallback

### Integration tests (local node)
- **Memo roundtrip**: server-specified memo verified end-to-end
- **Wrong memo rejection**: mismatched memo correctly rejected on-chain
- **Default memo behavior**: documents the client `encode_attribution()` vs server `TRANSFER_TOPIC` mismatch — client always adds a memo when server doesn't specify one, but the server's `_verify_transfer_logs` requires `TRANSFER_TOPIC` (no-memo) when `expected_memo` is falsy
- **Client→server memo roundtrip** via `PaymentTransport`

### Verification
```
uv run pytest -x --ignore=tests/test_client_integration.py --ignore=tests/test_tempo_integration.py -v
# 335 passed

uv run pytest --cov=mpp --cov-report=term-missing -q
# TOTAL 1455 stmts, 78 missed, 95%
```