### PR TITLE
fix: remove purl references and update stale secret_key docs

### DIFF
--- a/.changelog/keen-slugs-slide.md
+++ b/.changelog/keen-slugs-slide.md
@@ -1,0 +1,5 @@
+---
+pympp: patch
+---
+
+Updated `examples/api-server/README.md` to replace references to the external `purl` tool with the `pympp` client (`python -m mpp.fetch`) and corrected the `secret_key` documentation to reflect that it is read from the `MPP_SECRET_KEY` env var rather than auto-generated.

--- a/examples/api-server/README.md
+++ b/examples/api-server/README.md
@@ -12,7 +12,6 @@ A FastAPI server with payment-protected endpoints using the Machine Payments Pro
 
 - Python 3.10+
 - [uv](https://docs.astral.sh/uv/) (recommended) or pip
-- [purl](https://purl.tempo.xyz/) for testing paid endpoints
 
 ## Installation
 
@@ -47,10 +46,10 @@ curl http://localhost:8000/free
 # {"message":"This content is free!"}
 ```
 
-**Paid endpoint** (use purl to handle payment automatically):
+**Paid endpoint** (use the pympp client to handle payment automatically):
 
 ```bash
-purl http://localhost:8000/paid
+python -m mpp.fetch http://localhost:8000/paid
 # {"message":"This is paid content!","payer":"0x...","tx":"0x..."}
 ```
 
@@ -77,7 +76,7 @@ server = Mpp.create(
 
 `Mpp.create()` sets up the payment handler with smart defaults:
 - **realm** auto-detected from environment (`MPP_REALM`, `VERCEL_URL`, etc.)
-- **secret_key** auto-generated and persisted to `.env`
+- **secret_key** read from `MPP_SECRET_KEY` env var (or passed explicitly)
 - **currency** and **recipient** configured once on the method
 
 ### Charging


### PR DESCRIPTION
Prep for open-sourcing pympp.

- Remove `purl.tempo.xyz` prerequisite and CLI usage from api-server example (internal tool, not accessible to external users)
- Replace with pympp client command
- Fix stale docs on L80 claiming `secret_key` is "auto-generated and persisted to `.env`" — v0.4.0 removed that behavior; now requires explicit `MPP_SECRET_KEY` env var or `secret_key` param