### PR TITLE
feat: add testnet faucet helper and connection check for Tempo Moderato

### DIFF
--- a/src/mpp/methods/tempo/__init__.py
+++ b/src/mpp/methods/tempo/__init__.py
@@ -38,3 +38,11 @@ from mpp.methods.tempo._defaults import (
 from mpp.methods.tempo.account import TempoAccount
 from mpp.methods.tempo.client import TempoMethod, TransactionError, tempo
 from mpp.methods.tempo.intents import ChargeIntent
+from mpp.methods.tempo.testnet import (
+    TEMPO_MAINNET_CHAIN_ID,
+    TEMPO_MAINNET_RPC,
+    TEMPO_TESTNET_CHAIN_ID,
+    TEMPO_TESTNET_RPC,
+    check_connection,
+    fund_testnet_address,
+)

--- a/src/mpp/methods/tempo/__init__.py
+++ b/src/mpp/methods/tempo/__init__.py
@@ -39,10 +39,6 @@ from mpp.methods.tempo.account import TempoAccount
 from mpp.methods.tempo.client import TempoMethod, TransactionError, tempo
 from mpp.methods.tempo.intents import ChargeIntent
 from mpp.methods.tempo.testnet import (
-    TEMPO_MAINNET_CHAIN_ID,
-    TEMPO_MAINNET_RPC,
-    TEMPO_TESTNET_CHAIN_ID,
-    TEMPO_TESTNET_RPC,
     check_connection,
     fund_testnet_address,
 )

--- a/src/mpp/methods/tempo/testnet.py
+++ b/src/mpp/methods/tempo/testnet.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 
 import httpx
 
-TEMPO_TESTNET_RPC = "https://rpc.moderato.tempo.xyz"
-TEMPO_MAINNET_RPC = "https://rpc.tempo.xyz"
-TEMPO_TESTNET_CHAIN_ID = 42431
-TEMPO_MAINNET_CHAIN_ID = 4217
+from mpp.methods.tempo._defaults import CHAIN_ID, TESTNET_RPC_URL, rpc_url_for_chain
 
 
-async def fund_testnet_address(address: str, rpc_url: str = TEMPO_TESTNET_RPC) -> bool:
+async def fund_testnet_address(
+    address: str,
+    rpc_url: str = TESTNET_RPC_URL,
+) -> bool:
     """Fund an address via the Tempo testnet faucet RPC method.
 
     Uses the ``tempo_fundAddress`` JSON-RPC method available on the Moderato
@@ -23,6 +23,8 @@ async def fund_testnet_address(address: str, rpc_url: str = TEMPO_TESTNET_RPC) -
         ``True`` if the faucet request was accepted, ``False`` otherwise.
 
     Example::
+
+        from mpp.methods.tempo.testnet import fund_testnet_address
 
         funded = await fund_testnet_address("0xYourAddress")
 
@@ -44,8 +46,11 @@ async def fund_testnet_address(address: str, rpc_url: str = TEMPO_TESTNET_RPC) -
             return False
 
 
-async def check_connection(rpc_url: str = TEMPO_MAINNET_RPC) -> dict:
+async def check_connection(chain_id: int = CHAIN_ID) -> dict:
     """Check connectivity to a Tempo RPC endpoint.
+
+    Uses :func:`mpp.methods.tempo._defaults.rpc_url_for_chain` to resolve
+    the RPC URL for known chain IDs (4217 mainnet, 42431 Moderato testnet).
 
     Returns a dict with ``connected`` (bool), ``chain_id`` (int), and
     ``block`` (int) on success, or ``connected=False`` with an ``error``
@@ -53,17 +58,25 @@ async def check_connection(rpc_url: str = TEMPO_MAINNET_RPC) -> dict:
 
     Example::
 
+        from mpp.methods.tempo.testnet import check_connection
+        from mpp.methods.tempo import TESTNET_CHAIN_ID
+
+        # mainnet
         info = await check_connection()
         # {"connected": True, "chain_id": 4217, "block": 1234567}
+
+        # testnet
+        info = await check_connection(chain_id=TESTNET_CHAIN_ID)
     """
-    payload = {"jsonrpc": "2.0", "method": "eth_blockNumber", "params": [], "id": 1}
+    rpc_url = rpc_url_for_chain(chain_id)
+    block_payload = {"jsonrpc": "2.0", "method": "eth_blockNumber", "params": [], "id": 1}
     chain_payload = {"jsonrpc": "2.0", "method": "eth_chainId", "params": [], "id": 2}
     async with httpx.AsyncClient() as client:
         try:
-            r1 = await client.post(rpc_url, json=payload, timeout=10.0)
+            r1 = await client.post(rpc_url, json=block_payload, timeout=10.0)
             r2 = await client.post(rpc_url, json=chain_payload, timeout=10.0)
             block = int(r1.json()["result"], 16)
-            chain_id = int(r2.json()["result"], 16)
-            return {"connected": True, "chain_id": chain_id, "block": block}
+            detected_chain_id = int(r2.json()["result"], 16)
+            return {"connected": True, "chain_id": detected_chain_id, "block": block}
         except Exception as e:
             return {"connected": False, "error": str(e)}

--- a/src/mpp/methods/tempo/testnet.py
+++ b/src/mpp/methods/tempo/testnet.py
@@ -1,0 +1,69 @@
+"""Tempo testnet utilities."""
+from __future__ import annotations
+
+import httpx
+
+TEMPO_TESTNET_RPC = "https://rpc.moderato.tempo.xyz"
+TEMPO_MAINNET_RPC = "https://rpc.tempo.xyz"
+TEMPO_TESTNET_CHAIN_ID = 42431
+TEMPO_MAINNET_CHAIN_ID = 4217
+
+
+async def fund_testnet_address(address: str, rpc_url: str = TEMPO_TESTNET_RPC) -> bool:
+    """Fund an address via the Tempo testnet faucet RPC method.
+
+    Uses the ``tempo_fundAddress`` JSON-RPC method available on the Moderato
+    testnet. Mainnet calls will fail — this is intentional.
+
+    Args:
+        address: The EVM address to fund (e.g. ``"0xABCD...1234"``).
+        rpc_url: Testnet RPC URL. Defaults to Moderato testnet.
+
+    Returns:
+        ``True`` if the faucet request was accepted, ``False`` otherwise.
+
+    Example::
+
+        funded = await fund_testnet_address("0xYourAddress")
+
+    Docs: https://docs.tempo.xyz/quickstart/faucet
+    """
+    payload = {
+        "jsonrpc": "2.0",
+        "method": "tempo_fundAddress",
+        "params": [address],
+        "id": 1,
+    }
+    async with httpx.AsyncClient() as client:
+        try:
+            resp = await client.post(rpc_url, json=payload, timeout=10.0)
+            resp.raise_for_status()
+            data = resp.json()
+            return "error" not in data
+        except Exception:
+            return False
+
+
+async def check_connection(rpc_url: str = TEMPO_MAINNET_RPC) -> dict:
+    """Check connectivity to a Tempo RPC endpoint.
+
+    Returns a dict with ``connected`` (bool), ``chain_id`` (int), and
+    ``block`` (int) on success, or ``connected=False`` with an ``error``
+    key on failure.
+
+    Example::
+
+        info = await check_connection()
+        # {"connected": True, "chain_id": 4217, "block": 1234567}
+    """
+    payload = {"jsonrpc": "2.0", "method": "eth_blockNumber", "params": [], "id": 1}
+    chain_payload = {"jsonrpc": "2.0", "method": "eth_chainId", "params": [], "id": 2}
+    async with httpx.AsyncClient() as client:
+        try:
+            r1 = await client.post(rpc_url, json=payload, timeout=10.0)
+            r2 = await client.post(rpc_url, json=chain_payload, timeout=10.0)
+            block = int(r1.json()["result"], 16)
+            chain_id = int(r2.json()["result"], 16)
+            return {"connected": True, "chain_id": chain_id, "block": block}
+        except Exception as e:
+            return {"connected": False, "error": str(e)}

--- a/tests/test_tempo_testnet.py
+++ b/tests/test_tempo_testnet.py
@@ -3,95 +3,77 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from mpp.methods.tempo.testnet import (
-    TEMPO_MAINNET_RPC,
-    TEMPO_TESTNET_RPC,
-    check_connection,
-    fund_testnet_address,
-)
+import pytest
+
+from mpp.methods.tempo._defaults import CHAIN_ID
+from mpp.methods.tempo.testnet import check_connection, fund_testnet_address
 
 
-def _make_response(json_data: dict, status_code: int = 200) -> MagicMock:
-    resp = MagicMock()
-    resp.json.return_value = json_data
-    resp.status_code = status_code
-    resp.raise_for_status = MagicMock()
-    return resp
-
-
+@pytest.mark.asyncio
 async def test_fund_testnet_address_success() -> None:
-    mock_resp = _make_response({"jsonrpc": "2.0", "result": "funded", "id": 1})
+    mock_resp = MagicMock()
+    mock_resp.raise_for_status = MagicMock()
+    mock_resp.json.return_value = {"result": "0x1"}
     mock_client = AsyncMock()
-    mock_client.__aenter__.return_value = mock_client
-    mock_client.__aexit__.return_value = False
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
     mock_client.post = AsyncMock(return_value=mock_resp)
-
     with patch("mpp.methods.tempo.testnet.httpx.AsyncClient", return_value=mock_client):
-        result = await fund_testnet_address("0xABCD1234")
-
+        result = await fund_testnet_address("0xDeadBeef")
     assert result is True
-    mock_client.post.assert_awaited_once()
-    call_kwargs = mock_client.post.call_args
-    assert call_kwargs[0][0] == TEMPO_TESTNET_RPC
-    assert call_kwargs[1]["json"]["method"] == "tempo_fundAddress"
-    assert call_kwargs[1]["json"]["params"] == ["0xABCD1234"]
 
 
-async def test_fund_testnet_address_rpc_error() -> None:
-    error_body = {"jsonrpc": "2.0", "error": {"code": -32000, "message": "fail"}, "id": 1}
-    mock_resp = _make_response(error_body)
+@pytest.mark.asyncio
+async def test_fund_testnet_address_error_response() -> None:
+    mock_resp = MagicMock()
+    mock_resp.raise_for_status = MagicMock()
+    mock_resp.json.return_value = {"error": {"code": -32000, "message": "rate limited"}}
     mock_client = AsyncMock()
-    mock_client.__aenter__.return_value = mock_client
-    mock_client.__aexit__.return_value = False
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
     mock_client.post = AsyncMock(return_value=mock_resp)
-
     with patch("mpp.methods.tempo.testnet.httpx.AsyncClient", return_value=mock_client):
-        result = await fund_testnet_address("0xABCD1234")
-
+        result = await fund_testnet_address("0xDeadBeef")
     assert result is False
 
 
+@pytest.mark.asyncio
 async def test_fund_testnet_address_network_error() -> None:
     mock_client = AsyncMock()
-    mock_client.__aenter__.return_value = mock_client
-    mock_client.__aexit__.return_value = False
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
     mock_client.post = AsyncMock(side_effect=Exception("connection refused"))
-
     with patch("mpp.methods.tempo.testnet.httpx.AsyncClient", return_value=mock_client):
-        result = await fund_testnet_address("0xABCD1234")
-
+        result = await fund_testnet_address("0xDeadBeef")
     assert result is False
 
 
-async def test_check_connection_success() -> None:
-    block_resp = _make_response({"jsonrpc": "2.0", "result": "0x12d687", "id": 1})
-    chain_resp = _make_response({"jsonrpc": "2.0", "result": "0x1079", "id": 2})
-
+@pytest.mark.asyncio
+async def test_check_connection_mainnet() -> None:
+    mock_resp = MagicMock()
+    mock_resp.raise_for_status = MagicMock()
+    mock_resp.json.side_effect = [
+        {"result": hex(9_000_000)},
+        {"result": hex(CHAIN_ID)},
+    ]
     mock_client = AsyncMock()
-    mock_client.__aenter__.return_value = mock_client
-    mock_client.__aexit__.return_value = False
-    mock_client.post = AsyncMock(side_effect=[block_resp, chain_resp])
-
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+    mock_client.post = AsyncMock(return_value=mock_resp)
     with patch("mpp.methods.tempo.testnet.httpx.AsyncClient", return_value=mock_client):
-        result = await check_connection()
-
-    assert result["connected"] is True
-    assert result["chain_id"] == 0x1079  # 4217
-    assert result["block"] == 0x12D687
-    assert mock_client.post.call_count == 2
-    first_call = mock_client.post.call_args_list[0]
-    assert first_call[0][0] == TEMPO_MAINNET_RPC
+        info = await check_connection(chain_id=CHAIN_ID)
+    assert info["connected"] is True
+    assert info["chain_id"] == CHAIN_ID
+    assert info["block"] == 9_000_000
 
 
+@pytest.mark.asyncio
 async def test_check_connection_failure() -> None:
     mock_client = AsyncMock()
-    mock_client.__aenter__.return_value = mock_client
-    mock_client.__aexit__.return_value = False
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
     mock_client.post = AsyncMock(side_effect=Exception("timeout"))
-
     with patch("mpp.methods.tempo.testnet.httpx.AsyncClient", return_value=mock_client):
-        result = await check_connection()
-
-    assert result["connected"] is False
-    assert "error" in result
-    assert "timeout" in result["error"]
+        info = await check_connection()
+    assert info["connected"] is False
+    assert "error" in info

--- a/tests/test_tempo_testnet.py
+++ b/tests/test_tempo_testnet.py
@@ -1,0 +1,97 @@
+"""Tests for Tempo testnet utilities."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from mpp.methods.tempo.testnet import (
+    TEMPO_MAINNET_RPC,
+    TEMPO_TESTNET_RPC,
+    check_connection,
+    fund_testnet_address,
+)
+
+
+def _make_response(json_data: dict, status_code: int = 200) -> MagicMock:
+    resp = MagicMock()
+    resp.json.return_value = json_data
+    resp.status_code = status_code
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+async def test_fund_testnet_address_success() -> None:
+    mock_resp = _make_response({"jsonrpc": "2.0", "result": "funded", "id": 1})
+    mock_client = AsyncMock()
+    mock_client.__aenter__.return_value = mock_client
+    mock_client.__aexit__.return_value = False
+    mock_client.post = AsyncMock(return_value=mock_resp)
+
+    with patch("mpp.methods.tempo.testnet.httpx.AsyncClient", return_value=mock_client):
+        result = await fund_testnet_address("0xABCD1234")
+
+    assert result is True
+    mock_client.post.assert_awaited_once()
+    call_kwargs = mock_client.post.call_args
+    assert call_kwargs[0][0] == TEMPO_TESTNET_RPC
+    assert call_kwargs[1]["json"]["method"] == "tempo_fundAddress"
+    assert call_kwargs[1]["json"]["params"] == ["0xABCD1234"]
+
+
+async def test_fund_testnet_address_rpc_error() -> None:
+    error_body = {"jsonrpc": "2.0", "error": {"code": -32000, "message": "fail"}, "id": 1}
+    mock_resp = _make_response(error_body)
+    mock_client = AsyncMock()
+    mock_client.__aenter__.return_value = mock_client
+    mock_client.__aexit__.return_value = False
+    mock_client.post = AsyncMock(return_value=mock_resp)
+
+    with patch("mpp.methods.tempo.testnet.httpx.AsyncClient", return_value=mock_client):
+        result = await fund_testnet_address("0xABCD1234")
+
+    assert result is False
+
+
+async def test_fund_testnet_address_network_error() -> None:
+    mock_client = AsyncMock()
+    mock_client.__aenter__.return_value = mock_client
+    mock_client.__aexit__.return_value = False
+    mock_client.post = AsyncMock(side_effect=Exception("connection refused"))
+
+    with patch("mpp.methods.tempo.testnet.httpx.AsyncClient", return_value=mock_client):
+        result = await fund_testnet_address("0xABCD1234")
+
+    assert result is False
+
+
+async def test_check_connection_success() -> None:
+    block_resp = _make_response({"jsonrpc": "2.0", "result": "0x12d687", "id": 1})
+    chain_resp = _make_response({"jsonrpc": "2.0", "result": "0x1079", "id": 2})
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__.return_value = mock_client
+    mock_client.__aexit__.return_value = False
+    mock_client.post = AsyncMock(side_effect=[block_resp, chain_resp])
+
+    with patch("mpp.methods.tempo.testnet.httpx.AsyncClient", return_value=mock_client):
+        result = await check_connection()
+
+    assert result["connected"] is True
+    assert result["chain_id"] == 0x1079  # 4217
+    assert result["block"] == 0x12D687
+    assert mock_client.post.call_count == 2
+    first_call = mock_client.post.call_args_list[0]
+    assert first_call[0][0] == TEMPO_MAINNET_RPC
+
+
+async def test_check_connection_failure() -> None:
+    mock_client = AsyncMock()
+    mock_client.__aenter__.return_value = mock_client
+    mock_client.__aexit__.return_value = False
+    mock_client.post = AsyncMock(side_effect=Exception("timeout"))
+
+    with patch("mpp.methods.tempo.testnet.httpx.AsyncClient", return_value=mock_client):
+        result = await check_connection()
+
+    assert result["connected"] is False
+    assert "error" in result
+    assert "timeout" in result["error"]


### PR DESCRIPTION
Two utilities that come up immediately when building on Tempo for the first time.

Both use the existing _defaults constants (TESTNET_RPC_URL, rpc_url_for_chain()) — no new chain ID definitions.

fund_testnet_address() — fund a wallet via the Moderato faucet in one line:
```
from mpp.methods.tempo.testnet import fund_testnet_address

funded = await fund_testnet_address("0xYourAddress")
```
Uses `tempo_fundAddress` RPC — docs: https://docs.tempo.xyz/quickstart/faucet

`check_connection()` — verify RPC connectivity before sending transactions:

```
from mpp.methods.tempo.testnet import check_connection
from mpp.methods.tempo import TESTNET_CHAIN_ID

info = await check_connection()                          # mainnet
info = await check_connection(chain_id=TESTNET_CHAIN_ID) # testnet
# {"connected": True, "chain_id": 4217, "block": 9420000}
```
Takes `chain_id` and resolves via `rpc_url_for_chain()` — works for any chain in `CHAIN_RPC_URLS.`

Includes: `src/mpp/methods/tempo/testnet.py`, exported from `tempo/__init__.py`, 5 tests.