### PR TITLE
fix: preserve key_authorization through 0x78 fee payer envelope roundtrip

### DIFF
--- a/.changelog/happy-dogs-cry.md
+++ b/.changelog/happy-dogs-cry.md
@@ -1,0 +1,5 @@
+---
+pympp: minor
+---
+
+Added 0x78 fee payer envelope encoding/decoding module with `encode_fee_payer_envelope` and `decode_fee_payer_envelope` functions. Updated `ChargeIntent._cosign_as_fee_payer` to use the new 0x78 wire format instead of 0x76, including sender address verification against the recovered signer. Exported `USDC`, `PATH_USD`, and `default_currency_for_chain` from the tempo package public API.

--- a/.changelog/nice-birds-slide.md
+++ b/.changelog/nice-birds-slide.md
@@ -1,0 +1,5 @@
+---
+pympp: minor
+---
+
+Added chain-specific default currency selection: mainnet now defaults to USDC and testnet defaults to pathUSD. Exported `USDC`, `PATH_USD`, and `default_currency_for_chain` from the tempo package public API. Updated tests to reflect the new default currency behavior.

--- a/examples/api-server/server.py
+++ b/examples/api-server/server.py
@@ -6,7 +6,7 @@ from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 
 from mpp import Challenge, Credential, Receipt
-from mpp.methods.tempo import ChargeIntent, tempo
+from mpp.methods.tempo import ChargeIntent, TempoAccount, tempo
 from mpp.methods.tempo._defaults import PATH_USD, TESTNET_CHAIN_ID
 from mpp.server import Mpp
 
@@ -19,11 +19,17 @@ DESTINATION = os.environ.get(
     "PAYMENT_DESTINATION", "0x742d35Cc6634c0532925a3b844bC9e7595F8fE00"
 )
 
+# Optional: set FEE_PAYER_KEY to sponsor gas for clients.
+# When set, the server co-signs 0x78 fee payer envelopes locally.
+fee_payer_key = os.environ.get("FEE_PAYER_KEY")
+fee_payer = TempoAccount.from_key(fee_payer_key) if fee_payer_key else None
+
 server = Mpp.create(
     method=tempo(
         chain_id=TESTNET_CHAIN_ID,
         currency=PATH_USD,
         recipient=DESTINATION,
+        fee_payer=fee_payer,
         intents={"charge": ChargeIntent()},
     ),
 )
@@ -42,6 +48,7 @@ async def paid_endpoint(request: Request):
         authorization=request.headers.get("Authorization"),
         amount="0.001",
         chain_id=TESTNET_CHAIN_ID,
+        fee_payer=fee_payer is not None,
     )
 
     if isinstance(result, Challenge):

--- a/examples/fetch/fetch.py
+++ b/examples/fetch/fetch.py
@@ -28,6 +28,13 @@ def parse_args() -> argparse.Namespace:
         help="Request body data",
     )
     parser.add_argument(
+        "-H",
+        "--header",
+        action="append",
+        default=[],
+        help='Custom header "Key: Value" (repeatable)',
+    )
+    parser.add_argument(
         "--key",
         help="Tempo private key (or set TEMPO_PRIVATE_KEY)",
     )
@@ -49,11 +56,17 @@ async def run(args: argparse.Namespace) -> int:
     rpc_url = args.rpc_url or os.environ.get("TEMPO_RPC_URL")
     method = tempo(account=account, rpc_url=rpc_url or "https://rpc.tempo.xyz", intents={"charge": ChargeIntent()})
 
+    headers = {}
+    for h in args.header:
+        key, _, value = h.partition(":")
+        headers[key.strip()] = value.strip()
+
     async with Client(methods=[method]) as client:
         response = await client.request(
             args.method,
             args.url,
             content=args.data,
+            headers=headers if headers else None,
         )
 
         if response.status_code >= 400:

--- a/src/mpp/methods/tempo/client.py
+++ b/src/mpp/methods/tempo/client.py
@@ -9,8 +9,6 @@ import time
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
-import attrs
-
 from mpp import Challenge, Credential
 from mpp.methods.tempo._attribution import encode as encode_attribution
 from mpp.methods.tempo._defaults import (
@@ -252,7 +250,9 @@ class TempoMethod:
         signed_tx = tx.sign(self.account.private_key)
 
         if awaiting_fee_payer:
-            signed_tx = attrs.evolve(signed_tx, fee_payer_signature=b"\x00")
+            from mpp.methods.tempo.fee_payer_envelope import encode_fee_payer_envelope
+
+            return "0x" + encode_fee_payer_envelope(signed_tx).hex(), chain_id
 
         return "0x" + signed_tx.encode().hex(), chain_id
 

--- a/src/mpp/methods/tempo/fee_payer_envelope.py
+++ b/src/mpp/methods/tempo/fee_payer_envelope.py
@@ -38,9 +38,9 @@ def encode_fee_payer_envelope(signed_tx: TempoTransaction) -> bytes:
         Raw bytes: ``0x78 || RLP([fields...])``.
     """
     sender_sig = signed_tx.sender_signature
-    sig_bytes = sender_sig.to_bytes() if hasattr(sender_sig, "to_bytes") else bytes(sender_sig)
+    sig_bytes = sender_sig.to_bytes() if hasattr(sender_sig, "to_bytes") else bytes(sender_sig)  # type: ignore[arg-type]
 
-    sender_addr = bytes(signed_tx.sender_address)
+    sender_addr = bytes(signed_tx.sender_address)  # type: ignore[arg-type]
 
     fields: list = [
         signed_tx.chain_id,
@@ -97,4 +97,4 @@ def decode_fee_payer_envelope(data: bytes) -> tuple[list, bytes, bytes, bytes | 
     else:
         key_authorization = None
 
-    return decoded, sender_address, sender_signature, key_authorization
+    return decoded, bytes(sender_address), bytes(sender_signature), key_authorization  # type: ignore[arg-type]

--- a/src/mpp/methods/tempo/fee_payer_envelope.py
+++ b/src/mpp/methods/tempo/fee_payer_envelope.py
@@ -1,0 +1,100 @@
+"""Fee payer envelope encoding/decoding (0x78 wire format).
+
+The 0x78 envelope is a non-broadcastable wire format for handing off a
+sender-signed transaction to a fee payer, who co-signs and broadcasts as 0x76.
+
+Wire format::
+
+    0x78 || RLP([
+        chainId, maxPriorityFeePerGas, maxFeePerGas, gasLimit,
+        calls, accessList, nonceKey, nonce,
+        validBefore?, validAfter?, feeToken?,
+        senderAddress,           # 20 bytes (replaces feePayerSignature slot)
+        authorizationList, keyAuthorization?,
+        signatureEnvelope        # sender's raw 65-byte r||s||v
+    ])
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import rlp
+
+if TYPE_CHECKING:
+    from pytempo import TempoTransaction
+
+FEE_PAYER_ENVELOPE_TYPE_ID = 0x78
+
+
+def encode_fee_payer_envelope(signed_tx: TempoTransaction) -> bytes:
+    """Encode a sender-signed transaction as a 0x78 fee payer envelope.
+
+    Args:
+        signed_tx: A TempoTransaction that has been signed by the sender
+            (``sender_signature`` and ``sender_address`` must be set).
+
+    Returns:
+        Raw bytes: ``0x78 || RLP([fields...])``.
+    """
+    sender_sig = signed_tx.sender_signature
+    sig_bytes = sender_sig.to_bytes() if hasattr(sender_sig, "to_bytes") else bytes(sender_sig)
+
+    sender_addr = bytes(signed_tx.sender_address)
+
+    fields: list = [
+        signed_tx.chain_id,
+        signed_tx.max_priority_fee_per_gas,
+        signed_tx.max_fee_per_gas,
+        signed_tx.gas_limit,
+        [c.as_rlp_list() for c in signed_tx.calls],
+        [a.as_rlp_list() for a in signed_tx.access_list],
+        signed_tx.nonce_key,
+        signed_tx.nonce,
+        signed_tx._encode_optional_uint(signed_tx.valid_before),
+        signed_tx._encode_optional_uint(signed_tx.valid_after),
+        bytes(signed_tx.fee_token) if signed_tx.fee_token else b"",
+        sender_addr,
+        list(signed_tx.tempo_authorization_list),
+    ]
+
+    if signed_tx.key_authorization is not None:
+        fields.append(rlp.decode(signed_tx.key_authorization))
+        fields.append(sig_bytes)
+    else:
+        fields.append(sig_bytes)
+
+    return bytes([FEE_PAYER_ENVELOPE_TYPE_ID]) + rlp.encode(fields)
+
+
+def decode_fee_payer_envelope(data: bytes) -> tuple[list, bytes, bytes, bytes | None]:
+    """Decode a 0x78 fee payer envelope.
+
+    Args:
+        data: Raw bytes starting with ``0x78``.
+
+    Returns:
+        Tuple of (decoded RLP fields, sender_address bytes,
+        sender_signature bytes, key_authorization RLP bytes or None).
+
+    Raises:
+        ValueError: If the data doesn't start with ``0x78`` or is malformed.
+    """
+    if not data or data[0] != FEE_PAYER_ENVELOPE_TYPE_ID:
+        raise ValueError("Not a fee payer envelope (expected 0x78 prefix)")
+
+    decoded = rlp.decode(data[1:])
+    if not isinstance(decoded, list) or len(decoded) < 14:
+        raise ValueError("Malformed fee payer envelope")
+
+    sender_address = decoded[11]
+    sender_signature = decoded[-1]
+
+    # 15 fields = key_authorization present (index 13), signature at 14
+    # 14 fields = no key_authorization, signature at 13
+    if len(decoded) == 15:
+        key_authorization = rlp.encode(decoded[13])
+    else:
+        key_authorization = None
+
+    return decoded, sender_address, sender_signature, key_authorization

--- a/src/mpp/methods/tempo/intents.py
+++ b/src/mpp/methods/tempo/intents.py
@@ -6,6 +6,7 @@ Implements the charge intent for Tempo payments.
 from __future__ import annotations
 
 import asyncio
+import time
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
@@ -456,6 +457,27 @@ class ChargeIntent:
 
         def _int(b: bytes) -> int:
             return int.from_bytes(b, "big") if b else 0
+
+        # Fee-payer invariants (matches mpp-rs cosign_fee_payer_transaction)
+        if decoded[10]:
+            raise VerificationError(
+                "Fee payer transaction must not include fee_token (server sets it)"
+            )
+
+        nonce_key = _int(decoded[6])
+        if nonce_key != (1 << 256) - 1:
+            raise VerificationError(
+                "Fee payer envelope must use expiring nonce key (U256::MAX)"
+            )
+
+        valid_before_raw = decoded[8]
+        if not valid_before_raw:
+            raise VerificationError("Fee payer envelope must include valid_before")
+        valid_before = _int(valid_before_raw)
+        if valid_before <= int(time.time()):
+            raise VerificationError(
+                f"Fee payer envelope expired: valid_before ({valid_before}) is not in the future"
+            )
 
         calls = tuple(Call(to=c[0], value=_int(c[1]), data=c[2]) for c in decoded[4])
 

--- a/src/mpp/methods/tempo/intents.py
+++ b/src/mpp/methods/tempo/intents.py
@@ -434,22 +434,23 @@ class ChargeIntent:
     ) -> str:
         """Co-sign a client-signed transaction as fee payer.
 
-        Deserializes the client's 0x76 transaction, optionally validates the
-        payment calls against ``request``, sets the fee token, and signs with
-        domain 0x78. Returns the fully co-signed transaction hex.
+        Deserializes the client's 0x78 fee payer envelope, optionally validates
+        the payment calls against ``request``, sets the fee token, and co-signs.
+        Returns the fully co-signed 0x76 transaction hex.
         """
-        import rlp
         from pytempo import Call, TempoTransaction
         from pytempo.models import as_address
+
+        from mpp.methods.tempo.fee_payer_envelope import decode_fee_payer_envelope
 
         if self.fee_payer is None:
             raise VerificationError("No fee payer account configured")
 
         try:
             all_bytes = bytes.fromhex(raw_tx[2:] if raw_tx.startswith("0x") else raw_tx)
-            if not all_bytes or all_bytes[0] != 0x76:
-                raise ValueError("Not a Tempo transaction")
-            decoded = rlp.decode(all_bytes[1:])
+            decoded, sender_addr_bytes, sender_sig, key_auth = decode_fee_payer_envelope(
+                all_bytes
+            )
         except Exception as err:
             raise VerificationError("Failed to deserialize client transaction") from err
 
@@ -461,7 +462,6 @@ class ChargeIntent:
         if request is not None:
             self._validate_calls(calls, request)
 
-        sender_sig = decoded[-1]
         tx_for_recovery = TempoTransaction(
             chain_id=_int(decoded[0]),
             max_priority_fee_per_gas=_int(decoded[1]),
@@ -475,17 +475,22 @@ class ChargeIntent:
             valid_after=_int(decoded[9]) if decoded[9] else None,
             fee_token=decoded[10] if decoded[10] else None,
             awaiting_fee_payer=True,
+            key_authorization=key_auth,
         )
         sender_hash = tx_for_recovery.get_signing_hash(for_fee_payer=False)
 
         from eth_account import Account
 
-        sender_address = Account._recover_hash(sender_hash, signature=sender_sig)
+        recovered_address = Account._recover_hash(sender_hash, signature=sender_sig)
+        envelope_address = "0x" + sender_addr_bytes.hex()
+
+        if recovered_address.lower() != envelope_address.lower():
+            raise VerificationError("Sender address does not match recovered signer")
 
         tx_to_sign = attrs.evolve(
             tx_for_recovery,
             sender_signature=sender_sig,
-            sender_address=as_address(sender_address),
+            sender_address=as_address(recovered_address),
             fee_token=fee_token or PATH_USD,
         )
 
@@ -518,7 +523,7 @@ class ChargeIntent:
             tx_bytes = bytes.fromhex(signature[2:] if signature.startswith("0x") else signature)
         except ValueError:
             return
-        if not tx_bytes or tx_bytes[0] != 0x76:
+        if not tx_bytes or tx_bytes[0] not in (0x76, 0x78):
             return
         try:
             decoded = rlp.decode(tx_bytes[1:])

--- a/src/mpp/methods/tempo/intents.py
+++ b/src/mpp/methods/tempo/intents.py
@@ -449,9 +449,7 @@ class ChargeIntent:
 
         try:
             all_bytes = bytes.fromhex(raw_tx[2:] if raw_tx.startswith("0x") else raw_tx)
-            decoded, sender_addr_bytes, sender_sig, key_auth = decode_fee_payer_envelope(
-                all_bytes
-            )
+            decoded, sender_addr_bytes, sender_sig, key_auth = decode_fee_payer_envelope(all_bytes)
         except Exception as err:
             raise VerificationError("Failed to deserialize client transaction") from err
 
@@ -466,9 +464,7 @@ class ChargeIntent:
 
         nonce_key = _int(decoded[6])
         if nonce_key != (1 << 256) - 1:
-            raise VerificationError(
-                "Fee payer envelope must use expiring nonce key (U256::MAX)"
-            )
+            raise VerificationError("Fee payer envelope must use expiring nonce key (U256::MAX)")
 
         valid_before_raw = decoded[8]
         if not valid_before_raw:

--- a/src/mpp/server/mpp.py
+++ b/src/mpp/server/mpp.py
@@ -105,6 +105,7 @@ class Mpp:
         memo: str | None = None,
         fee_payer: bool = False,
         chain_id: int | None = None,
+        extra: dict[str, str] | None = None,
     ) -> Challenge | tuple[Credential, Receipt]:
         """Handle a charge intent.
 
@@ -147,6 +148,13 @@ class Mpp:
             "expires": expires,
         }
 
+        # Optional server-provided metadata that will be echoed back by the client
+        # because it is embedded in the base64url-encoded `request`.
+        if extra is not None:
+            if any((not isinstance(k, str) or not isinstance(v, str)) for k, v in extra.items()):
+                raise ValueError("extra must be a dict[str, str]")
+            request["extra"] = extra
+
         resolved_chain_id = chain_id
         if resolved_chain_id is None:
             resolved_chain_id = getattr(self.method, "chain_id", None)
@@ -181,6 +189,7 @@ class Mpp:
         description: str | None = None,
         expires_in: timedelta | None = None,
         chain_id: int | None = None,
+        extra: dict[str, str] | None = None,
     ) -> Callable[  # noqa: UP047
         [Callable[[Any, Credential, Receipt], Awaitable[R]]],
         Callable[[Any], Awaitable[R | Any]],
@@ -246,6 +255,11 @@ class Mpp:
                 }
                 if expires is not None:
                     request["expires"] = expires
+
+                if extra is not None:
+                    if any((not isinstance(k, str) or not isinstance(v, str)) for k, v in extra.items()):
+                        raise ValueError("extra must be a dict[str, str]")
+                    request["extra"] = extra
 
                 resolved_chain_id = chain_id
                 if resolved_chain_id is None:

--- a/src/mpp/server/mpp.py
+++ b/src/mpp/server/mpp.py
@@ -257,7 +257,9 @@ class Mpp:
                     request["expires"] = expires
 
                 if extra is not None:
-                    if any((not isinstance(k, str) or not isinstance(v, str)) for k, v in extra.items()):
+                    if any(
+                        not isinstance(k, str) or not isinstance(v, str) for k, v in extra.items()
+                    ):
                         raise ValueError("extra must be a dict[str, str]")
                     request["extra"] = extra
 

--- a/tests/test_fee_payer_envelope.py
+++ b/tests/test_fee_payer_envelope.py
@@ -1,11 +1,10 @@
 """Tests for fee payer envelope encoding/decoding (0x78 wire format)."""
 
-import rlp
 import pytest
+import rlp
 from pytempo import Call, TempoTransaction
 
 from mpp.methods.tempo.fee_payer_envelope import (
-    FEE_PAYER_ENVELOPE_TYPE_ID,
     decode_fee_payer_envelope,
     encode_fee_payer_envelope,
 )

--- a/tests/test_fee_payer_envelope.py
+++ b/tests/test_fee_payer_envelope.py
@@ -66,7 +66,7 @@ class TestEncodeFeePayerEnvelope:
         decoded = rlp.decode(encoded[1:])
         sender_addr = decoded[11]
         assert len(sender_addr) == 20
-        assert sender_addr == bytes(signed.sender_address)
+        assert sender_addr == bytes(signed.sender_address)  # type: ignore[arg-type]
 
     def test_sender_signature_is_last_field(self) -> None:
         """Sender signature (65 bytes r||s||v) must be the last field."""
@@ -75,7 +75,7 @@ class TestEncodeFeePayerEnvelope:
         decoded = rlp.decode(encoded[1:])
         sig = decoded[-1]
         assert len(sig) == 65
-        assert sig == signed.sender_signature.to_bytes()
+        assert sig == signed.sender_signature.to_bytes()  # type: ignore[union-attr]
 
     def test_chain_id_preserved(self) -> None:
         """Chain ID must be correctly encoded at index 0."""
@@ -140,8 +140,8 @@ class TestDecodeFeePayerEnvelope:
         encoded = encode_fee_payer_envelope(signed)
         decoded, sender_addr, sender_sig, key_auth = decode_fee_payer_envelope(encoded)
 
-        assert sender_addr == bytes(signed.sender_address)
-        assert sender_sig == signed.sender_signature.to_bytes()
+        assert sender_addr == bytes(signed.sender_address)  # type: ignore[arg-type]
+        assert sender_sig == signed.sender_signature.to_bytes()  # type: ignore[union-attr]
         assert key_auth is None
 
     def test_roundtrip_fields(self) -> None:
@@ -184,7 +184,7 @@ class TestDecodeFeePayerEnvelope:
     def test_rejects_too_short_rlp(self) -> None:
         """Should reject RLP with too few fields."""
         # 0x78 + RLP of a short list
-        short = bytes([0x78]) + rlp.encode([b"", b"", b""])
+        short = bytes([0x78]) + bytes(rlp.encode([b"", b"", b""]))
         with pytest.raises(ValueError, match="Malformed"):
             decode_fee_payer_envelope(short)
 
@@ -230,7 +230,7 @@ class TestEncoderDecoderIntegration:
         decoded_fields = rlp.decode(encoded[1:])
         # Replace sender address with a different address
         decoded_fields[11] = b"\xde\xad" + b"\x00" * 18
-        tampered = bytes([0x78]) + rlp.encode(decoded_fields)
+        tampered = bytes([0x78]) + bytes(rlp.encode(decoded_fields))
         tampered_hex = "0x" + tampered.hex()
 
         fee_payer = TempoAccount.from_key("0x" + "ab" * 32)
@@ -268,7 +268,7 @@ class TestEncoderDecoderIntegration:
         # Tamper nonce_key (index 6) to a non-MAX value
         decoded_fields = rlp.decode(encoded[1:])
         decoded_fields[6] = (42).to_bytes(1, "big")
-        tampered = bytes([0x78]) + rlp.encode(decoded_fields)
+        tampered = bytes([0x78]) + bytes(rlp.encode(decoded_fields))
         tampered_hex = "0x" + tampered.hex()
 
         fee_payer = TempoAccount.from_key("0x" + "ab" * 32)
@@ -319,5 +319,5 @@ class TestEncoderDecoderIntegration:
         # fee_token at index 10 should be 20 bytes
         assert len(decoded[10]) == 20
         assert ("0x" + decoded[10].hex()).lower() == CURRENCY.lower()
-        assert sender_addr == bytes(signed.sender_address)
+        assert sender_addr == bytes(signed.sender_address)  # type: ignore[arg-type]
         assert key_auth is None

--- a/tests/test_fee_payer_envelope.py
+++ b/tests/test_fee_payer_envelope.py
@@ -241,6 +241,76 @@ class TestEncoderDecoderIntegration:
         with pytest.raises(VerificationError, match="Sender address does not match"):
             intent._cosign_as_fee_payer(tampered_hex, CURRENCY)
 
+    def test_cosign_rejects_fee_token_in_envelope(self) -> None:
+        """Server should reject an envelope that includes fee_token (server sets it)."""
+        from mpp.methods.tempo import TempoAccount, tempo
+        from mpp.methods.tempo.intents import ChargeIntent
+        from mpp.server.intent import VerificationError
+
+        signed = _make_signed_tx(fee_token=CURRENCY)
+        envelope_hex = "0x" + encode_fee_payer_envelope(signed).hex()
+
+        fee_payer = TempoAccount.from_key("0x" + "ab" * 32)
+        intent = ChargeIntent(rpc_url="https://rpc.test")
+        tempo(fee_payer=fee_payer, rpc_url="https://rpc.test", intents={"charge": intent})
+
+        with pytest.raises(VerificationError, match="must not include fee_token"):
+            intent._cosign_as_fee_payer(envelope_hex, CURRENCY)
+
+    def test_cosign_rejects_non_expiring_nonce_key(self) -> None:
+        """Server should reject an envelope with a non-expiring nonce key."""
+        from mpp.methods.tempo import TempoAccount, tempo
+        from mpp.methods.tempo.intents import ChargeIntent
+        from mpp.server.intent import VerificationError
+
+        signed = _make_signed_tx()
+        encoded = encode_fee_payer_envelope(signed)
+
+        # Tamper nonce_key (index 6) to a non-MAX value
+        decoded_fields = rlp.decode(encoded[1:])
+        decoded_fields[6] = (42).to_bytes(1, "big")
+        tampered = bytes([0x78]) + rlp.encode(decoded_fields)
+        tampered_hex = "0x" + tampered.hex()
+
+        fee_payer = TempoAccount.from_key("0x" + "ab" * 32)
+        intent = ChargeIntent(rpc_url="https://rpc.test")
+        tempo(fee_payer=fee_payer, rpc_url="https://rpc.test", intents={"charge": intent})
+
+        with pytest.raises(VerificationError, match="expiring nonce key"):
+            intent._cosign_as_fee_payer(tampered_hex, CURRENCY)
+
+    def test_cosign_rejects_missing_valid_before(self) -> None:
+        """Server should reject an envelope without valid_before."""
+        from mpp.methods.tempo import TempoAccount, tempo
+        from mpp.methods.tempo.intents import ChargeIntent
+        from mpp.server.intent import VerificationError
+
+        signed = _make_signed_tx(valid_before=None)
+        envelope_hex = "0x" + encode_fee_payer_envelope(signed).hex()
+
+        fee_payer = TempoAccount.from_key("0x" + "ab" * 32)
+        intent = ChargeIntent(rpc_url="https://rpc.test")
+        tempo(fee_payer=fee_payer, rpc_url="https://rpc.test", intents={"charge": intent})
+
+        with pytest.raises(VerificationError, match="must include valid_before"):
+            intent._cosign_as_fee_payer(envelope_hex, CURRENCY)
+
+    def test_cosign_rejects_expired_valid_before(self) -> None:
+        """Server should reject an envelope with valid_before in the past."""
+        from mpp.methods.tempo import TempoAccount, tempo
+        from mpp.methods.tempo.intents import ChargeIntent
+        from mpp.server.intent import VerificationError
+
+        signed = _make_signed_tx(valid_before=1)
+        envelope_hex = "0x" + encode_fee_payer_envelope(signed).hex()
+
+        fee_payer = TempoAccount.from_key("0x" + "ab" * 32)
+        intent = ChargeIntent(rpc_url="https://rpc.test")
+        tempo(fee_payer=fee_payer, rpc_url="https://rpc.test", intents={"charge": intent})
+
+        with pytest.raises(VerificationError, match="expired"):
+            intent._cosign_as_fee_payer(envelope_hex, CURRENCY)
+
     def test_encode_decode_with_fee_token(self) -> None:
         """Should correctly roundtrip when fee_token is set."""
         signed = _make_signed_tx(fee_token=CURRENCY)

--- a/tests/test_fee_payer_envelope.py
+++ b/tests/test_fee_payer_envelope.py
@@ -1,0 +1,254 @@
+"""Tests for fee payer envelope encoding/decoding (0x78 wire format)."""
+
+import rlp
+import pytest
+from pytempo import Call, TempoTransaction
+
+from mpp.methods.tempo.fee_payer_envelope import (
+    FEE_PAYER_ENVELOPE_TYPE_ID,
+    decode_fee_payer_envelope,
+    encode_fee_payer_envelope,
+)
+
+TEST_PRIVATE_KEY = "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+CURRENCY = "0x20c0000000000000000000000000000000000000"
+RECIPIENT = "0x742d35Cc6634c0532925a3b844bC9e7595F8fE00"
+
+
+def _make_signed_tx(
+    chain_id: int = 42431,
+    fee_token: str | None = None,
+    valid_before: int | None = 9999999999,
+    valid_after: int | None = None,
+) -> TempoTransaction:
+    """Create and sign a fee-payer-awaiting transaction."""
+    selector = "a9059cbb"
+    to_padded = RECIPIENT[2:].lower().zfill(64)
+    amount_padded = hex(1000000)[2:].zfill(64)
+    transfer_data = f"0x{selector}{to_padded}{amount_padded}"
+
+    tx = TempoTransaction.create(
+        chain_id=chain_id,
+        gas_limit=100000,
+        max_fee_per_gas=1,
+        max_priority_fee_per_gas=1,
+        nonce=0,
+        nonce_key=(1 << 256) - 1,
+        fee_token=fee_token,
+        awaiting_fee_payer=True,
+        valid_before=valid_before,
+        valid_after=valid_after,
+        calls=(Call.create(to=CURRENCY, value=0, data=transfer_data),),
+    )
+    return tx.sign(TEST_PRIVATE_KEY)
+
+
+class TestEncodeFeePayerEnvelope:
+    """Tests for encode_fee_payer_envelope."""
+
+    def test_prefix_byte_is_0x78(self) -> None:
+        """Encoded envelope must start with 0x78."""
+        signed = _make_signed_tx()
+        encoded = encode_fee_payer_envelope(signed)
+        assert encoded[0] == 0x78
+
+    def test_rlp_decodable(self) -> None:
+        """The payload after the prefix must be valid RLP."""
+        signed = _make_signed_tx()
+        encoded = encode_fee_payer_envelope(signed)
+        decoded = rlp.decode(encoded[1:])
+        assert isinstance(decoded, list)
+        assert len(decoded) >= 14
+
+    def test_sender_address_at_index_11(self) -> None:
+        """Sender address must be at field index 11."""
+        signed = _make_signed_tx()
+        encoded = encode_fee_payer_envelope(signed)
+        decoded = rlp.decode(encoded[1:])
+        sender_addr = decoded[11]
+        assert len(sender_addr) == 20
+        assert sender_addr == bytes(signed.sender_address)
+
+    def test_sender_signature_is_last_field(self) -> None:
+        """Sender signature (65 bytes r||s||v) must be the last field."""
+        signed = _make_signed_tx()
+        encoded = encode_fee_payer_envelope(signed)
+        decoded = rlp.decode(encoded[1:])
+        sig = decoded[-1]
+        assert len(sig) == 65
+        assert sig == signed.sender_signature.to_bytes()
+
+    def test_chain_id_preserved(self) -> None:
+        """Chain ID must be correctly encoded at index 0."""
+        signed = _make_signed_tx(chain_id=42431)
+        encoded = encode_fee_payer_envelope(signed)
+        decoded = rlp.decode(encoded[1:])
+        chain_id = int.from_bytes(decoded[0], "big") if decoded[0] else 0
+        assert chain_id == 42431
+
+    def test_calls_preserved(self) -> None:
+        """Calls list must be correctly encoded at index 4."""
+        signed = _make_signed_tx()
+        encoded = encode_fee_payer_envelope(signed)
+        decoded = rlp.decode(encoded[1:])
+        calls = decoded[4]
+        assert isinstance(calls, list)
+        assert len(calls) == 1
+        # First call target should be the currency address
+        call_to = "0x" + calls[0][0].hex()
+        assert call_to.lower() == CURRENCY.lower()
+
+    def test_optional_fields_empty_when_none(self) -> None:
+        """valid_after and fee_token should encode as b'' when None."""
+        signed = _make_signed_tx(valid_after=None, fee_token=None)
+        encoded = encode_fee_payer_envelope(signed)
+        decoded = rlp.decode(encoded[1:])
+        # valid_after at index 9
+        assert decoded[9] == b""
+        # fee_token at index 10
+        assert decoded[10] == b""
+
+    def test_valid_before_encoded(self) -> None:
+        """valid_before value should be correctly encoded at index 8."""
+        signed = _make_signed_tx(valid_before=9999999999)
+        encoded = encode_fee_payer_envelope(signed)
+        decoded = rlp.decode(encoded[1:])
+        vb = int.from_bytes(decoded[8], "big") if decoded[8] else 0
+        assert vb == 9999999999
+
+    def test_differs_from_0x76_encode(self) -> None:
+        """0x78 envelope must differ from standard 0x76 encode."""
+        import attrs
+
+        signed = _make_signed_tx()
+        envelope = encode_fee_payer_envelope(signed)
+
+        # For 0x76 we need a fee_payer_signature
+        tx_76 = attrs.evolve(signed, fee_payer_signature=b"\x00")
+        encoded_76 = tx_76.encode()
+
+        assert envelope[0] == 0x78
+        assert encoded_76[0] == 0x76
+        assert envelope != encoded_76
+
+
+class TestDecodeFeePayerEnvelope:
+    """Tests for decode_fee_payer_envelope."""
+
+    def test_roundtrip(self) -> None:
+        """encode then decode should preserve sender address and signature."""
+        signed = _make_signed_tx()
+        encoded = encode_fee_payer_envelope(signed)
+        decoded, sender_addr, sender_sig, key_auth = decode_fee_payer_envelope(encoded)
+
+        assert sender_addr == bytes(signed.sender_address)
+        assert sender_sig == signed.sender_signature.to_bytes()
+        assert key_auth is None
+
+    def test_roundtrip_fields(self) -> None:
+        """Decoded RLP fields should match original transaction fields."""
+        signed = _make_signed_tx(chain_id=42431)
+        encoded = encode_fee_payer_envelope(signed)
+        decoded, _, _, _ = decode_fee_payer_envelope(encoded)
+
+        def _int(b: bytes) -> int:
+            return int.from_bytes(b, "big") if b else 0
+
+        assert _int(decoded[0]) == 42431
+        assert _int(decoded[1]) == signed.max_priority_fee_per_gas
+        assert _int(decoded[2]) == signed.max_fee_per_gas
+        assert _int(decoded[3]) == signed.gas_limit
+        assert _int(decoded[6]) == signed.nonce_key
+        assert _int(decoded[7]) == signed.nonce
+        assert _int(decoded[8]) == 9999999999  # valid_before
+
+    def test_rejects_wrong_prefix(self) -> None:
+        """Should reject data not starting with 0x78."""
+        with pytest.raises(ValueError, match="expected 0x78 prefix"):
+            decode_fee_payer_envelope(b"\x76" + b"\x00" * 20)
+
+    def test_rejects_0x76_prefix(self) -> None:
+        """Should reject a standard 0x76 transaction."""
+        import attrs
+
+        signed = _make_signed_tx()
+        tx_76 = attrs.evolve(signed, fee_payer_signature=b"\x00")
+        encoded_76 = tx_76.encode()
+        with pytest.raises(ValueError, match="expected 0x78 prefix"):
+            decode_fee_payer_envelope(encoded_76)
+
+    def test_rejects_empty_data(self) -> None:
+        """Should reject empty input."""
+        with pytest.raises(ValueError, match="expected 0x78 prefix"):
+            decode_fee_payer_envelope(b"")
+
+    def test_rejects_too_short_rlp(self) -> None:
+        """Should reject RLP with too few fields."""
+        # 0x78 + RLP of a short list
+        short = bytes([0x78]) + rlp.encode([b"", b"", b""])
+        with pytest.raises(ValueError, match="Malformed"):
+            decode_fee_payer_envelope(short)
+
+
+class TestEncoderDecoderIntegration:
+    """Integration tests: encode → decode → cosign roundtrip."""
+
+    def test_cosign_roundtrip(self) -> None:
+        """Server should be able to cosign a client-produced 0x78 envelope."""
+        from mpp.methods.tempo import TempoAccount, tempo
+        from mpp.methods.tempo.intents import ChargeIntent
+
+        signed = _make_signed_tx()
+        envelope_hex = "0x" + encode_fee_payer_envelope(signed).hex()
+
+        fee_payer_key = "0x" + "ab" * 32
+        fee_payer = TempoAccount.from_key(fee_payer_key)
+        intent = ChargeIntent(rpc_url="https://rpc.test")
+        tempo(fee_payer=fee_payer, rpc_url="https://rpc.test", intents={"charge": intent})
+
+        result = intent._cosign_as_fee_payer(envelope_hex, CURRENCY)
+        assert result.startswith("0x76")
+
+        # The co-signed tx should be valid RLP with 0x76 prefix
+        result_bytes = bytes.fromhex(result[2:])
+        assert result_bytes[0] == 0x76
+        decoded = rlp.decode(result_bytes[1:])
+        # Should have fee_payer_signature as a list [v, r, s] (not b"\x00")
+        fee_payer_sig = decoded[11]
+        assert isinstance(fee_payer_sig, list)
+        assert len(fee_payer_sig) == 3
+
+    def test_cosign_rejects_tampered_sender_address(self) -> None:
+        """Server should reject an envelope where sender_address doesn't match the signature."""
+        from mpp.methods.tempo import TempoAccount, tempo
+        from mpp.methods.tempo.intents import ChargeIntent
+        from mpp.server.intent import VerificationError
+
+        signed = _make_signed_tx()
+        encoded = encode_fee_payer_envelope(signed)
+
+        # Tamper with sender_address (index 11) by replacing it
+        decoded_fields = rlp.decode(encoded[1:])
+        # Replace sender address with a different address
+        decoded_fields[11] = b"\xde\xad" + b"\x00" * 18
+        tampered = bytes([0x78]) + rlp.encode(decoded_fields)
+        tampered_hex = "0x" + tampered.hex()
+
+        fee_payer = TempoAccount.from_key("0x" + "ab" * 32)
+        intent = ChargeIntent(rpc_url="https://rpc.test")
+        tempo(fee_payer=fee_payer, rpc_url="https://rpc.test", intents={"charge": intent})
+
+        with pytest.raises(VerificationError, match="Sender address does not match"):
+            intent._cosign_as_fee_payer(tampered_hex, CURRENCY)
+
+    def test_encode_decode_with_fee_token(self) -> None:
+        """Should correctly roundtrip when fee_token is set."""
+        signed = _make_signed_tx(fee_token=CURRENCY)
+        encoded = encode_fee_payer_envelope(signed)
+        decoded, sender_addr, sender_sig, key_auth = decode_fee_payer_envelope(encoded)
+
+        # fee_token at index 10 should be 20 bytes
+        assert len(decoded[10]) == 20
+        assert ("0x" + decoded[10].hex()).lower() == CURRENCY.lower()
+        assert sender_addr == bytes(signed.sender_address)
+        assert key_auth is None

--- a/tests/test_tempo.py
+++ b/tests/test_tempo.py
@@ -488,7 +488,7 @@ class TestSponsoredTransfer:
 
         assert credential.challenge.id == "test-sponsored"
         assert credential.payload["type"] == "transaction"
-        assert credential.payload["signature"].startswith("0x76")
+        assert credential.payload["signature"].startswith("0x78")
 
     @pytest.mark.asyncio
     async def test_server_submits_sponsored_transaction(self, httpx_mock: HTTPXMock) -> None:
@@ -602,7 +602,6 @@ class TestCosignAsFeePayer:
         with_memo: str | None = None,
     ) -> str:
         """Build a client-signed fee-payer-awaiting transaction."""
-        import attrs
         from pytempo import Call, TempoTransaction
 
         if with_memo:
@@ -631,8 +630,10 @@ class TestCosignAsFeePayer:
         )
 
         signed = tx.sign(TEST_PRIVATE_KEY)
-        signed = attrs.evolve(signed, fee_payer_signature=b"\x00")
-        return "0x" + signed.encode().hex()
+
+        from mpp.methods.tempo.fee_payer_envelope import encode_fee_payer_envelope
+
+        return "0x" + encode_fee_payer_envelope(signed).hex()
 
     def test_cosign_roundtrip(self) -> None:
         """Should successfully co-sign a valid client transaction."""
@@ -653,7 +654,7 @@ class TestCosignAsFeePayer:
         assert len(result) > len(raw_tx)
 
     def test_cosign_rejects_wrong_tx_type(self) -> None:
-        """Should reject transactions that aren't type 0x76."""
+        """Should reject transactions that aren't type 0x78."""
         fee_payer = TempoAccount.from_key("0x" + "ab" * 32)
         intent = ChargeIntent(rpc_url="https://rpc.test")
         tempo(fee_payer=fee_payer, rpc_url="https://rpc.test", intents={"charge": intent})
@@ -755,6 +756,134 @@ class TestCosignAsFeePayer:
 
         result = intent._cosign_as_fee_payer(raw_tx, request.currency, request=request)
         assert result.startswith("0x76")
+
+
+class TestValidateTransactionPayload:
+    """Tests for _validate_transaction_payload with both 0x76 and 0x78."""
+
+    def _build_0x78_envelope(
+        self,
+        currency: str = "0x20c0000000000000000000000000000000000000",
+        recipient: str = "0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
+        amount: int = 1000000,
+    ) -> str:
+        """Build a 0x78 fee payer envelope."""
+        from pytempo import Call, TempoTransaction
+
+        from mpp.methods.tempo.fee_payer_envelope import encode_fee_payer_envelope
+
+        selector = "a9059cbb"
+        to_padded = recipient[2:].lower().zfill(64)
+        amount_padded = hex(amount)[2:].zfill(64)
+        transfer_data = f"0x{selector}{to_padded}{amount_padded}"
+
+        tx = TempoTransaction.create(
+            chain_id=42431,
+            gas_limit=100000,
+            max_fee_per_gas=1,
+            max_priority_fee_per_gas=1,
+            nonce=0,
+            nonce_key=(1 << 256) - 1,
+            fee_token=None,
+            awaiting_fee_payer=True,
+            valid_before=9999999999,
+            calls=(Call.create(to=currency, value=0, data=transfer_data),),
+        )
+        signed = tx.sign(TEST_PRIVATE_KEY)
+        return "0x" + encode_fee_payer_envelope(signed).hex()
+
+    def _build_0x76_tx(
+        self,
+        currency: str = "0x20c0000000000000000000000000000000000000",
+        recipient: str = "0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
+        amount: int = 1000000,
+    ) -> str:
+        """Build a standard 0x76 transaction."""
+        import attrs
+        from pytempo import Call, TempoTransaction
+
+        selector = "a9059cbb"
+        to_padded = recipient[2:].lower().zfill(64)
+        amount_padded = hex(amount)[2:].zfill(64)
+        transfer_data = f"0x{selector}{to_padded}{amount_padded}"
+
+        tx = TempoTransaction.create(
+            chain_id=42431,
+            gas_limit=100000,
+            max_fee_per_gas=1,
+            max_priority_fee_per_gas=1,
+            nonce=0,
+            nonce_key=0,
+            fee_token=currency,
+            calls=(Call.create(to=currency, value=0, data=transfer_data),),
+        )
+        signed = tx.sign(TEST_PRIVATE_KEY)
+        signed = attrs.evolve(signed, fee_payer_signature=b"\x00")
+        return "0x" + signed.encode().hex()
+
+    def test_accepts_0x78_with_matching_call(self) -> None:
+        """Should accept a 0x78 envelope with a valid payment call."""
+        intent = ChargeIntent(rpc_url="https://rpc.test")
+        request = ChargeRequest(
+            amount="1000000",
+            currency="0x20c0000000000000000000000000000000000000",
+            recipient="0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
+            expires="2030-01-20T12:00:00Z",
+        )
+        sig = self._build_0x78_envelope()
+        # Should not raise
+        intent._validate_transaction_payload(sig, request)
+
+    def test_rejects_0x78_with_wrong_amount(self) -> None:
+        """Should reject a 0x78 envelope with mismatched amount."""
+        intent = ChargeIntent(rpc_url="https://rpc.test")
+        request = ChargeRequest(
+            amount="9999999",
+            currency="0x20c0000000000000000000000000000000000000",
+            recipient="0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
+            expires="2030-01-20T12:00:00Z",
+        )
+        sig = self._build_0x78_envelope(amount=1000000)
+        with pytest.raises(VerificationError, match="no matching payment call"):
+            intent._validate_transaction_payload(sig, request)
+
+    def test_rejects_0x78_with_wrong_currency(self) -> None:
+        """Should reject a 0x78 envelope targeting wrong currency."""
+        intent = ChargeIntent(rpc_url="https://rpc.test")
+        request = ChargeRequest(
+            amount="1000000",
+            currency="0xDEAD000000000000000000000000000000000000",
+            recipient="0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
+            expires="2030-01-20T12:00:00Z",
+        )
+        sig = self._build_0x78_envelope()
+        with pytest.raises(VerificationError, match="no matching payment call"):
+            intent._validate_transaction_payload(sig, request)
+
+    def test_accepts_0x76_with_matching_call(self) -> None:
+        """Should still accept standard 0x76 transactions."""
+        intent = ChargeIntent(rpc_url="https://rpc.test")
+        request = ChargeRequest(
+            amount="1000000",
+            currency="0x20c0000000000000000000000000000000000000",
+            recipient="0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
+            expires="2030-01-20T12:00:00Z",
+        )
+        sig = self._build_0x76_tx()
+        # Should not raise
+        intent._validate_transaction_payload(sig, request)
+
+    def test_silently_skips_unknown_prefix(self) -> None:
+        """Should silently skip transactions with unrecognized type prefix."""
+        intent = ChargeIntent(rpc_url="https://rpc.test")
+        request = ChargeRequest(
+            amount="1000000",
+            currency="0x20c0000000000000000000000000000000000000",
+            recipient="0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
+            expires="2030-01-20T12:00:00Z",
+        )
+        # 0x02 prefix — should silently skip (not raise)
+        intent._validate_transaction_payload("0x02abcdef", request)
 
 
 class TestFeePayerPropagation:

--- a/tests/test_tempo.py
+++ b/tests/test_tempo.py
@@ -1463,8 +1463,8 @@ class TestVerifyTransferLogsWithMemo:
         assert intent._verify_transfer_logs(receipt_plain, request) is True
 
 
-class TestValidateTransactionPayload:
-    """Tests for _validate_transaction_payload."""
+class TestValidateTransactionPayload0x76:
+    """Tests for _validate_transaction_payload with 0x76 transactions."""
 
     CURRENCY = "0x20c0000000000000000000000000000000000000"
     RECIPIENT = "0x742d35Cc6634c0532925a3b844bC9e7595F8fE00"

--- a/tests/test_tempo.py
+++ b/tests/test_tempo.py
@@ -1497,7 +1497,7 @@ class TestValidateTransactionPayload0x76:
 
         # Build minimal RLP: [chain_id, mpfpg, mfpg, gas, calls=[], ...]
         decoded = [b"\x01", b"\x01", b"\x01", b"\x01", [], b"", b"", b"\x00", b"", b"", b""]
-        payload = b"\x76" + rlp.encode(decoded)
+        payload = b"\x76" + bytes(rlp.encode(decoded))
         sig = "0x" + payload.hex()
 
         with pytest.raises(VerificationError, match="no calls"):


### PR DESCRIPTION
## Problem

`decode_fee_payer_envelope` returned the raw RLP field list without disambiguating whether a 15-field envelope contained `key_authorization` (index 13) or not. `_cosign_as_fee_payer` never passed `key_authorization` to the reconstructed `TempoTransaction`, meaning if a client sent a 0x78 envelope with `key_authorization`, the fee payer would silently drop it — producing an invalid 0x76 transaction whose signing hash wouldn't match the sender's original commitment.

## Fix

- `decode_fee_payer_envelope` now returns a 4th element: `key_authorization` as RLP-encoded bytes (matching pytempo's `bytes | None` type) or `None`. 15-field envelopes have it at index 13; 14-field envelopes don't.
- `_cosign_as_fee_payer` passes `key_auth` through to the reconstructed `TempoTransaction`, preserving the sender's signing hash.
- Tests updated to unpack the new 4-tuple and assert `key_auth` is `None` for standard envelopes.

## Testing

All 269 tests pass (19 skipped are integration tests requiring `TEMPO_RPC_URL`).