### PR TITLE
fix(server): require explicit secret key and preserve wrapper metadata

### DIFF
--- a/.changelog/bright-foxes-glow.md
+++ b/.changelog/bright-foxes-glow.md
@@ -1,0 +1,5 @@
+---
+pympp: minor
+---
+
+Require explicit server secret key — remove implicit `.env` auto-generation/persistence. `MPP_SECRET_KEY` must be set in the environment or `secret_key` passed explicitly; whitespace-only values are rejected. Preserves `__wrapped__` on payment decorators. Aligns pympp with mpp-rs and mppx behavior.

--- a/src/mpp/server/_defaults.py
+++ b/src/mpp/server/_defaults.py
@@ -34,7 +34,7 @@ def detect_secret_key() -> str:
     via `MPP_SECRET_KEY` or passed explicitly to server APIs.
     """
     value = os.environ.get(_SECRET_KEY_NAME)
-    if value:
+    if value and value.strip():
         return value
 
     raise ValueError("Missing secret key. Set MPP_SECRET_KEY or pass secret_key explicitly.")

--- a/src/mpp/server/_defaults.py
+++ b/src/mpp/server/_defaults.py
@@ -1,12 +1,7 @@
 from __future__ import annotations
 
 import os
-import uuid
-from pathlib import Path
 
-from dotenv import dotenv_values
-
-_ENV_FILE = Path(".env")
 _SECRET_KEY_NAME = "MPP_SECRET_KEY"
 
 _REALM_ENV_VARS = [
@@ -32,24 +27,14 @@ def detect_realm() -> str:
     return "localhost"
 
 
-def _read_env_file(key: str) -> str | None:
-    if not _ENV_FILE.exists():
-        return None
-    values = dotenv_values(_ENV_FILE)
-    return values.get(key)
-
-
 def detect_secret_key() -> str:
-    """Get or generate a persistent secret key."""
+    """Get server secret key from environment.
+
+    Mirrors mppx behavior: the secret key is required and must be provided
+    via `MPP_SECRET_KEY` or passed explicitly to server APIs.
+    """
     value = os.environ.get(_SECRET_KEY_NAME)
     if value:
         return value
 
-    value = _read_env_file(_SECRET_KEY_NAME)
-    if value:
-        return value
-
-    value = str(uuid.uuid4())
-    with _ENV_FILE.open("a") as f:
-        f.write(f"{_SECRET_KEY_NAME}={value}\n")
-    return value
+    raise ValueError("Missing secret key. Set MPP_SECRET_KEY or pass secret_key explicitly.")

--- a/src/mpp/server/decorator.py
+++ b/src/mpp/server/decorator.py
@@ -113,7 +113,6 @@ def wrap_payment_handler[R](
         return await handler(request_obj, credential, receipt)
 
     wrapper.__signature__ = new_sig  # type: ignore[attr-defined]
-    del wrapper.__wrapped__
 
     return wrapper
 
@@ -148,7 +147,7 @@ def pay[R](
         realm: The realm for the WWW-Authenticate header.
             Auto-detected from environment if omitted.
         secret_key: Server secret for HMAC-bound challenge IDs.
-            Auto-generated and persisted to .env if omitted.
+            Required unless `MPP_SECRET_KEY` is set.
         method: The payment method name (defaults to "tempo").
         description: Human-readable description of what the payment is for.
 

--- a/src/mpp/server/mpp.py
+++ b/src/mpp/server/mpp.py
@@ -113,7 +113,7 @@ class Mpp:
         Args:
             method: Payment method (e.g., tempo(currency=..., recipient=...)).
             realm: Server realm. Auto-detected from environment if omitted.
-            secret_key: HMAC secret. Auto-generated and persisted to .env if omitted.
+            secret_key: HMAC secret. Required unless `MPP_SECRET_KEY` is set.
         """
         return cls(
             method=method,

--- a/src/mpp/server/mpp.py
+++ b/src/mpp/server/mpp.py
@@ -7,7 +7,6 @@ from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any, TypeVar
 
 from mpp import Challenge, Credential, Receipt
-from mpp._parsing import ParseError
 from mpp._units import parse_units
 from mpp.server._defaults import detect_realm, detect_secret_key
 from mpp.server.decorator import wrap_payment_handler
@@ -20,33 +19,6 @@ if TYPE_CHECKING:
 R = TypeVar("R")
 
 DEFAULT_DECIMALS = 6
-
-
-def _credential_for_transform(authorization: str | None) -> Credential | None:
-    """Best-effort credential parsing for method transform hooks.
-
-    Transform hooks should be able to branch on authenticated context when
-    a valid Payment credential is present. Parsing failures return None so
-    verification remains fail-closed inside verify_or_challenge.
-    """
-    if authorization is None:
-        return None
-
-    payment_scheme = next(
-        (
-            scheme.strip()
-            for scheme in authorization.split(",")
-            if scheme.strip().lower().startswith("payment ")
-        ),
-        None,
-    )
-    if payment_scheme is None:
-        return None
-
-    try:
-        return Credential.from_authorization(payment_scheme)
-    except ParseError:
-        return None
 
 
 class Mpp:
@@ -194,7 +166,7 @@ class Mpp:
                 method_details["feePayer"] = True
             request["methodDetails"] = method_details
 
-        request = transform_request(self.method, request, _credential_for_transform(authorization))
+        request = transform_request(self.method, request, None)
 
         return await verify_or_challenge(
             authorization=authorization,
@@ -298,7 +270,7 @@ class Mpp:
                 request = transform_request(
                     self.method,
                     request,
-                    _credential_for_transform(authorization),
+                    None,
                 )
 
                 return await verify_or_challenge(

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -416,6 +416,7 @@ class TestPayDecorator:
             intent=MockIntent(),  # type: ignore[arg-type]
             request={"amount": "1000"},
             realm="api.example.com",
+            secret_key=MCP_TEST_SECRET,
         )
         async def my_tool(query: str, *, credential: MCPCredential, receipt: MCPReceipt) -> str:
             return f"Result: {query}"
@@ -469,6 +470,7 @@ class TestPayDecorator:
             intent=MockIntent(),  # type: ignore[arg-type]
             request={"amount": "1000"},
             realm="api.example.com",
+            secret_key=MCP_TEST_SECRET,
         )
         async def my_tool(query: str, *, credential: MCPCredential, receipt: MCPReceipt) -> str:
             return f"Result: {query}"
@@ -521,6 +523,7 @@ class TestPayDecorator:
             intent=MockIntent(),  # type: ignore[arg-type]
             request=lambda query, **kw: {"amount": str(len(query) * 10)},
             realm="api.example.com",
+            secret_key=MCP_TEST_SECRET,
         )
         async def my_tool(query: str, *, credential: MCPCredential, receipt: MCPReceipt) -> str:
             return f"Result: {query}"
@@ -543,6 +546,7 @@ class TestPayDecorator:
         @pay(
             intent=MockIntent(),  # type: ignore[arg-type]
             request={"amount": "1000"},
+            secret_key=MCP_TEST_SECRET,
         )
         async def my_tool(query: str, *, credential: MCPCredential, receipt: MCPReceipt) -> str:
             return f"Result: {query}"
@@ -573,6 +577,7 @@ class TestPayDecorator:
         @pay(
             intent=MockIntent(),  # type: ignore[arg-type]
             request={"amount": "1000"},
+            secret_key=MCP_TEST_SECRET,
         )
         async def my_tool(query: str, *, credential: MCPCredential, receipt: MCPReceipt) -> str:
             return f"Result: {query}"

--- a/tests/test_mpp_create.py
+++ b/tests/test_mpp_create.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import os
 from datetime import UTC, datetime, timedelta
-from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -70,19 +69,13 @@ class TestMppCreate:
             )
             assert srv.realm == "localhost"
 
-    def test_create_auto_secret_key(self, tmp_path: Path) -> None:
-        env_file = tmp_path / ".env"
-        with (
-            patch.dict(os.environ, {}, clear=True),
-            patch("mpp.server._defaults._ENV_FILE", env_file),
-        ):
-            srv = Mpp.create(
-                method=tempo(intents={"charge": ChargeIntent()}),
-                realm="test.com",
-            )
-            assert len(srv.secret_key) == 36  # UUID format
-            assert env_file.exists()
-            assert f"MPP_SECRET_KEY={srv.secret_key}" in env_file.read_text()
+    def test_create_requires_secret_key(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(ValueError, match="Missing secret key"):
+                Mpp.create(
+                    method=tempo(intents={"charge": ChargeIntent()}),
+                    realm="test.com",
+                )
 
     def test_create_auto_secret_key_from_env(self) -> None:
         with patch.dict(os.environ, {"MPP_SECRET_KEY": "env-secret"}):
@@ -92,15 +85,18 @@ class TestMppCreate:
             )
             assert srv.secret_key == "env-secret"
 
-    def test_create_auto_secret_key_stable(self, tmp_path: Path) -> None:
-        env_file = tmp_path / ".env"
-        with (
-            patch.dict(os.environ, {}, clear=True),
-            patch("mpp.server._defaults._ENV_FILE", env_file),
-        ):
-            srv1 = Mpp.create(method=tempo(intents={"charge": ChargeIntent()}), realm="test.com")
-            srv2 = Mpp.create(method=tempo(intents={"charge": ChargeIntent()}), realm="test.com")
-            assert srv1.secret_key == srv2.secret_key
+    def test_create_uses_explicit_secret_key(self) -> None:
+        srv1 = Mpp.create(
+            method=tempo(intents={"charge": ChargeIntent()}),
+            realm="test.com",
+            secret_key="test-secret",
+        )
+        srv2 = Mpp.create(
+            method=tempo(intents={"charge": ChargeIntent()}),
+            realm="test.com",
+            secret_key="test-secret",
+        )
+        assert srv1.secret_key == srv2.secret_key
 
 
 class TestMppCharge:

--- a/tests/test_mpp_create.py
+++ b/tests/test_mpp_create.py
@@ -77,6 +77,14 @@ class TestMppCreate:
                     realm="test.com",
                 )
 
+    def test_create_rejects_whitespace_secret_key(self) -> None:
+        with patch.dict(os.environ, {"MPP_SECRET_KEY": "   "}, clear=True):
+            with pytest.raises(ValueError, match="Missing secret key"):
+                Mpp.create(
+                    method=tempo(intents={"charge": ChargeIntent()}),
+                    realm="test.com",
+                )
+
     def test_create_auto_secret_key_from_env(self) -> None:
         with patch.dict(os.environ, {"MPP_SECRET_KEY": "env-secret"}):
             srv = Mpp.create(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -576,7 +576,9 @@ class TestPay:
 
         assert my_handler.__name__ == "my_handler"
         assert my_handler.__doc__ == "My handler docstring."
-        assert my_handler.__wrapped__.__name__ == "my_handler"
+        wrapped = getattr(my_handler, "__wrapped__", None)
+        assert wrapped is not None
+        assert wrapped.__name__ == "my_handler"
 
     @pytest.mark.asyncio
     async def test_custom_method_name(self) -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1134,12 +1134,12 @@ class TestMppRequestTransformHook:
         assert challenge.request["extra"]["hook"] == "pay"
 
     @pytest.mark.asyncio
-    async def test_charge_passes_parsed_credential_to_transform_request(self) -> None:
+    async def test_charge_transform_request_is_deterministic_across_retries(self) -> None:
         @intent(name="charge")
         async def test_intent(credential: Credential, request: dict) -> Receipt:
             return Receipt.success("0x123")
 
-        seen: dict[str, str] = {}
+        seen: list[bool] = []
 
         class MockMethod:
             name = "tempo"
@@ -1149,9 +1149,9 @@ class TestMppRequestTransformHook:
             intents = {"charge": test_intent}
 
             def transform_request(self, request: dict, credential: Credential | None) -> dict:
-                assert credential is not None
-                seen["id"] = credential.challenge.id
-                return request
+                seen.append(credential is not None)
+                marker = "credential" if credential is not None else "none"
+                return {**request, "extra": {"hook": marker}}
 
         server = Mpp(
             method=MockMethod(),  # type: ignore[arg-type]
@@ -1159,24 +1159,28 @@ class TestMppRequestTransformHook:
             secret_key="test-secret",
         )
 
+        first = await server.charge(authorization=None, amount="0.50")
+        assert isinstance(first, Challenge)
+        assert first.request["extra"]["hook"] == "none"
+
         credential = make_bound_credential(
             payload={},
-            request={"amount": "500000", "currency": "0xUSD", "recipient": "0xRecipient"},
+            request=first.request,
             realm="api.example.com",
             secret_key="test-secret",
         )
 
         result = await server.charge(authorization=credential.to_authorization(), amount="0.50")
         assert isinstance(result, tuple)
-        assert seen["id"] == credential.challenge.id
+        assert seen == [False, False]
 
     @pytest.mark.asyncio
-    async def test_pay_passes_parsed_credential_to_transform_request(self) -> None:
+    async def test_pay_transform_request_is_deterministic_across_retries(self) -> None:
         @intent(name="charge")
         async def test_intent(credential: Credential, request: dict) -> Receipt:
             return Receipt.success("0x123")
 
-        seen: dict[str, str] = {}
+        seen: list[bool] = []
 
         class MockMethod:
             name = "tempo"
@@ -1186,9 +1190,9 @@ class TestMppRequestTransformHook:
             intents = {"charge": test_intent}
 
             def transform_request(self, request: dict, credential: Credential | None) -> dict:
-                assert credential is not None
-                seen["id"] = credential.challenge.id
-                return request
+                seen.append(credential is not None)
+                marker = "credential" if credential is not None else "none"
+                return {**request, "extra": {"hook": marker}}
 
         server = Mpp(
             method=MockMethod(),  # type: ignore[arg-type]
@@ -1200,16 +1204,29 @@ class TestMppRequestTransformHook:
         async def handler(req: MockRequest, credential: Credential, receipt: Receipt) -> dict:
             return {"data": "paid"}
 
+        challenge_result = await handler(MockRequest())
+        if HAS_STARLETTE:
+            assert StarletteResponse is not None
+            assert isinstance(challenge_result, StarletteResponse)
+            challenge = Challenge.from_www_authenticate(
+                challenge_result.headers["WWW-Authenticate"]
+            )
+        else:
+            assert isinstance(challenge_result, dict)
+            challenge = Challenge.from_www_authenticate(
+                challenge_result["headers"]["WWW-Authenticate"]
+            )
+
         credential = make_bound_credential(
             payload={},
-            request={"amount": "500000", "currency": "0xUSD", "recipient": "0xRecipient"},
+            request=challenge.request,
             realm="api.example.com",
             secret_key="test-secret",
         )
 
         result = await handler(MockRequest(authorization=credential.to_authorization()))
         assert result["data"] == "paid"
-        assert seen["id"] == credential.challenge.id
+        assert seen == [False, False]
 
 
 class TestMalformedEchoedFields:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -576,6 +576,7 @@ class TestPay:
 
         assert my_handler.__name__ == "my_handler"
         assert my_handler.__doc__ == "My handler docstring."
+        assert my_handler.__wrapped__.__name__ == "my_handler"
 
     @pytest.mark.asyncio
     async def test_custom_method_name(self) -> None:


### PR DESCRIPTION
## Summary
- make server secret key resolution fail-closed unless `MPP_SECRET_KEY` or explicit `secret_key` is provided
- remove implicit `.env` key generation/persistence path
- keep `__wrapped__` on payment decorators
- update docs/tests for required secret key behavior

This matches equivalent implementations in mppx and mpp-rs 