### PR TITLE
fix: tx hash replay protection for charge intent

### DIFF
--- a/.changelog/mild-crabs-whisper.md
+++ b/.changelog/mild-crabs-whisper.md
@@ -1,0 +1,5 @@
+---
+pympp: patch
+---
+
+Added a pluggable `Store` interface and `MemoryStore` implementation for transaction hash replay protection in `ChargeIntent`. When a store is provided, verified tx hashes are recorded and subsequent attempts to reuse the same hash are rejected with a `VerificationError`.

--- a/src/mpp/__init__.py
+++ b/src/mpp/__init__.py
@@ -399,3 +399,4 @@ class Receipt:
 
 from . import _body_digest as BodyDigest  # noqa: E402
 from . import _expires as Expires  # noqa: E402
+from .store import MemoryStore, Store  # noqa: E402

--- a/src/mpp/methods/tempo/intents.py
+++ b/src/mpp/methods/tempo/intents.py
@@ -14,7 +14,6 @@ import attrs
 
 from mpp import Credential, Receipt
 from mpp.errors import VerificationError
-from mpp.store import Store
 from mpp.methods.tempo._defaults import DEFAULT_FEE_PAYER_URL, PATH_USD, rpc_url_for_chain
 from mpp.methods.tempo.schemas import (
     ChargeRequest,
@@ -22,6 +21,7 @@ from mpp.methods.tempo.schemas import (
     HashCredentialPayload,
     TransactionCredentialPayload,
 )
+from mpp.store import Store
 
 if TYPE_CHECKING:
     import httpx
@@ -153,7 +153,7 @@ class ChargeIntent:
         self._http_client = http_client
         self._owns_client = http_client is None
         self._timeout = timeout
-        self.store = store
+        self._store = store
 
     @property
     def fee_payer(self) -> TempoAccount | None:
@@ -239,8 +239,8 @@ class ChargeIntent:
         request: ChargeRequest,
     ) -> Receipt:
         """Verify a credential with a transaction hash."""
-        if self.store is not None:
-            seen = await self.store.get(f"mpp:charge:{payload.hash}")
+        if self._store is not None:
+            seen = await self._store.get(f"mpp:charge:{payload.hash}")
             if seen is not None:
                 raise VerificationError("Transaction hash has already been used.")
 
@@ -274,8 +274,8 @@ class ChargeIntent:
                 "Transaction must contain a Transfer log matching request parameters"
             )
 
-        if self.store is not None:
-            await self.store.put(f"mpp:charge:{payload.hash}", time.time())
+        if self._store is not None:
+            await self._store.put(f"mpp:charge:{payload.hash}", True)
 
         return Receipt.success(payload.hash)
 

--- a/src/mpp/methods/tempo/intents.py
+++ b/src/mpp/methods/tempo/intents.py
@@ -14,6 +14,7 @@ import attrs
 
 from mpp import Credential, Receipt
 from mpp.errors import VerificationError
+from mpp.store import Store
 from mpp.methods.tempo._defaults import DEFAULT_FEE_PAYER_URL, PATH_USD, rpc_url_for_chain
 from mpp.methods.tempo.schemas import (
     ChargeRequest,
@@ -129,6 +130,7 @@ class ChargeIntent:
         rpc_url: str | None = None,
         http_client: httpx.AsyncClient | None = None,
         timeout: float = DEFAULT_TIMEOUT,
+        store: Store | None = None,
     ) -> None:
         """Initialize the charge intent.
 
@@ -140,6 +142,9 @@ class ChargeIntent:
             http_client: Optional httpx client for making RPC calls.
                 If provided, the caller is responsible for closing it.
             timeout: Request timeout in seconds (default: 30).
+            store: Optional key-value store for tx hash replay protection.
+                When provided, each verified hash is recorded and subsequent
+                attempts to reuse it are rejected.
         """
         if rpc_url is None and chain_id is not None:
             rpc_url = rpc_url_for_chain(chain_id)
@@ -148,6 +153,7 @@ class ChargeIntent:
         self._http_client = http_client
         self._owns_client = http_client is None
         self._timeout = timeout
+        self.store = store
 
     @property
     def fee_payer(self) -> TempoAccount | None:
@@ -233,6 +239,11 @@ class ChargeIntent:
         request: ChargeRequest,
     ) -> Receipt:
         """Verify a credential with a transaction hash."""
+        if self.store is not None:
+            seen = await self.store.get(f"mpp:charge:{payload.hash}")
+            if seen is not None:
+                raise VerificationError("Transaction hash has already been used.")
+
         client = await self._get_client()
 
         rpc_url = self._get_rpc_url()
@@ -262,6 +273,9 @@ class ChargeIntent:
             raise VerificationError(
                 "Transaction must contain a Transfer log matching request parameters"
             )
+
+        if self.store is not None:
+            await self.store.put(f"mpp:charge:{payload.hash}", time.time())
 
         return Receipt.success(payload.hash)
 

--- a/src/mpp/store.py
+++ b/src/mpp/store.py
@@ -1,0 +1,33 @@
+"""Pluggable key-value store for replay protection.
+
+Modeled after Cloudflare KV's API (get/put/delete).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class Store(Protocol):
+    """Async key-value store interface."""
+
+    async def get(self, key: str) -> Any | None: ...
+    async def put(self, key: str, value: Any) -> None: ...
+    async def delete(self, key: str) -> None: ...
+
+
+class MemoryStore:
+    """In-memory store backed by a dict. For development/testing."""
+
+    def __init__(self) -> None:
+        self._data: dict[str, Any] = {}
+
+    async def get(self, key: str) -> Any | None:
+        return self._data.get(key)
+
+    async def put(self, key: str, value: Any) -> None:
+        self._data[key] = value
+
+    async def delete(self, key: str) -> None:
+        self._data.pop(key, None)

--- a/src/mpp/store.py
+++ b/src/mpp/store.py
@@ -5,10 +5,9 @@ Modeled after Cloudflare KV's API (get/put/delete).
 
 from __future__ import annotations
 
-from typing import Any, Protocol, runtime_checkable
+from typing import Any, Protocol
 
 
-@runtime_checkable
 class Store(Protocol):
     """Async key-value store interface."""
 

--- a/tests/test_tempo.py
+++ b/tests/test_tempo.py
@@ -277,6 +277,160 @@ class TestChargeIntent:
         assert receipt.reference == "0xabc123"
 
     @pytest.mark.asyncio
+    async def test_verify_hash_rejects_replayed_hash(self) -> None:
+        """Should reject a replayed transaction hash when store is configured."""
+        from mpp.store import MemoryStore
+
+        future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
+        store = MemoryStore()
+        intent = ChargeIntent(rpc_url="https://rpc.test", store=store)
+
+        mock_client = AsyncMock()
+        transfer_topic = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
+        mock_client.post = AsyncMock(
+            return_value=mock_response(
+                200,
+                {
+                    "jsonrpc": "2.0",
+                    "result": {
+                        "status": "0x1",
+                        "logs": [
+                            {
+                                "address": "0x20c0000000000000000000000000000000000000",
+                                "topics": [
+                                    transfer_topic,
+                                    "0x0000000000000000000000001234567890123456789012345678901234567890",
+                                    "0x000000000000000000000000742d35cc6634c0532925a3b844bc9e7595f8fe00",
+                                ],
+                                "data": "0x"
+                                + "00000000000000000000000000000000"
+                                + "00000000000000000000000000000000000003e8",
+                            }
+                        ],
+                    },
+                    "id": 1,
+                },
+            )
+        )
+        intent._http_client = mock_client
+
+        credential = make_credential(payload={"type": "hash", "hash": "0xabc123"}, expires=future)
+        request = {
+            "amount": "1000",
+            "currency": "0x20c0000000000000000000000000000000000000",
+            "recipient": "0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
+        }
+
+        # First verification should succeed
+        receipt = await intent.verify(credential, request)
+        assert receipt.status == "success"
+
+        # Second verification with same hash should fail
+        with pytest.raises(VerificationError, match="Transaction hash has already been used"):
+            await intent.verify(credential, request)
+
+    @pytest.mark.asyncio
+    async def test_verify_hash_allows_replay_without_store(self) -> None:
+        """Should allow same hash twice when no store is configured."""
+        future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
+        intent = ChargeIntent(rpc_url="https://rpc.test")  # no store
+
+        mock_client = AsyncMock()
+        transfer_topic = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
+        mock_client.post = AsyncMock(
+            return_value=mock_response(
+                200,
+                {
+                    "jsonrpc": "2.0",
+                    "result": {
+                        "status": "0x1",
+                        "logs": [
+                            {
+                                "address": "0x20c0000000000000000000000000000000000000",
+                                "topics": [
+                                    transfer_topic,
+                                    "0x0000000000000000000000001234567890123456789012345678901234567890",
+                                    "0x000000000000000000000000742d35cc6634c0532925a3b844bc9e7595f8fe00",
+                                ],
+                                "data": "0x"
+                                + "00000000000000000000000000000000"
+                                + "00000000000000000000000000000000000003e8",
+                            }
+                        ],
+                    },
+                    "id": 1,
+                },
+            )
+        )
+        intent._http_client = mock_client
+
+        credential = make_credential(payload={"type": "hash", "hash": "0xabc123"}, expires=future)
+        request = {
+            "amount": "1000",
+            "currency": "0x20c0000000000000000000000000000000000000",
+            "recipient": "0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
+        }
+
+        # Both should succeed without store
+        receipt1 = await intent.verify(credential, request)
+        assert receipt1.status == "success"
+        receipt2 = await intent.verify(credential, request)
+        assert receipt2.status == "success"
+
+    @pytest.mark.asyncio
+    async def test_verify_hash_store_records_on_success(self) -> None:
+        """Should record hash in store after successful verification."""
+        from mpp.store import MemoryStore
+
+        future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
+        store = MemoryStore()
+        intent = ChargeIntent(rpc_url="https://rpc.test", store=store)
+
+        mock_client = AsyncMock()
+        transfer_topic = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
+        mock_client.post = AsyncMock(
+            return_value=mock_response(
+                200,
+                {
+                    "jsonrpc": "2.0",
+                    "result": {
+                        "status": "0x1",
+                        "logs": [
+                            {
+                                "address": "0x20c0000000000000000000000000000000000000",
+                                "topics": [
+                                    transfer_topic,
+                                    "0x0000000000000000000000001234567890123456789012345678901234567890",
+                                    "0x000000000000000000000000742d35cc6634c0532925a3b844bc9e7595f8fe00",
+                                ],
+                                "data": "0x"
+                                + "00000000000000000000000000000000"
+                                + "00000000000000000000000000000000000003e8",
+                            }
+                        ],
+                    },
+                    "id": 1,
+                },
+            )
+        )
+        intent._http_client = mock_client
+
+        credential = make_credential(payload={"type": "hash", "hash": "0xabc123"}, expires=future)
+        request = {
+            "amount": "1000",
+            "currency": "0x20c0000000000000000000000000000000000000",
+            "recipient": "0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
+        }
+
+        # Before verification, store should be empty
+        assert await store.get("mpp:charge:0xabc123") is None
+
+        await intent.verify(credential, request)
+
+        # After verification, hash should be recorded
+        assert await store.get("mpp:charge:0xabc123") is not None
+
+    @pytest.mark.asyncio
     async def test_verify_hash_tx_not_found(self) -> None:
         """Should reject when transaction not found."""
         future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()


### PR DESCRIPTION
## Summary

Fixes transaction hash replay vulnerability in `ChargeIntent`. A malicious client could pay once and reuse the same tx hash across multiple challenges to get free service.

## Changes

- Created `mpp.store` module with `Store` protocol and `MemoryStore`
- Added optional `store` parameter to `ChargeIntent.__init__`
- In `_verify_hash`: checks store for previously-seen hash before RPC verification; records hash after success
- Exported `Store` and `MemoryStore` from `mpp`
- Added 3 tests: replay rejection, backward compat without store, store recording

## Usage

```python
from mpp import MemoryStore
from mpp.methods.tempo import ChargeIntent

intent = ChargeIntent(chain_id=42431, store=MemoryStore())
```

Store is opt-in — existing usage without a store is unaffected.