### PR TITLE
feat: add opaque/meta field for server-defined correlation data

### DIFF
--- a/.changelog/cool-clams-whisper.md
+++ b/.changelog/cool-clams-whisper.md
@@ -1,0 +1,5 @@
+---
+pympp: minor
+---
+
+Added `opaque`/`meta` field support for server-defined correlation data in challenges. The `meta` parameter on `Challenge.create()` and `verify_or_challenge()` stores arbitrary string key-value pairs as an HMAC-bound `opaque` field, included in challenge IDs and serialized in `WWW-Authenticate` and `Authorization` headers.

--- a/src/mpp/__init__.py
+++ b/src/mpp/__init__.py
@@ -58,6 +58,7 @@ def generate_challenge_id(
     request: dict[str, Any],
     expires: str | None = None,
     digest: str | None = None,
+    opaque: dict[str, str] | None = None,
 ) -> str:
     """Generate HMAC-SHA256 challenge ID per spec.
 
@@ -66,7 +67,7 @@ def generate_challenge_id(
     verification - the server can verify a challenge was issued by it without
     storing state.
 
-    HMAC input format: realm|method|intent|request_b64|expires|digest (pipe-delimited).
+    HMAC input format: realm|method|intent|request_b64|expires|digest|opaque (pipe-delimited).
     All fields are always included; absent optional fields use empty string.
     Output: base64url(HMAC-SHA256(secret_key, input))
 
@@ -78,6 +79,7 @@ def generate_challenge_id(
         request: Payment request parameters.
         expires: Optional expiration timestamp (ISO 8601).
         digest: Optional digest of request body.
+        opaque: Optional server-defined correlation data.
 
     Returns:
         Base64url-encoded HMAC-SHA256 of the challenge parameters.
@@ -94,7 +96,12 @@ def generate_challenge_id(
     request_json = json.dumps(request, separators=(",", ":"), sort_keys=True, ensure_ascii=False)
     request_b64 = _b64url_encode(request_json)
 
-    hmac_input = "|".join([realm, method, intent, request_b64, expires or "", digest or ""])
+    opaque_b64 = ""
+    if opaque is not None:
+        opaque_json = json.dumps(opaque, separators=(",", ":"), sort_keys=True, ensure_ascii=False)
+        opaque_b64 = _b64url_encode(opaque_json)
+
+    hmac_input = "|".join([realm, method, intent, request_b64, expires or "", digest or "", opaque_b64])
 
     mac = hmac.new(
         secret_key.encode("utf-8"),
@@ -141,6 +148,7 @@ class Challenge:
     digest: str | None = None
     expires: str | None = None
     description: str | None = None
+    opaque: dict[str, str] | None = None
 
     @classmethod
     def create(
@@ -154,6 +162,7 @@ class Challenge:
         expires: str | None = None,
         digest: str | None = None,
         description: str | None = None,
+        meta: dict[str, str] | None = None,
     ) -> Challenge:
         """Create a Challenge with an HMAC-bound ID.
 
@@ -171,6 +180,7 @@ class Challenge:
             expires: Optional expiration timestamp (ISO 8601).
             digest: Optional digest of request body.
             description: Optional human-readable description.
+            meta: Optional server-defined correlation data (stored as opaque).
 
         Returns:
             A Challenge with an HMAC-bound ID.
@@ -183,6 +193,7 @@ class Challenge:
             request=request,
             expires=expires,
             digest=digest,
+            opaque=meta,
         )
         request_json = json.dumps(
             request,
@@ -201,6 +212,7 @@ class Challenge:
             digest=digest,
             expires=expires,
             description=description,
+            opaque=meta,
         )
 
     @classmethod
@@ -235,6 +247,7 @@ class Challenge:
             request=self.request,
             expires=self.expires,
             digest=self.digest,
+            opaque=self.opaque,
         )
         return _constant_time_equal(self.id, expected_id)
 
@@ -244,6 +257,10 @@ class Challenge:
         Returns:
             A ChallengeEcho with the challenge parameters.
         """
+        opaque_b64 = None
+        if self.opaque is not None:
+            opaque_json = json.dumps(self.opaque, separators=(",", ":"), sort_keys=True, ensure_ascii=False)
+            opaque_b64 = _b64url_encode(opaque_json)
         return ChallengeEcho(
             id=self.id,
             realm=self.realm,
@@ -252,6 +269,7 @@ class Challenge:
             request=self.request_b64,
             expires=self.expires,
             digest=self.digest,
+            opaque=opaque_b64,
         )
 
 
@@ -279,6 +297,7 @@ class ChallengeEcho:
     request: str
     expires: str | None = None
     digest: str | None = None
+    opaque: str | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/mpp/_parsing.py
+++ b/src/mpp/_parsing.py
@@ -38,7 +38,7 @@ class ParseError(Exception):
 
 def _b64_encode(data: dict[str, Any]) -> str:
     """Encode dict as URL-safe base64 JSON (compact, no padding)."""
-    compact_json = json.dumps(data, separators=(",", ":"))
+    compact_json = json.dumps(data, separators=(",", ":"), sort_keys=True)
     encoded = base64.urlsafe_b64encode(compact_json.encode()).decode()
     return encoded.rstrip("=")
 
@@ -131,6 +131,11 @@ def parse_www_authenticate(header: str) -> Challenge:
     # Decode request JSON
     request = _b64_decode(request_b64)
 
+    opaque_b64 = params.get("opaque")
+    opaque = None
+    if opaque_b64:
+        opaque = _b64_decode(opaque_b64)
+
     return Challenge(
         id=id_,
         method=method,
@@ -141,6 +146,7 @@ def parse_www_authenticate(header: str) -> Challenge:
         digest=params.get("digest"),
         expires=params.get("expires"),
         description=params.get("description"),
+        opaque=opaque,
     )
 
 
@@ -169,6 +175,9 @@ def format_www_authenticate(challenge: Challenge, realm: str) -> str:
         parts.append(f'expires="{_escape_quoted(challenge.expires)}"')
     if challenge.description:
         parts.append(f'description="{_escape_quoted(challenge.description)}"')
+    if challenge.opaque is not None:
+        opaque_b64 = _b64_encode(challenge.opaque)
+        parts.append(f'opaque="{opaque_b64}"')
 
     return "Payment " + ", ".join(parts)
 
@@ -213,6 +222,7 @@ def parse_authorization(header: str) -> Credential:
         request=str(challenge_data.get("request", "")),
         expires=str(challenge_data["expires"]) if challenge_data.get("expires") else None,
         digest=str(challenge_data["digest"]) if challenge_data.get("digest") else None,
+        opaque=str(challenge_data["opaque"]) if challenge_data.get("opaque") else None,
     )
 
     return Credential(
@@ -244,6 +254,8 @@ def format_authorization(credential: Credential) -> str:
         challenge_dict["expires"] = credential.challenge.expires
     if credential.challenge.digest:
         challenge_dict["digest"] = credential.challenge.digest
+    if credential.challenge.opaque is not None:
+        challenge_dict["opaque"] = credential.challenge.opaque
 
     payload: dict[str, Any] = {
         "challenge": challenge_dict,

--- a/src/mpp/server/verify.py
+++ b/src/mpp/server/verify.py
@@ -24,6 +24,7 @@ async def verify_or_challenge(
     secret_key: str,
     method: str | None = None,
     description: str | None = None,
+    meta: dict[str, str] | None = None,
 ) -> Challenge | tuple[Credential, Receipt]:
     """Verify a payment credential or generate a new challenge.
 
@@ -78,21 +79,22 @@ async def verify_or_challenge(
     request = transform_units(request)
 
     if authorization is None:
-        return _create_challenge(method_name, intent.name, request, realm, secret_key, description)
+        return _create_challenge(method_name, intent.name, request, realm, secret_key, description, meta)
 
     payment_scheme = _extract_payment_scheme(authorization)
     if payment_scheme is None:
-        return _create_challenge(method_name, intent.name, request, realm, secret_key, description)
+        return _create_challenge(method_name, intent.name, request, realm, secret_key, description, meta)
 
     try:
         credential = Credential.from_authorization(payment_scheme)
     except ParseError:
-        return _create_challenge(method_name, intent.name, request, realm, secret_key, description)
+        return _create_challenge(method_name, intent.name, request, realm, secret_key, description, meta)
 
     # Stateless challenge verification: recompute expected challenge ID from
     # echoed parameters and compare to the credential's challenge ID.
     echo = credential.challenge
     echo_request = _b64_decode(echo.request) if echo.request else {}
+    echo_opaque = _b64_decode(echo.opaque) if echo.opaque else None
     expected_id = generate_challenge_id(
         secret_key=secret_key,
         realm=echo.realm,
@@ -101,9 +103,10 @@ async def verify_or_challenge(
         request=echo_request,
         expires=echo.expires,
         digest=echo.digest,
+        opaque=echo_opaque,
     )
     if not _constant_time_equal(echo.id, expected_id):
-        return _create_challenge(method_name, intent.name, request, realm, secret_key, description)
+        return _create_challenge(method_name, intent.name, request, realm, secret_key, description, meta)
 
     receipt: Receipt = await intent.verify(credential, request)
 
@@ -117,6 +120,7 @@ def _create_challenge(
     realm: str,
     secret_key: str,
     description: str | None = None,
+    meta: dict[str, str] | None = None,
 ) -> Challenge:
     """Create a new payment challenge with HMAC-bound ID."""
     if "expires" not in request:
@@ -130,6 +134,7 @@ def _create_challenge(
         intent=intent_name,
         request=request,
         description=description,
+        meta=meta,
     )
 
 

--- a/tests/test_challenge_id.py
+++ b/tests/test_challenge_id.py
@@ -23,7 +23,7 @@ class TestGenerateChallengeId:
                 "recipient": "0x1234567890abcdef1234567890abcdef12345678",
             },
         )
-        assert result == "s0gsoewXwdYI13oPnrtdKTEN4-sIQ-LbQUNV_HttPnA"
+        assert result == "XmJ98SdsAdzwP9Oa-8In322Uh6yweMO6rywdomWk_V4"
 
     def test_with_expires(self) -> None:
         """Challenge ID with expires field included in HMAC."""
@@ -39,7 +39,7 @@ class TestGenerateChallengeId:
             },
             expires="2026-01-29T12:00:00Z",
         )
-        assert result == "0rMv3trZIudpkJCQxeL2RLQz6uALKTNErWulN07hDLk"
+        assert result == "EvqUWMPJjqhoVJVG3mhTYVqCa3Mk7bUVd_OjeJGek1A"
 
     def test_with_digest(self) -> None:
         """Challenge ID with digest field included in HMAC."""
@@ -55,7 +55,7 @@ class TestGenerateChallengeId:
             },
             digest="sha-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=",
         )
-        assert result == "EAX2sqwdeg8Km8LIKRBFhM5xDQvEgIlbTif9FKBsOiU"
+        assert result == "qcJUPoapy4bFLznQjQUutwPLyXW7FvALrWA_sMENgAY"
 
     def test_full_challenge(self) -> None:
         """Challenge ID with all optional fields."""
@@ -74,7 +74,7 @@ class TestGenerateChallengeId:
             expires="2026-02-01T00:00:00Z",
             digest="sha-256=abc123def456",
         )
-        assert result == "jDq_IazIMny5JJk3-xm3eSxGaP6XbbaApxBi6fG_320"
+        assert result == "J6w7zq6nHLnchss3AYbLxNirdpuaV8_Msn37DQSz6Bw"
 
     def test_different_secret_different_id(self) -> None:
         """Same parameters with different secret produces different ID."""
@@ -89,7 +89,7 @@ class TestGenerateChallengeId:
                 "recipient": "0x1234567890abcdef1234567890abcdef12345678",
             },
         )
-        assert result == "UMEn_1WPt2vz3XK8rrkbHET6RwqfwtK8VVNz0Xc2x4A"
+        assert result == "_o55RP0duNvJYtw9PXnf44mGyY5ajV_wwGzoGdTFuNs"
 
     def test_empty_request(self) -> None:
         """Challenge ID with empty request object."""
@@ -100,7 +100,7 @@ class TestGenerateChallengeId:
             intent="authorize",
             request={},
         )
-        assert result == "jUTqTVe3kCv5rVizv1XBCs9qKCLg4AZLwBUnk4N3MR8"
+        assert result == "MYEC2oq3_B3cHa_My1Lx3NQKn_iUiMfsns6361N0SX0"
 
     def test_unicode_in_description(self) -> None:
         """Request with unicode characters."""
@@ -116,7 +116,7 @@ class TestGenerateChallengeId:
                 "description": "Payment for café ☕",
             },
         )
-        assert result == "OjiT_PsisJ_SkHEomn9dcfraObt4U3nO5Tg3gU0Etmg"
+        assert result == "1_GKJqATKvVnIUY3f8MFq48bMs18JHz_3CBK8pu52yA"
 
     def test_nested_method_details(self) -> None:
         """Request with nested methodDetails object."""
@@ -132,7 +132,7 @@ class TestGenerateChallengeId:
                 "methodDetails": {"chainId": 42431, "feePayer": True},
             },
         )
-        assert result == "9Sl6t74wn9zPaakjTSK6DqhGtS5HQVQEkIUYBYdHTbA"
+        assert result == "VkSq83C7vQFvdX3MqHM7s-N1QOo2nae4F1iHmbV5pgg"
 
 
 class TestGoldenVectors:
@@ -156,7 +156,7 @@ class TestGoldenVectors:
             intent="charge",
             request={"amount": "1000000"},
         )
-        assert result == "SOfbA51LV3LCkGE7RbomqwXdbWVlrZwlW-Z9aOHolxw"
+        assert result == "X6v1eo7fJ76gAxqY0xN9Jd__4lUyDDYmriryOM-5FO4"
 
     def test_with_expires(self) -> None:
         result = generate_challenge_id(
@@ -167,7 +167,7 @@ class TestGoldenVectors:
             request={"amount": "1000000"},
             expires="2025-01-06T12:00:00Z",
         )
-        assert result == "R1ZSIwoIjkFhMCSzUGiCTesiigf5vV65EQ_3gVNtsNw"
+        assert result == "ChPX33RkKSZoSUyZcu8ai4hhkvjZJFkZVnvWs5s0iXI"
 
     def test_with_digest(self) -> None:
         result = generate_challenge_id(
@@ -178,7 +178,7 @@ class TestGoldenVectors:
             request={"amount": "1000000"},
             digest="sha-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE",
         )
-        assert result == "AiMmBdsSOkOYpXTupMnzVnrzZbqMY_P2i80vENRUSN4"
+        assert result == "JHB7EFsPVb-xsYCo8LHcOzeX1gfXWVoUSzQsZhKAfKM"
 
     def test_with_expires_and_digest(self) -> None:
         result = generate_challenge_id(
@@ -190,7 +190,7 @@ class TestGoldenVectors:
             expires="2025-01-06T12:00:00Z",
             digest="sha-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE",
         )
-        assert result == "FMBGqN7MzpKagHsCcartZM09CnUqv7UgmaCy45Ozgug"
+        assert result == "m39jbWWCIfmfJZSwCfvKFFtBl0Qwf9X4nOmDb21peLA"
 
     def test_description_not_in_hmac(self) -> None:
         """description is not part of HMAC input, so ID matches 'required fields only'."""
@@ -201,7 +201,7 @@ class TestGoldenVectors:
             intent="charge",
             request={"amount": "1000000"},
         )
-        assert with_desc == "SOfbA51LV3LCkGE7RbomqwXdbWVlrZwlW-Z9aOHolxw"
+        assert with_desc == "X6v1eo7fJ76gAxqY0xN9Jd__4lUyDDYmriryOM-5FO4"
 
     def test_multi_field_request(self) -> None:
         result = generate_challenge_id(
@@ -211,7 +211,7 @@ class TestGoldenVectors:
             intent="charge",
             request={"amount": "1000000", "currency": "0x1234", "recipient": "0xabcd"},
         )
-        assert result == "5CXJi4bWMz2W54WjnlmoxnwTYe-JKwhw0z32ICQ65Es"
+        assert result == "_H5TOnnlW0zduQ5OhQ3EyLVze_TqxLDPda2CGZPZxOc"
 
     def test_nested_method_details(self) -> None:
         result = generate_challenge_id(
@@ -225,7 +225,7 @@ class TestGoldenVectors:
                 "methodDetails": {"chainId": 42431},
             },
         )
-        assert result == "eid66xXUZsj46Pb30AfAf7m5kPehgianI16rZ-QY8HU"
+        assert result == "TqujwpuDDg_zsWGINAd5XObO2rRe6uYufpqvtDmr6N8"
 
     def test_empty_request(self) -> None:
         result = generate_challenge_id(
@@ -235,7 +235,7 @@ class TestGoldenVectors:
             intent="charge",
             request={},
         )
-        assert result == "6kq-PYTyXtaGAHTHCVUrc_hIsAwLeskeQFtDZerMYhM"
+        assert result == "yLN7yChAejW9WNmb54HpJIWpdb1WWXeA3_aCx4dxmkU"
 
     def test_different_realm(self) -> None:
         result = generate_challenge_id(
@@ -245,7 +245,7 @@ class TestGoldenVectors:
             intent="charge",
             request={"amount": "1000000"},
         )
-        assert result == "-gMjd8UeUvBcqUaUzarVj6ikH_YoDowpaNbEwK1Tmx8"
+        assert result == "3F5bOo2a9RUihdwKk4hGRvBvzQmVPBMDvW0YM-8GD00"
 
     def test_different_method(self) -> None:
         result = generate_challenge_id(
@@ -255,7 +255,7 @@ class TestGoldenVectors:
             intent="charge",
             request={"amount": "1000000"},
         )
-        assert result == "DRH9ycmIlZ2lYUatIHCrxpm9K7ig5pniZ3ulleb7vl0"
+        assert result == "o0ra2sd7HcB4Ph0Vns69gRDUhSj5WNOnUopcDqKPLz4"
 
     def test_different_intent(self) -> None:
         result = generate_challenge_id(
@@ -265,7 +265,7 @@ class TestGoldenVectors:
             intent="session",
             request={"amount": "1000000"},
         )
-        assert result == "INeBi93MhinvbwdUxeUUIaT5Q_ufgLKPYZb5Tg43A1o"
+        assert result == "aAY7_IEDzsznNYplhOSE8cERQxvjFcT4Lcn-7FHjLVE"
 
 
 class TestChallengeCreate:
@@ -284,7 +284,7 @@ class TestChallengeCreate:
                 "recipient": "0x1234567890abcdef1234567890abcdef12345678",
             },
         )
-        assert challenge.id == "s0gsoewXwdYI13oPnrtdKTEN4-sIQ-LbQUNV_HttPnA"
+        assert challenge.id == "XmJ98SdsAdzwP9Oa-8In322Uh6yweMO6rywdomWk_V4"
         assert challenge.method == "tempo"
         assert challenge.intent == "charge"
 
@@ -303,7 +303,7 @@ class TestChallengeCreate:
             expires="2026-01-29T12:00:00Z",
             description="Test payment",
         )
-        assert challenge.id == "0rMv3trZIudpkJCQxeL2RLQz6uALKTNErWulN07hDLk"
+        assert challenge.id == "EvqUWMPJjqhoVJVG3mhTYVqCa3Mk7bUVd_OjeJGek1A"
         assert challenge.expires == "2026-01-29T12:00:00Z"
         assert challenge.description == "Test payment"
 
@@ -387,3 +387,119 @@ class TestChallengeVerify:
             expires="2099-12-31T23:59:59Z",  # Tampered
         )
         assert not tampered.verify("test-secret-key-12345", "api.example.com")
+
+
+class TestOpaque:
+    """Test opaque/meta field for server-defined correlation data."""
+
+    def test_meta_sets_opaque_on_challenge(self) -> None:
+        challenge = Challenge.create(
+            secret_key="test-secret",
+            realm="api.example.com",
+            method="tempo",
+            intent="charge",
+            request={"amount": "1000000"},
+            meta={"pi": "pi_3abc123XYZ"},
+        )
+        assert challenge.opaque == {"pi": "pi_3abc123XYZ"}
+
+    def test_opaque_is_none_when_no_meta(self) -> None:
+        challenge = Challenge.create(
+            secret_key="test-secret",
+            realm="api.example.com",
+            method="tempo",
+            intent="charge",
+            request={"amount": "1000000"},
+        )
+        assert challenge.opaque is None
+
+    def test_opaque_affects_challenge_id(self) -> None:
+        with_meta = Challenge.create(
+            secret_key="test-secret",
+            realm="api.example.com",
+            method="tempo",
+            intent="charge",
+            request={"amount": "1000000"},
+            meta={"pi": "pi_3abc123XYZ"},
+        )
+        without_meta = Challenge.create(
+            secret_key="test-secret",
+            realm="api.example.com",
+            method="tempo",
+            intent="charge",
+            request={"amount": "1000000"},
+        )
+        assert with_meta.id != without_meta.id
+
+    def test_different_opaque_different_ids(self) -> None:
+        meta1 = Challenge.create(
+            secret_key="test-secret",
+            realm="api.example.com",
+            method="tempo",
+            intent="charge",
+            request={"amount": "1000000"},
+            meta={"pi": "pi_111"},
+        )
+        meta2 = Challenge.create(
+            secret_key="test-secret",
+            realm="api.example.com",
+            method="tempo",
+            intent="charge",
+            request={"amount": "1000000"},
+            meta={"pi": "pi_222"},
+        )
+        assert meta1.id != meta2.id
+
+    def test_same_opaque_same_id(self) -> None:
+        c1 = Challenge.create(
+            secret_key="test-secret",
+            realm="api.example.com",
+            method="tempo",
+            intent="charge",
+            request={"amount": "1000000"},
+            meta={"pi": "pi_3abc123XYZ"},
+        )
+        c2 = Challenge.create(
+            secret_key="test-secret",
+            realm="api.example.com",
+            method="tempo",
+            intent="charge",
+            request={"amount": "1000000"},
+            meta={"pi": "pi_3abc123XYZ"},
+        )
+        assert c1.id == c2.id
+
+    def test_verify_succeeds_with_opaque(self) -> None:
+        challenge = Challenge.create(
+            secret_key="my-secret",
+            realm="api.example.com",
+            method="tempo",
+            intent="charge",
+            request={"amount": "1000000"},
+            meta={"pi": "pi_3abc123XYZ"},
+        )
+        assert challenge.verify("my-secret", "api.example.com")
+
+    def test_verify_detects_tampered_opaque(self) -> None:
+        challenge = Challenge.create(
+            secret_key="my-secret",
+            realm="api.example.com",
+            method="tempo",
+            intent="charge",
+            request={"amount": "1000000"},
+            meta={"pi": "pi_3abc123XYZ"},
+        )
+        from dataclasses import replace
+        tampered = replace(challenge, opaque={"pi": "pi_TAMPERED"})
+        assert not tampered.verify("my-secret", "api.example.com")
+
+    def test_empty_meta_produces_opaque(self) -> None:
+        challenge = Challenge.create(
+            secret_key="test-secret",
+            realm="api.example.com",
+            method="tempo",
+            intent="charge",
+            request={"amount": "1000000"},
+            meta={},
+        )
+        assert challenge.opaque == {}


### PR DESCRIPTION
## Summary

Adds a top-level `opaque` challenge parameter for server-defined correlation data (e.g. Stripe PaymentIntent IDs), per [mpp-specs#148](https://github.com/ArkEcosystem/mpp-specs/issues/148). Ports the feature from [wevm/mppx#121](https://github.com/wevm/mppx/pull/121) (TypeScript SDK).

## API

The creation API uses `meta` as the parameter name, which maps to `opaque` on the Challenge object:

```python
challenge = Challenge.create(
    secret_key="...",
    realm="api.example.com",
    method="tempo",
    intent="charge",
    request={"amount": "1000000"},
    meta={"pi": "pi_3abc123XYZ"},  # stored as challenge.opaque
)
```

## HMAC Format Change

HMAC input changes from 6 to 7 pipe-delimited slots:

```
realm|method|intent|request_b64|expires|digest|opaque
```

When `opaque` is absent, the 7th slot is empty string. This changes **all** existing test vectors even when opaque is not used.

The opaque value is a `dict[str, str]` serialized as `base64url(JSON with sorted keys, compact separators)`.

## Changes

- `__init__.py`: `generate_challenge_id` accepts `opaque`, `Challenge` dataclass gets `opaque` field, `Challenge.create` accepts `meta`, `to_echo()` encodes opaque
- `_parsing.py`: parse/format WWW-Authenticate and Authorization with opaque roundtrip; fixed `_b64_encode` to use `sort_keys=True` for cross-SDK consistency; fixed `format_authorization` to use `is not None` check
- `server/verify.py`: `verify_or_challenge` and `_create_challenge` accept and forward `meta`
- `tests/test_challenge_id.py`: all vectors updated + new `TestOpaque` class with 8 tests

## Test Results

218 passed, 19 skipped (skips are pre-existing MCP dependency)