### PR TITLE
feat: default currency to USDC on mainnet, pathUSD on testnet

### DIFF
--- a/.changelog/nice-birds-slide.md
+++ b/.changelog/nice-birds-slide.md
@@ -1,0 +1,5 @@
+---
+pympp: minor
+---
+
+Added chain-specific default currency selection: mainnet now defaults to USDC and testnet defaults to pathUSD. Exported `USDC`, `PATH_USD`, and `default_currency_for_chain` from the tempo package public API. Updated tests to reflect the new default currency behavior.

--- a/src/mpp/methods/tempo/__init__.py
+++ b/src/mpp/methods/tempo/__init__.py
@@ -29,7 +29,10 @@ Example:
 from mpp.methods.tempo._defaults import (
     CHAIN_ID,
     ESCROW_CONTRACTS,
+    PATH_USD,
     TESTNET_CHAIN_ID,
+    USDC,
+    default_currency_for_chain,
     escrow_contract_for_chain,
 )
 from mpp.methods.tempo.account import TempoAccount

--- a/src/mpp/methods/tempo/_defaults.py
+++ b/src/mpp/methods/tempo/_defaults.py
@@ -6,6 +6,7 @@ from types import MappingProxyType
 CHAIN_ID = 4217
 RPC_URL = "https://rpc.tempo.xyz"
 PATH_USD = "0x20c0000000000000000000000000000000000000"
+USDC = "0x20C000000000000000000000b9537d11c60E8b50"
 PATH_USD_DECIMALS = 6
 
 # Testnet (Moderato)
@@ -15,6 +16,15 @@ TESTNET_RPC_URL = "https://rpc.moderato.tempo.xyz"
 # Testnet only — the fee payer service sponsors gas on testnet.
 # On mainnet, the server itself must pay gas or provide its own fee payer.
 DEFAULT_FEE_PAYER_URL = "https://sponsor.moderato.tempo.xyz"
+
+# Chain ID -> default currency mapping
+# Mainnet defaults to USDC, testnet defaults to pathUSD
+DEFAULT_CURRENCIES: MappingProxyType[int, str] = MappingProxyType(
+    {
+        CHAIN_ID: USDC,
+        TESTNET_CHAIN_ID: PATH_USD,
+    }
+)
 
 # Chain ID -> default RPC URL mapping
 CHAIN_RPC_URLS: MappingProxyType[int, str] = MappingProxyType(
@@ -47,6 +57,17 @@ def rpc_url_for_chain(chain_id: int) -> str:
             f"Pass rpc_url explicitly for custom chains."
         )
     return url
+
+
+def default_currency_for_chain(chain_id: int | None) -> str:
+    """Return the default currency for a known chain ID.
+
+    Returns USDC for mainnet, pathUSD for testnet.
+    If chain_id is None, returns USDC (mainnet default).
+    """
+    if chain_id is None:
+        return USDC
+    return DEFAULT_CURRENCIES.get(chain_id, USDC)
 
 
 def escrow_contract_for_chain(chain_id: int) -> str:

--- a/src/mpp/methods/tempo/_defaults.py
+++ b/src/mpp/methods/tempo/_defaults.py
@@ -62,11 +62,11 @@ def rpc_url_for_chain(chain_id: int) -> str:
 def default_currency_for_chain(chain_id: int | None) -> str:
     """Return the default currency for a known chain ID.
 
-    Returns USDC for mainnet, pathUSD for testnet and unknown chains.
-    If chain_id is None, returns USDC (mainnet default).
+    Returns USDC only for explicit mainnet (4217).
+    Returns pathUSD for testnet, unknown chains, and None.
     """
     if chain_id is None:
-        return USDC
+        return PATH_USD
     return DEFAULT_CURRENCIES.get(chain_id, PATH_USD)
 
 

--- a/src/mpp/methods/tempo/_defaults.py
+++ b/src/mpp/methods/tempo/_defaults.py
@@ -62,12 +62,12 @@ def rpc_url_for_chain(chain_id: int) -> str:
 def default_currency_for_chain(chain_id: int | None) -> str:
     """Return the default currency for a known chain ID.
 
-    Returns USDC for mainnet, pathUSD for testnet.
+    Returns USDC for mainnet, pathUSD for testnet and unknown chains.
     If chain_id is None, returns USDC (mainnet default).
     """
     if chain_id is None:
         return USDC
-    return DEFAULT_CURRENCIES.get(chain_id, USDC)
+    return DEFAULT_CURRENCIES.get(chain_id, PATH_USD)
 
 
 def escrow_contract_for_chain(chain_id: int) -> str:

--- a/src/mpp/methods/tempo/client.py
+++ b/src/mpp/methods/tempo/client.py
@@ -13,7 +13,12 @@ import attrs
 
 from mpp import Challenge, Credential
 from mpp.methods.tempo._attribution import encode as encode_attribution
-from mpp.methods.tempo._defaults import CHAIN_RPC_URLS, RPC_URL, rpc_url_for_chain
+from mpp.methods.tempo._defaults import (
+    CHAIN_RPC_URLS,
+    RPC_URL,
+    default_currency_for_chain,
+    rpc_url_for_chain,
+)
 from mpp.methods.tempo._rpc import estimate_gas, get_tx_params
 
 if TYPE_CHECKING:
@@ -334,6 +339,9 @@ def tempo(
     """
     if rpc_url is None:
         rpc_url = rpc_url_for_chain(chain_id) if chain_id else RPC_URL
+
+    if currency is None:
+        currency = default_currency_for_chain(chain_id)
 
     method = TempoMethod(
         account=account,

--- a/tests/test_mpp_create.py
+++ b/tests/test_mpp_create.py
@@ -212,14 +212,12 @@ class TestMppCharge:
         assert result.request["recipient"] == "0xother"
 
     @pytest.mark.asyncio
-    async def test_charge_missing_currency_raises(self) -> None:
-        srv = Mpp.create(
-            method=tempo(intents={"charge": ChargeIntent()}),
-            realm="test.com",
-            secret_key="test-secret",
-        )
-        with pytest.raises(ValueError, match="currency must be set"):
-            await srv.charge(authorization=None, amount="1.00")
+    async def test_charge_defaults_currency_to_usdc(self) -> None:
+        """Currency defaults to USDC when not explicitly set."""
+        from mpp.methods.tempo import USDC
+
+        method = tempo(intents={"charge": ChargeIntent()})
+        assert method.currency == USDC
 
     @pytest.mark.asyncio
     async def test_charge_missing_recipient_raises(self) -> None:

--- a/tests/test_mpp_create.py
+++ b/tests/test_mpp_create.py
@@ -212,11 +212,19 @@ class TestMppCharge:
         assert result.request["recipient"] == "0xother"
 
     @pytest.mark.asyncio
-    async def test_charge_defaults_currency_to_usdc(self) -> None:
-        """Currency defaults to USDC when not explicitly set."""
-        from mpp.methods.tempo import USDC
+    async def test_charge_defaults_currency_to_pathusd(self) -> None:
+        """Currency defaults to pathUSD when chain_id is not set."""
+        from mpp.methods.tempo import PATH_USD
 
         method = tempo(intents={"charge": ChargeIntent()})
+        assert method.currency == PATH_USD
+
+    @pytest.mark.asyncio
+    async def test_charge_defaults_currency_to_usdc_on_mainnet(self) -> None:
+        """Currency defaults to USDC when chain_id is explicitly mainnet."""
+        from mpp.methods.tempo import CHAIN_ID, USDC
+
+        method = tempo(intents={"charge": ChargeIntent()}, chain_id=CHAIN_ID)
         assert method.currency == USDC
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Add USDC (USDC.e) as the default currency for **explicit mainnet** (chain ID 4217). All other cases — testnet (42431), unknown chain IDs, and `None` — default to pathUSD.

### Currency Resolution Rule

| `chain_id` | Default Currency |
|------------|-----------------|
| `4217` (mainnet) | USDC (`0x20C000000000000000000000b9537d11c60E8b50`) |
| `42431` (testnet) | pathUSD (`0x20c0...000`) |
| Unknown / `None` | pathUSD |

### Changes

- Add `USDC` constant and `DEFAULT_CURRENCIES` chain→currency mapping
- Add `default_currency_for_chain()` helper — returns USDC only for `4217`, pathUSD for everything else including `None`
- `tempo()` factory auto-resolves currency via `default_currency_for_chain(chain_id)`
- Export `USDC`, `PATH_USD`, and `default_currency_for_chain` from package
- Tests updated: `test_charge_defaults_currency_to_pathusd` (None→pathUSD) and `test_charge_defaults_currency_to_usdc_on_mainnet` (4217→USDC)

### Breaking Changes

- `tempo()` without explicit `currency` or `chain_id` now defaults to pathUSD (previously USDC)

### CI

All checks passing ✅

Part of cross-SDK USDC default currency rollout ([mppx#120](https://github.com/wevm/mppx/pull/120), pympp#67, [mpp-rs#81](https://github.com/tempoxyz/mpp-rs/pull/81)).