### PR TITLE
fix: make Method.intents a read-only property in protocol

### DIFF
--- a/.changelog/easy-rocks-meow.md
+++ b/.changelog/easy-rocks-meow.md
@@ -1,0 +1,5 @@
+---
+pympp: patch
+---
+
+Fixed `Method.intents` to be declared as a read-only property in the `Method` protocol instead of a plain attribute.

--- a/src/mpp/server/method.py
+++ b/src/mpp/server/method.py
@@ -32,7 +32,11 @@ class Method(Protocol):
     """
 
     name: str
-    intents: dict[str, Intent]
+
+    @property
+    def intents(self) -> dict[str, Intent]:
+        """Available intents for this method."""
+        ...
 
     async def create_credential(self, challenge: Challenge) -> Credential:
         """Create a credential to satisfy the given challenge.


### PR DESCRIPTION
## Problem

`TempoMethod` exposes `intents` as a `@property` (read-only), but the `Method` protocol declared it as a bare attribute (read-write). Pyright correctly rejects this:

```
Argument of type "TempoMethod" cannot be assigned to parameter "method" of type "Method" in function "create"
```

A read-only property doesn't satisfy a read-write attribute contract — if code received a `Method` and tried `method.intents = {...}`, it would fail at runtime on `TempoMethod`.

## Fix

Changed `Method.intents` from a bare attribute to a `@property` in the protocol, matching how it's actually used. Nothing in the SDK writes to `method.intents`, so the protocol should reflect this.

## Note

CI doesn't run pyright today (only `ruff check` + `ruff format`), which is why this wasn't caught. Adding pyright to CI is a follow-up (73 pre-existing errors to triage).