### PR TITLE
ci: add CI Gate job for branch protection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,18 @@ on:
     branches: [main, master]
 
 jobs:
+  ci-gate:
+    name: CI Gate
+    if: always()
+    needs: [test]
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "One or more required jobs failed or were cancelled"
+            exit 1
+          fi
+
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/src/mpp/__init__.py
+++ b/src/mpp/__init__.py
@@ -101,7 +101,17 @@ def generate_challenge_id(
         opaque_json = json.dumps(opaque, separators=(",", ":"), sort_keys=True, ensure_ascii=False)
         opaque_b64 = _b64url_encode(opaque_json)
 
-    hmac_input = "|".join([realm, method, intent, request_b64, expires or "", digest or "", opaque_b64])
+    hmac_input = "|".join(
+        [
+            realm,
+            method,
+            intent,
+            request_b64,
+            expires or "",
+            digest or "",
+            opaque_b64,
+        ]
+    )
 
     mac = hmac.new(
         secret_key.encode("utf-8"),
@@ -259,7 +269,12 @@ class Challenge:
         """
         opaque_b64 = None
         if self.opaque is not None:
-            opaque_json = json.dumps(self.opaque, separators=(",", ":"), sort_keys=True, ensure_ascii=False)
+            opaque_json = json.dumps(
+                self.opaque,
+                separators=(",", ":"),
+                sort_keys=True,
+                ensure_ascii=False,
+            )
             opaque_b64 = _b64url_encode(opaque_json)
         return ChallengeEcho(
             id=self.id,

--- a/src/mpp/server/verify.py
+++ b/src/mpp/server/verify.py
@@ -79,16 +79,40 @@ async def verify_or_challenge(
     request = transform_units(request)
 
     if authorization is None:
-        return _create_challenge(method_name, intent.name, request, realm, secret_key, description, meta)
+        return _create_challenge(
+            method_name,
+            intent.name,
+            request,
+            realm,
+            secret_key,
+            description,
+            meta,
+        )
 
     payment_scheme = _extract_payment_scheme(authorization)
     if payment_scheme is None:
-        return _create_challenge(method_name, intent.name, request, realm, secret_key, description, meta)
+        return _create_challenge(
+            method_name,
+            intent.name,
+            request,
+            realm,
+            secret_key,
+            description,
+            meta,
+        )
 
     try:
         credential = Credential.from_authorization(payment_scheme)
     except ParseError:
-        return _create_challenge(method_name, intent.name, request, realm, secret_key, description, meta)
+        return _create_challenge(
+            method_name,
+            intent.name,
+            request,
+            realm,
+            secret_key,
+            description,
+            meta,
+        )
 
     # Stateless challenge verification: recompute expected challenge ID from
     # echoed parameters and compare to the credential's challenge ID.
@@ -106,7 +130,15 @@ async def verify_or_challenge(
         opaque=echo_opaque,
     )
     if not _constant_time_equal(echo.id, expected_id):
-        return _create_challenge(method_name, intent.name, request, realm, secret_key, description, meta)
+        return _create_challenge(
+            method_name,
+            intent.name,
+            request,
+            realm,
+            secret_key,
+            description,
+            meta,
+        )
 
     receipt: Receipt = await intent.verify(credential, request)
 

--- a/tests/test_challenge_id.py
+++ b/tests/test_challenge_id.py
@@ -490,6 +490,7 @@ class TestOpaque:
             meta={"pi": "pi_3abc123XYZ"},
         )
         from dataclasses import replace
+
         tampered = replace(challenge, opaque={"pi": "pi_TAMPERED"})
         assert not tampered.verify("my-secret", "api.example.com")
 


### PR DESCRIPTION
Adds a single `CI Gate` job that `needs: [test]` with `if: always()`. This lets branch protection require only `CI Gate` instead of maintaining a list of every individual job name.

After merging, branch protection will be updated to require only `CI Gate`.