### PR TITLE
fix: raise DEFAULT_GAS_LIMIT to 1M for Tempo AA transactions

### DIFF
--- a/.changelog/quick-crabs-shout.md
+++ b/.changelog/quick-crabs-shout.md
@@ -1,0 +1,5 @@
+---
+pympp: patch
+---
+
+Raised `DEFAULT_GAS_LIMIT` from 100,000 to 1,000,000 for Tempo AA (type-0x76) transactions to account for their higher intrinsic gas cost (~270k for a single TIP-20 transfer).

--- a/src/mpp/methods/tempo/client.py
+++ b/src/mpp/methods/tempo/client.py
@@ -24,7 +24,10 @@ if TYPE_CHECKING:
     from mpp.server.intent import Intent
 
 
-DEFAULT_GAS_LIMIT = 100_000
+# Tempo AA (type-0x76) transactions have higher intrinsic gas than legacy txs
+# (~270k for a single TIP-20 transfer). A safe static limit avoids the need for
+# AA-aware eth_estimateGas calls, matching the approach used by mpp-rs.
+DEFAULT_GAS_LIMIT = 1_000_000
 EXPIRING_NONCE_KEY = (1 << 256) - 1  # U256::MAX
 FEE_PAYER_VALID_BEFORE_SECS = 25
 


### PR DESCRIPTION
## Problem

Payment settlement failing with the following in some mainnet transactions:
```
Insufficient gas for AA transaction: gas limit 100000 is less than intrinsic gas 271976
```

## Cause

Tempo type-0x76 (AA) transactions have ~270k intrinsic gas for a single TIP-20 transfer. The legacy-style `eth_estimateGas` call doesn't send the full AA envelope (`calls`, `feeToken`, `nonceKey`, etc.), so estimation always fails and silently falls back to the hardcoded `DEFAULT_GAS_LIMIT = 100_000` — which is below intrinsic gas.

## Fix

Bump `DEFAULT_GAS_LIMIT` from `100_000` to `1_000_000`, matching the approach used by [mpp-rs](https://github.com/tempoxyz/mpay-rs/blob/main/src/client/tempo/provider.rs#L191).
