### PR TITLE
refactor: consolidate expires into challenge auth-param only

### DIFF
--- a/.changelog/dark-deer-wink.md
+++ b/.changelog/dark-deer-wink.md
@@ -1,0 +1,5 @@
+---
+pympp: minor
+---
+
+Consolidated `expires` from the request body into the challenge-level `expires` auth-param exclusively. Removed `expires` as a field from `ChargeRequest` schema and updated all server, intent, and test code to read expiry from `credential.challenge.expires` instead.

--- a/src/mpp/methods/tempo/intents.py
+++ b/src/mpp/methods/tempo/intents.py
@@ -202,9 +202,13 @@ class ChargeIntent:
         """
         req = ChargeRequest.model_validate(request)
 
-        expires = datetime.fromisoformat(req.expires.replace("Z", "+00:00"))
-        if expires < datetime.now(UTC):
-            raise VerificationError("Request has expired")
+        # Expiry is conveyed via the challenge-level expires auth-param,
+        # not inside the request body.
+        challenge_expires = credential.challenge.expires
+        if challenge_expires:
+            expires = datetime.fromisoformat(challenge_expires.replace("Z", "+00:00"))
+            if expires < datetime.now(UTC):
+                raise VerificationError("Request has expired")
 
         payload_data = credential.payload
         if not isinstance(payload_data, dict) or "type" not in payload_data:

--- a/src/mpp/methods/tempo/schemas.py
+++ b/src/mpp/methods/tempo/schemas.py
@@ -20,12 +20,13 @@ class ChargeRequest(BaseModel):
     """Request schema for the charge intent.
 
     Follows the IETF Payment Authentication Scheme spec for Tempo method.
+    Expiry is conveyed exclusively via the challenge-level ``expires``
+    auth-param, not inside the request body.
     """
 
     amount: str
     currency: Annotated[str, Field(pattern=r"^0x[a-fA-F0-9]+$")]
     recipient: Annotated[str, Field(pattern=r"^0x[a-fA-F0-9]+$")]
-    expires: str
     description: str | None = None
     externalId: str | None = None
     methodDetails: MethodDetails = Field(default_factory=MethodDetails)

--- a/src/mpp/server/mpp.py
+++ b/src/mpp/server/mpp.py
@@ -19,7 +19,6 @@ if TYPE_CHECKING:
 
 R = TypeVar("R")
 
-DEFAULT_EXPIRY_SECONDS = 300
 DEFAULT_DECIMALS = 6
 
 
@@ -144,7 +143,8 @@ class Mpp:
                 Automatically converted to base units (6 decimals for pathUSD).
             currency: Override the method's default currency.
             recipient: Override the method's default recipient.
-            expires: Challenge expiration (ISO 8601). Defaults to now + 5 minutes.
+            expires: Challenge expiration as auth-param (ISO 8601).
+                Defaults to now + 5 minutes. Not included in the request body.
             description: Optional human-readable description.
             memo: Optional 32-byte memo (hex string) for transferWithMemo.
             fee_payer: Whether to use a fee payer for gas sponsorship.
@@ -164,9 +164,6 @@ class Mpp:
         if not resolved_recipient:
             raise ValueError("recipient must be set on the method or passed to charge()")
 
-        if expires is None:
-            expires = (datetime.now(UTC) + timedelta(seconds=DEFAULT_EXPIRY_SECONDS)).isoformat()
-
         decimals = getattr(self.method, "decimals", DEFAULT_DECIMALS)
         base_amount = str(parse_units(amount, decimals))
 
@@ -174,7 +171,6 @@ class Mpp:
             "amount": base_amount,
             "currency": resolved_currency,
             "recipient": resolved_recipient,
-            "expires": expires,
         }
 
         # Optional server-provided metadata that will be echoed back by the client
@@ -208,6 +204,7 @@ class Mpp:
             secret_key=self.secret_key,
             method=self.method.name,
             description=description,
+            expires=expires,
         )
 
     def pay(
@@ -275,17 +272,15 @@ class Mpp:
                 decimals = getattr(self.method, "decimals", DEFAULT_DECIMALS)
                 base_amount = str(parse_units(amount, decimals))
 
-                expires: str | None = None
+                challenge_expires: str | None = None
                 if expires_in is not None:
-                    expires = (datetime.now(UTC) + expires_in).isoformat()
+                    challenge_expires = (datetime.now(UTC) + expires_in).isoformat()
 
                 request: dict[str, Any] = {
                     "amount": base_amount,
                     "currency": resolved_currency,
                     "recipient": resolved_recipient,
                 }
-                if expires is not None:
-                    request["expires"] = expires
 
                 if extra is not None:
                     if any(
@@ -314,6 +309,7 @@ class Mpp:
                     secret_key=self.secret_key,
                     method=self.method.name,
                     description=description,
+                    expires=challenge_expires,
                 )
 
             return wrap_payment_handler(handler, _verify, lambda: self.realm)

--- a/src/mpp/server/verify.py
+++ b/src/mpp/server/verify.py
@@ -25,6 +25,7 @@ async def verify_or_challenge(
     method: str | None = None,
     description: str | None = None,
     meta: dict[str, str] | None = None,
+    expires: str | None = None,
 ) -> Challenge | tuple[Credential, Receipt]:
     """Verify a payment credential or generate a new challenge.
 
@@ -47,6 +48,7 @@ async def verify_or_challenge(
             Enables stateless challenge verification by computing challenge IDs
             as HMAC-SHA256 over the challenge parameters.
         method: The payment method name (defaults to "tempo").
+        expires: Challenge expiration (ISO 8601). Defaults to now + 5 minutes.
 
     Returns:
         If no valid Authorization header:
@@ -80,7 +82,7 @@ async def verify_or_challenge(
 
     def new_challenge() -> Challenge:
         return _create_challenge(
-            method_name, intent.name, request, realm, secret_key, description, meta
+            method_name, intent.name, request, realm, secret_key, description, meta, expires
         )
 
     if authorization is None:
@@ -121,10 +123,9 @@ async def verify_or_challenge(
     if echo.realm != realm or echo.method != method_name or echo.intent != intent.name:
         return new_challenge()
 
-    # Assert echoed request matches server's current request (exclude dynamic expires)
-    echo_req_comparable = {k: v for k, v in echo_request.items() if k != "expires"}
-    server_req_comparable = {k: v for k, v in request.items() if k != "expires"}
-    if echo_req_comparable != server_req_comparable:
+    # Assert echoed request matches server's current request.
+    # expires is a challenge-level auth-param, not in the request body.
+    if echo_request != request:
         return new_challenge()
 
     if echo_opaque != meta:
@@ -142,11 +143,7 @@ async def verify_or_challenge(
     # Verify the echoed request parameters match this endpoint's expected
     # request to prevent cross-endpoint replay when two endpoints share
     # the same intent name but differ in amount, recipient, or currency.
-    # Compare only the fields present in the server's expected request
-    # (excluding "expires" which is generated per-challenge).
     for key, value in request.items():
-        if key == "expires":
-            continue
         if echo_request.get(key) != value:
             return new_challenge()
 
@@ -161,14 +158,6 @@ async def verify_or_challenge(
     if expires_dt < datetime.now(UTC):
         return new_challenge()
 
-    # Ensure request dict includes "expires" for intent.verify().
-    # _create_challenge generates expires into a copy, but when
-    # verification succeeds we skip that path.  Use the HMAC-bound
-    # expires from the echoed challenge so the intent sees the same
-    # value the client committed to.
-    if "expires" not in request and echo.expires:
-        request = {**request, "expires": echo.expires}
-
     receipt: Receipt = await intent.verify(credential, request)
 
     return (credential, receipt)
@@ -182,18 +171,16 @@ def _create_challenge(
     secret_key: str,
     description: str | None = None,
     meta: dict[str, str] | None = None,
+    expires: str | None = None,
 ) -> Challenge:
-    """Create a new payment challenge with HMAC-bound ID."""
-    if "expires" not in request:
-        expires_dt = datetime.now(UTC) + timedelta(minutes=DEFAULT_EXPIRES_MINUTES)
-        expires_str = expires_dt.isoformat().replace("+00:00", "Z")
-        request = {**request, "expires": expires_str}
+    """Create a new payment challenge with HMAC-bound ID.
 
-    # Guard against non-string values that would cause a TypeError in
-    # generate_challenge_id().
-    expires = request.get("expires")
-    if not isinstance(expires, str):
-        expires = None
+    ``expires`` is a challenge-level auth-param (not part of the request body).
+    If not provided, defaults to 5 minutes from now.
+    """
+    if expires is None:
+        expires_dt = datetime.now(UTC) + timedelta(minutes=DEFAULT_EXPIRES_MINUTES)
+        expires = expires_dt.isoformat().replace("+00:00", "Z")
 
     return Challenge.create(
         secret_key=secret_key,

--- a/src/mpp/server/verify.py
+++ b/src/mpp/server/verify.py
@@ -178,6 +178,11 @@ def _create_challenge(
     ``expires`` is a challenge-level auth-param (not part of the request body).
     If not provided, defaults to 5 minutes from now.
     """
+    # Runtime guard: untyped callers may pass a non-string expires value.
+    # Fall back to a generated default instead of raising during HMAC input join.
+    if expires is not None and not isinstance(expires, str):
+        expires = None
+
     if expires is None:
         expires_dt = datetime.now(UTC) + timedelta(minutes=DEFAULT_EXPIRES_MINUTES)
         expires = expires_dt.isoformat().replace("+00:00", "Z")

--- a/tests/test_mpp_create.py
+++ b/tests/test_mpp_create.py
@@ -122,7 +122,7 @@ class TestMppCharge:
         assert result.request["amount"] == "500000"
         assert result.request["currency"] == "0x20c0000000000000000000000000000000000000"
         assert result.request["recipient"] == "0x742d35Cc6634c0532925a3b844bC9e7595F8fE00"
-        assert "expires" in result.request
+        assert result.expires is not None  # expires is a challenge-level auth-param
 
     @pytest.mark.asyncio
     async def test_charge_auto_expires_5_minutes(self) -> None:
@@ -140,7 +140,8 @@ class TestMppCharge:
         after = datetime.now(UTC)
 
         assert isinstance(result, Challenge)
-        expires = datetime.fromisoformat(result.request["expires"])
+        assert result.expires is not None
+        expires = datetime.fromisoformat(result.expires)
         assert expires > before + timedelta(minutes=4, seconds=59)
         assert expires < after + timedelta(minutes=5, seconds=1)
 
@@ -158,7 +159,7 @@ class TestMppCharge:
         exp = "2030-01-20T12:00:00+00:00"
         result = await srv.charge(authorization=None, amount="1.00", expires=exp)
         assert isinstance(result, Challenge)
-        assert result.request["expires"] == exp
+        assert result.expires == exp
 
     @pytest.mark.asyncio
     async def test_charge_amount_conversion(self) -> None:

--- a/tests/test_mpp_create.py
+++ b/tests/test_mpp_create.py
@@ -162,6 +162,28 @@ class TestMppCharge:
         assert result.expires == exp
 
     @pytest.mark.asyncio
+    async def test_charge_non_string_expires_falls_back_to_default(self) -> None:
+        """Non-string runtime expires values should not crash challenge creation."""
+        srv = Mpp.create(
+            method=tempo(
+                currency="0x20c0000000000000000000000000000000000000",
+                recipient="0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
+                intents={"charge": ChargeIntent()},
+            ),
+            realm="test.com",
+            secret_key="test-secret",
+        )
+
+        result = await srv.charge(
+            authorization=None,
+            amount="1.00",
+            expires=datetime.now(UTC),  # type: ignore[arg-type]
+        )
+
+        assert isinstance(result, Challenge)
+        assert result.expires is not None
+
+    @pytest.mark.asyncio
     async def test_charge_amount_conversion(self) -> None:
         srv = Mpp.create(
             method=tempo(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -37,7 +37,7 @@ class TestVerifyOrChallenge:
         assert result.method == "tempo"
         assert result.intent == "charge"
         assert result.request["amount"] == "1000"
-        assert "expires" in result.request  # default expires is added
+        assert result.expires is not None  # default expires is a challenge-level auth-param
 
     @pytest.mark.asyncio
     async def test_returns_challenge_when_invalid_scheme(self) -> None:

--- a/tests/test_tempo.py
+++ b/tests/test_tempo.py
@@ -181,8 +181,8 @@ class TestChargeIntent:
     async def test_verify_expired_request(self) -> None:
         """Should reject expired requests."""
         intent = ChargeIntent(rpc_url="https://rpc.test")
-        credential = make_credential(payload={"type": "hash", "hash": "0x123"})
         expired = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
+        credential = make_credential(payload={"type": "hash", "hash": "0x123"}, expires=expired)
 
         with pytest.raises(VerificationError, match="expired"):
             await intent.verify(
@@ -191,7 +191,6 @@ class TestChargeIntent:
                     "amount": "1000",
                     "currency": "0x123",
                     "recipient": "0x456",
-                    "expires": expired,
                 },
             )
 
@@ -199,8 +198,8 @@ class TestChargeIntent:
     async def test_verify_invalid_payload(self) -> None:
         """Should reject invalid credential payload."""
         intent = ChargeIntent(rpc_url="https://rpc.test")
-        credential = make_credential(payload="not-a-dict")  # type: ignore[arg-type]
         future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
+        credential = make_credential(payload="not-a-dict", expires=future)  # type: ignore[arg-type]
 
         with pytest.raises(VerificationError, match="Invalid credential payload"):
             await intent.verify(
@@ -209,7 +208,6 @@ class TestChargeIntent:
                     "amount": "1000",
                     "currency": "0x123",
                     "recipient": "0x456",
-                    "expires": future,
                 },
             )
 
@@ -217,8 +215,8 @@ class TestChargeIntent:
     async def test_verify_unknown_credential_type(self) -> None:
         """Should reject unknown credential types."""
         intent = ChargeIntent(rpc_url="https://rpc.test")
-        credential = make_credential(payload={"type": "unknown"})
         future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
+        credential = make_credential(payload={"type": "unknown"}, expires=future)
 
         with pytest.raises(VerificationError, match="Invalid credential type"):
             await intent.verify(
@@ -227,7 +225,6 @@ class TestChargeIntent:
                     "amount": "1000",
                     "currency": "0x123",
                     "recipient": "0x456",
-                    "expires": future,
                 },
             )
 
@@ -266,14 +263,13 @@ class TestChargeIntent:
         )
         intent._http_client = mock_client
 
-        credential = make_credential(payload={"type": "hash", "hash": "0xabc123"})
+        credential = make_credential(payload={"type": "hash", "hash": "0xabc123"}, expires=future)
         receipt = await intent.verify(
             credential,
             {
                 "amount": "1000",
                 "currency": "0x20c0000000000000000000000000000000000000",
                 "recipient": "0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
-                "expires": future,
             },
         )
 
@@ -292,7 +288,7 @@ class TestChargeIntent:
         )
         intent._http_client = mock_client
 
-        credential = make_credential(payload={"type": "hash", "hash": "0xabc"})
+        credential = make_credential(payload={"type": "hash", "hash": "0xabc"}, expires=future)
         with pytest.raises(VerificationError, match="Transaction not found"):
             await intent.verify(
                 credential,
@@ -300,7 +296,6 @@ class TestChargeIntent:
                     "amount": "1000",
                     "currency": "0x1234567890123456789012345678901234567890",
                     "recipient": "0x4567890123456789012345678901234567890123",
-                    "expires": future,
                 },
             )
 
@@ -319,7 +314,7 @@ class TestChargeIntent:
         )
         intent._http_client = mock_client
 
-        credential = make_credential(payload={"type": "hash", "hash": "0xabc"})
+        credential = make_credential(payload={"type": "hash", "hash": "0xabc"}, expires=future)
         with pytest.raises(VerificationError, match="Transaction reverted"):
             await intent.verify(
                 credential,
@@ -327,7 +322,6 @@ class TestChargeIntent:
                     "amount": "1000",
                     "currency": "0x1234567890123456789012345678901234567890",
                     "recipient": "0x4567890123456789012345678901234567890123",
-                    "expires": future,
                 },
             )
 
@@ -346,7 +340,7 @@ class TestChargeIntent:
         )
         intent._http_client = mock_client
 
-        credential = make_credential(payload={"type": "hash", "hash": "0xabc"})
+        credential = make_credential(payload={"type": "hash", "hash": "0xabc"}, expires=future)
         with pytest.raises(VerificationError, match="Transfer log"):
             await intent.verify(
                 credential,
@@ -354,7 +348,6 @@ class TestChargeIntent:
                     "amount": "1000",
                     "currency": "0x1234567890123456789012345678901234567890",
                     "recipient": "0x4567890123456789012345678901234567890123",
-                    "expires": future,
                 },
             )
 
@@ -394,6 +387,7 @@ class TestChargeIntent:
 
         credential = make_credential(
             payload={"type": "transaction", "signature": "0xabcdef1234567890"},
+            expires=future,
         )
         receipt = await intent.verify(
             credential,
@@ -401,7 +395,6 @@ class TestChargeIntent:
                 "amount": str(amount),
                 "currency": asset,
                 "recipient": destination,
-                "expires": future,
             },
         )
 
@@ -425,6 +418,7 @@ class TestChargeIntent:
 
         credential = make_credential(
             payload={"type": "transaction", "signature": "0xabcdef1234567890"},
+            expires=future,
         )
         with pytest.raises(VerificationError, match="Transaction submission failed"):
             await intent.verify(
@@ -433,7 +427,6 @@ class TestChargeIntent:
                     "amount": "1000",
                     "currency": "0x1234567890123456789012345678901234567890",
                     "recipient": "0x4567890123456789012345678901234567890123",
-                    "expires": future,
                 },
             )
 
@@ -536,6 +529,7 @@ class TestSponsoredTransfer:
         intent = ChargeIntent(rpc_url="https://rpc.test")
         credential = make_credential(
             payload={"type": "transaction", "signature": "0x76abcdef"},
+            expires=future,
         )
 
         receipt = await intent.verify(
@@ -544,7 +538,6 @@ class TestSponsoredTransfer:
                 "amount": "1000000",
                 "currency": "0x20c0000000000000000000000000000000000000",
                 "recipient": "0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
-                "expires": future,
                 "methodDetails": {
                     "feePayer": True,
                     "feePayerUrl": "https://sponsor.test",
@@ -572,6 +565,7 @@ class TestSponsoredTransfer:
         intent = ChargeIntent(rpc_url="https://rpc.test")
         credential = make_credential(
             payload={"type": "transaction", "signature": "0x76abcdef"},
+            expires=future,
         )
 
         with pytest.raises(VerificationError, match="Fee payer signing failed"):
@@ -581,7 +575,6 @@ class TestSponsoredTransfer:
                     "amount": "1000000",
                     "currency": "0x20c0000000000000000000000000000000000000",
                     "recipient": "0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
-                    "expires": future,
                     "methodDetails": {
                         "feePayer": True,
                         "feePayerUrl": "https://sponsor.test",
@@ -693,7 +686,6 @@ class TestCosignAsFeePayer:
             amount="1000000",
             currency="0xDEAD000000000000000000000000000000000000",
             recipient="0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
-            expires="2030-01-20T12:00:00Z",
         )
 
         with pytest.raises(VerificationError, match="no matching payment call"):
@@ -711,7 +703,6 @@ class TestCosignAsFeePayer:
             amount="9999999",
             currency="0x20c0000000000000000000000000000000000000",
             recipient="0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
-            expires="2030-01-20T12:00:00Z",
         )
 
         with pytest.raises(VerificationError, match="no matching payment call"):
@@ -729,7 +720,6 @@ class TestCosignAsFeePayer:
             amount="1000000",
             currency="0x20c0000000000000000000000000000000000000",
             recipient="0xDEAD000000000000000000000000000000000000",
-            expires="2030-01-20T12:00:00Z",
         )
 
         with pytest.raises(VerificationError, match="no matching payment call"):
@@ -751,7 +741,6 @@ class TestCosignAsFeePayer:
             amount="1000000",
             currency="0x20c0000000000000000000000000000000000000",
             recipient="0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
-            expires="2030-01-20T12:00:00Z",
         )
 
         result = intent._cosign_as_fee_payer(raw_tx, request.currency, request=request)
@@ -828,7 +817,6 @@ class TestValidateTransactionPayload:
             amount="1000000",
             currency="0x20c0000000000000000000000000000000000000",
             recipient="0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
-            expires="2030-01-20T12:00:00Z",
         )
         sig = self._build_0x78_envelope()
         # Should not raise
@@ -841,7 +829,6 @@ class TestValidateTransactionPayload:
             amount="9999999",
             currency="0x20c0000000000000000000000000000000000000",
             recipient="0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
-            expires="2030-01-20T12:00:00Z",
         )
         sig = self._build_0x78_envelope(amount=1000000)
         with pytest.raises(VerificationError, match="no matching payment call"):
@@ -854,7 +841,6 @@ class TestValidateTransactionPayload:
             amount="1000000",
             currency="0xDEAD000000000000000000000000000000000000",
             recipient="0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
-            expires="2030-01-20T12:00:00Z",
         )
         sig = self._build_0x78_envelope()
         with pytest.raises(VerificationError, match="no matching payment call"):
@@ -867,7 +853,6 @@ class TestValidateTransactionPayload:
             amount="1000000",
             currency="0x20c0000000000000000000000000000000000000",
             recipient="0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
-            expires="2030-01-20T12:00:00Z",
         )
         sig = self._build_0x76_tx()
         # Should not raise
@@ -880,7 +865,6 @@ class TestValidateTransactionPayload:
             amount="1000000",
             currency="0x20c0000000000000000000000000000000000000",
             recipient="0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
-            expires="2030-01-20T12:00:00Z",
         )
         # 0x02 prefix — should silently skip (not raise)
         intent._validate_transaction_payload("0x02abcdef", request)
@@ -919,7 +903,6 @@ class TestSchemas:
             amount="1000",
             currency="0x20c0000000000000000000000000000000000000",
             recipient="0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
-            expires="2030-01-20T12:00:00Z",
         )
         assert req.amount == "1000"
         assert req.methodDetails.feePayer is False
@@ -931,7 +914,6 @@ class TestSchemas:
             amount="1000",
             currency="0x20c0000000000000000000000000000000000000",
             recipient="0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
-            expires="2030-01-20T12:00:00Z",
             methodDetails=MethodDetails(
                 feePayer=True,
                 feePayerUrl="https://sponsor.test",
@@ -958,7 +940,6 @@ class TestSchemas:
             amount="1000",
             currency="0x20c0000000000000000000000000000000000000",
             recipient="0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
-            expires="2030-01-20T12:00:00Z",
             description="Payment for API access",
         )
         assert req.description == "Payment for API access"
@@ -969,7 +950,6 @@ class TestSchemas:
             amount="1000",
             currency="0x20c0000000000000000000000000000000000000",
             recipient="0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
-            expires="2030-01-20T12:00:00Z",
             externalId="order-12345",
         )
         assert req.externalId == "order-12345"
@@ -980,7 +960,6 @@ class TestSchemas:
             amount="1000",
             currency="0x20c0000000000000000000000000000000000000",
             recipient="0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
-            expires="2030-01-20T12:00:00Z",
         )
         assert req.description is None
         assert req.externalId is None
@@ -991,7 +970,6 @@ class TestSchemas:
             amount="1000",
             currency="0x20c0000000000000000000000000000000000000",
             recipient="0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
-            expires="2030-01-20T12:00:00Z",
             description="Test payment",
             externalId="ext-001",
         )
@@ -1265,7 +1243,6 @@ class TestMatchTransferCalldataWithMemo:
             amount=str(self.AMOUNT),
             currency=self.CURRENCY,
             recipient=self.RECIPIENT,
-            expires="2030-01-20T12:00:00Z",
             methodDetails=MethodDetails(memo=memo),
         )
 
@@ -1362,7 +1339,6 @@ class TestVerifyTransferLogsWithMemo:
             amount=str(self.AMOUNT),
             currency=self.CURRENCY,
             recipient=self.RECIPIENT,
-            expires="2030-01-20T12:00:00Z",
             methodDetails=MethodDetails(memo=memo),
         )
 
@@ -1474,7 +1450,6 @@ class TestValidateTransactionPayload0x76:
             amount="1000000",
             currency=self.CURRENCY,
             recipient=self.RECIPIENT,
-            expires="2030-01-20T12:00:00Z",
         )
 
     def test_non_tempo_tx_returns_silently(self) -> None:


### PR DESCRIPTION
## Summary

Remove `expires` from the `ChargeRequest` schema (request body). Expiry is now conveyed exclusively via the challenge-level `expires` auth-param in `WWW-Authenticate`, eliminating the ambiguity of having it in two places.

Mirrors the mppx change in [wevm/mppx#161](https://github.com/wevm/mppx/pull/161).

## Motivation

`expires` was duplicated in two places — inside the request body AND as a challenge auth-param. This created ambiguity about which value is authoritative. Expiry is a property of the challenge lifecycle, not the payment request content. The request describes *what* to pay; the challenge controls *how long* you have to pay it.

## Changes

- **`schemas.py`**: Remove `expires` field from `ChargeRequest` model
- **`verify.py`**: `_create_challenge()` accepts `expires` as a parameter (defaults to 5 minutes); no longer reads/writes expires in the request dict
- **`intents.py`**: `ChargeIntent.verify()` reads expires from `credential.challenge.expires` instead of `request.expires`
- **`mpp.py`**: `Mpp.charge()` and `Mpp.pay()` pass `expires` to `verify_or_challenge()` as a challenge-level parameter instead of embedding it in the request dict
- **Tests**: Updated to reflect expires at challenge level, not request body

## Spec

Aligns with [tempoxyz/mpp-specs#165](https://github.com/tempoxyz/mpp-specs/pull/165).