### PR TITLE
fix: normalize charge tx hash to lowercase for dedup

### DIFF
--- a/.changelog/atomic-charge-replay.md
+++ b/.changelog/atomic-charge-replay.md
@@ -1,0 +1,5 @@
+---
+pympp: patch
+---
+
+Added atomic `put_if_absent` method to `Store` protocol and `MemoryStore`, replacing the racy `get()`/`put()` pattern for charge replay protection. Normalized transaction hashes to lowercase before dedup to prevent mixed-case bypasses.

--- a/src/mpp/methods/tempo/intents.py
+++ b/src/mpp/methods/tempo/intents.py
@@ -240,9 +240,9 @@ class ChargeIntent:
     ) -> Receipt:
         """Verify a credential with a transaction hash."""
         if self._store is not None:
-            seen = await self._store.get(f"mpp:charge:{payload.hash}")
-            if seen is not None:
-                raise VerificationError("Transaction hash has already been used.")
+            store_key = f"mpp:charge:{payload.hash.lower()}"
+            if not await self._store.put_if_absent(store_key, payload.hash):
+                raise VerificationError("Transaction hash already used")
 
         client = await self._get_client()
 
@@ -273,9 +273,6 @@ class ChargeIntent:
             raise VerificationError(
                 "Transaction must contain a Transfer log matching request parameters"
             )
-
-        if self._store is not None:
-            await self._store.put(f"mpp:charge:{payload.hash}", True)
 
         return Receipt.success(payload.hash)
 

--- a/src/mpp/store.py
+++ b/src/mpp/store.py
@@ -15,6 +15,16 @@ class Store(Protocol):
     async def put(self, key: str, value: Any) -> None: ...
     async def delete(self, key: str) -> None: ...
 
+    async def put_if_absent(self, key: str, value: Any) -> bool:
+        """Store *value* under *key* only if *key* does not already exist.
+
+        Returns ``True`` if the key was new and the write succeeded,
+        ``False`` if the key already existed (duplicate).
+
+        Maps to ``SETNX`` in Redis, conditional put in DynamoDB, etc.
+        """
+        ...
+
 
 class MemoryStore:
     """In-memory store backed by a dict. For development/testing."""
@@ -30,3 +40,9 @@ class MemoryStore:
 
     async def delete(self, key: str) -> None:
         self._data.pop(key, None)
+
+    async def put_if_absent(self, key: str, value: Any) -> bool:
+        if key in self._data:
+            return False
+        self._data[key] = value
+        return True

--- a/tests/test_tempo.py
+++ b/tests/test_tempo.py
@@ -326,7 +326,7 @@ class TestChargeIntent:
         assert receipt.status == "success"
 
         # Second verification with same hash should fail
-        with pytest.raises(VerificationError, match="Transaction hash has already been used"):
+        with pytest.raises(VerificationError, match="Transaction hash already used"):
             await intent.verify(credential, request)
 
     @pytest.mark.asyncio


### PR DESCRIPTION
Normalizes tx hashes to lowercase before store key lookup and write, preventing replay bypasses via mixed-case hashes.