### PR TITLE
feat: add OWS wallet support for TempoAccount

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ tempo = [
     "pytempo>=0.2.1",
     "pydantic>=2.0",
 ]
+ows = ["open-wallet-standard>=1.0.0"]
 server = ["pydantic>=2.0", "python-dotenv>=1.0"]
 mcp = ["mcp>=1.1.0"]
 dev = [

--- a/src/mpp/methods/tempo/account.py
+++ b/src/mpp/methods/tempo/account.py
@@ -24,6 +24,9 @@ class TempoAccount:
         # From environment variable
         account = TempoAccount.from_env("TEMPO_PRIVATE_KEY")
 
+        # From OWS encrypted vault (pip install pympp[ows])
+        account = TempoAccount.from_ows("my-wallet")
+
         # Sign a hash
         signature = account.sign_hash(msg_hash)
     """
@@ -43,6 +46,34 @@ class TempoAccount:
         from eth_account import Account
 
         return cls(_account=Account.from_key(private_key))
+
+    @classmethod
+    def from_ows(cls, wallet_name_or_id: str) -> TempoAccount:
+        """Load from an OWS (Open Wallet Standard) encrypted vault.
+
+        Args:
+            wallet_name_or_id: OWS wallet name or UUID.
+
+        Returns:
+            A TempoAccount instance.
+        """
+        from open_wallet_standard import export_wallet, derive_address
+
+        exported = export_wallet(wallet_name_or_id)
+
+        import json
+
+        try:
+            keys = json.loads(exported)
+            private_key = keys.get("secp256k1", "")
+        except (json.JSONDecodeError, TypeError):
+            info = derive_address(exported, "evm")
+            private_key = info.get("private_key", "")
+
+        if not private_key.startswith("0x"):
+            private_key = f"0x{private_key}"
+
+        return cls.from_key(private_key)
 
     @classmethod
     def from_env(cls, var: str = "TEMPO_PRIVATE_KEY") -> TempoAccount:


### PR DESCRIPTION
## Summary

Adds `TempoAccount.from_ows(wallet_name)` — creates a Tempo account by decrypting the signing key from an [OWS](https://openwallet.sh) encrypted vault.

## Usage

```python
# Before: raw key in code or env var
account = TempoAccount.from_key("0x...")
account = TempoAccount.from_env("TEMPO_PRIVATE_KEY")

# After: key stays encrypted until needed
account = TempoAccount.from_ows("my-wallet")
```

Install with OWS extra: `pip install pympp[ows]`

## Changes

| File | What |
|------|------|
| `pyproject.toml` | Added `ows` optional dependency (`open-wallet-standard>=1.0.0`) |
| `src/mpp/methods/tempo/account.py` | Added `from_ows()` classmethod |

No changes to existing code paths. The OWS import is lazy (inside the method).