### PR TITLE
refactor(pympp): wire method transform_request in Mpp helpers

### DIFF
--- a/.changelog/lively-frogs-sleep.md
+++ b/.changelog/lively-frogs-sleep.md
@@ -1,0 +1,5 @@
+---
+pympp: patch
+---
+
+Applied `transform_request` method hook in `Mpp.charge` and `Mpp.pay` helpers, ensuring the method's request transform is called before verification. Added tests covering both helpers.

--- a/src/mpp/server/mpp.py
+++ b/src/mpp/server/mpp.py
@@ -7,6 +7,7 @@ from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any, TypeVar
 
 from mpp import Challenge, Credential, Receipt
+from mpp._parsing import ParseError
 from mpp._units import parse_units
 from mpp.server._defaults import detect_realm, detect_secret_key
 from mpp.server.decorator import wrap_payment_handler
@@ -20,6 +21,33 @@ R = TypeVar("R")
 
 DEFAULT_EXPIRY_SECONDS = 300
 DEFAULT_DECIMALS = 6
+
+
+def _credential_for_transform(authorization: str | None) -> Credential | None:
+    """Best-effort credential parsing for method transform hooks.
+
+    Transform hooks should be able to branch on authenticated context when
+    a valid Payment credential is present. Parsing failures return None so
+    verification remains fail-closed inside verify_or_challenge.
+    """
+    if authorization is None:
+        return None
+
+    payment_scheme = next(
+        (
+            scheme.strip()
+            for scheme in authorization.split(",")
+            if scheme.strip().lower().startswith("payment ")
+        ),
+        None,
+    )
+    if payment_scheme is None:
+        return None
+
+    try:
+        return Credential.from_authorization(payment_scheme)
+    except ParseError:
+        return None
 
 
 class Mpp:
@@ -170,7 +198,7 @@ class Mpp:
                 method_details["feePayer"] = True
             request["methodDetails"] = method_details
 
-        request = transform_request(self.method, request, None)
+        request = transform_request(self.method, request, _credential_for_transform(authorization))
 
         return await verify_or_challenge(
             authorization=authorization,
@@ -272,7 +300,11 @@ class Mpp:
                 if resolved_chain_id is not None:
                     request["methodDetails"] = {"chainId": resolved_chain_id}
 
-                request = transform_request(self.method, request, None)
+                request = transform_request(
+                    self.method,
+                    request,
+                    _credential_for_transform(authorization),
+                )
 
                 return await verify_or_challenge(
                     authorization=authorization,

--- a/src/mpp/server/mpp.py
+++ b/src/mpp/server/mpp.py
@@ -10,6 +10,7 @@ from mpp import Challenge, Credential, Receipt
 from mpp._units import parse_units
 from mpp.server._defaults import detect_realm, detect_secret_key
 from mpp.server.decorator import wrap_payment_handler
+from mpp.server.method import transform_request
 from mpp.server.verify import verify_or_challenge
 
 if TYPE_CHECKING:
@@ -169,6 +170,8 @@ class Mpp:
                 method_details["feePayer"] = True
             request["methodDetails"] = method_details
 
+        request = transform_request(self.method, request, None)
+
         return await verify_or_challenge(
             authorization=authorization,
             intent=intent,
@@ -268,6 +271,8 @@ class Mpp:
                     resolved_chain_id = getattr(self.method, "chain_id", None)
                 if resolved_chain_id is not None:
                     request["methodDetails"] = {"chainId": resolved_chain_id}
+
+                request = transform_request(self.method, request, None)
 
                 return await verify_or_challenge(
                     authorization=authorization,

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1061,6 +1061,76 @@ class TestMppChainIdAutoEmit:
         assert challenge.request["methodDetails"]["chainId"] == 4217
 
 
+class TestMppRequestTransformHook:
+    """Tests for method.transform_request integration in Mpp helpers."""
+
+    @pytest.mark.asyncio
+    async def test_charge_applies_method_transform_request(self) -> None:
+        @intent(name="charge")
+        async def test_intent(credential: Credential, request: dict) -> Receipt:
+            return Receipt.success("0x123")
+
+        class MockMethod:
+            name = "tempo"
+            currency = "0xUSD"
+            recipient = "0xRecipient"
+            decimals = 6
+            intents = {"charge": test_intent}
+
+            def transform_request(self, request: dict, credential: Credential | None) -> dict:
+                assert credential is None
+                return {**request, "extra": {"hook": "charge"}}
+
+        server = Mpp(
+            method=MockMethod(),  # type: ignore[arg-type]
+            realm="api.example.com",
+            secret_key="test-secret",
+        )
+
+        result = await server.charge(authorization=None, amount="0.50")
+        assert isinstance(result, Challenge)
+        assert result.request["extra"]["hook"] == "charge"
+
+    @pytest.mark.asyncio
+    async def test_pay_applies_method_transform_request(self) -> None:
+        @intent(name="charge")
+        async def test_intent(credential: Credential, request: dict) -> Receipt:
+            return Receipt.success("0x123")
+
+        class MockMethod:
+            name = "tempo"
+            currency = "0xUSD"
+            recipient = "0xRecipient"
+            decimals = 6
+            intents = {"charge": test_intent}
+
+            def transform_request(self, request: dict, credential: Credential | None) -> dict:
+                assert credential is None
+                return {**request, "extra": {"hook": "pay"}}
+
+        server = Mpp(
+            method=MockMethod(),  # type: ignore[arg-type]
+            realm="api.example.com",
+            secret_key="test-secret",
+        )
+
+        @server.pay(amount="0.50")
+        async def handler(req: MockRequest, credential: Credential, receipt: Receipt) -> dict:
+            return {"data": "paid"}
+
+        result = await handler(MockRequest())
+        if HAS_STARLETTE:
+            assert StarletteResponse is not None
+            assert isinstance(result, StarletteResponse)
+            www_auth = result.headers["WWW-Authenticate"]
+        else:
+            assert isinstance(result, dict)
+            www_auth = result["headers"]["WWW-Authenticate"]
+
+        challenge = Challenge.from_www_authenticate(www_auth)
+        assert challenge.request["extra"]["hook"] == "pay"
+
+
 class TestMalformedEchoedFields:
     """Malformed base64 in echoed request/opaque should re-issue challenge, not crash."""
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1130,6 +1130,84 @@ class TestMppRequestTransformHook:
         challenge = Challenge.from_www_authenticate(www_auth)
         assert challenge.request["extra"]["hook"] == "pay"
 
+    @pytest.mark.asyncio
+    async def test_charge_passes_parsed_credential_to_transform_request(self) -> None:
+        @intent(name="charge")
+        async def test_intent(credential: Credential, request: dict) -> Receipt:
+            return Receipt.success("0x123")
+
+        seen: dict[str, str] = {}
+
+        class MockMethod:
+            name = "tempo"
+            currency = "0xUSD"
+            recipient = "0xRecipient"
+            decimals = 6
+            intents = {"charge": test_intent}
+
+            def transform_request(self, request: dict, credential: Credential | None) -> dict:
+                assert credential is not None
+                seen["id"] = credential.challenge.id
+                return request
+
+        server = Mpp(
+            method=MockMethod(),  # type: ignore[arg-type]
+            realm="api.example.com",
+            secret_key="test-secret",
+        )
+
+        credential = make_bound_credential(
+            payload={},
+            request={"amount": "500000", "currency": "0xUSD", "recipient": "0xRecipient"},
+            realm="api.example.com",
+            secret_key="test-secret",
+        )
+
+        result = await server.charge(authorization=credential.to_authorization(), amount="0.50")
+        assert isinstance(result, tuple)
+        assert seen["id"] == credential.challenge.id
+
+    @pytest.mark.asyncio
+    async def test_pay_passes_parsed_credential_to_transform_request(self) -> None:
+        @intent(name="charge")
+        async def test_intent(credential: Credential, request: dict) -> Receipt:
+            return Receipt.success("0x123")
+
+        seen: dict[str, str] = {}
+
+        class MockMethod:
+            name = "tempo"
+            currency = "0xUSD"
+            recipient = "0xRecipient"
+            decimals = 6
+            intents = {"charge": test_intent}
+
+            def transform_request(self, request: dict, credential: Credential | None) -> dict:
+                assert credential is not None
+                seen["id"] = credential.challenge.id
+                return request
+
+        server = Mpp(
+            method=MockMethod(),  # type: ignore[arg-type]
+            realm="api.example.com",
+            secret_key="test-secret",
+        )
+
+        @server.pay(amount="0.50")
+        async def handler(req: MockRequest, credential: Credential, receipt: Receipt) -> dict:
+            return {"data": "paid"}
+
+        credential = make_bound_credential(
+            payload={},
+            request={"amount": "500000", "currency": "0xUSD", "recipient": "0xRecipient"},
+            realm="api.example.com",
+            secret_key="test-secret",
+        )
+
+        result = await handler(MockRequest(authorization=credential.to_authorization()))
+        assert result["data"] == "paid"
+        assert seen["id"] == credential.challenge.id
+
 
 class TestMalformedEchoedFields:
     """Malformed base64 in echoed request/opaque should re-issue challenge, not crash."""


### PR DESCRIPTION
Summary:
- integrated transform_request hook into Mpp.charge request preparation
- integrated transform_request hook into Mpp.pay request preparation
- added regression tests proving the hook is applied in both helper paths (P-06)