### PR TITLE
test: raise coverage and publish coverage artifacts

### DIFF
--- a/.changelog/proud-goats-cry.md
+++ b/.changelog/proud-goats-cry.md
@@ -1,0 +1,5 @@
+---
+pympp: patch
+---
+
+Raised test coverage by adding tests for edge cases across charge, parsing, server, and store modules, and updated CI to generate and upload XML/HTML coverage reports for Python 3.12.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,22 @@ jobs:
           version: PATH
 
       - name: Run tests
-        run: uv run pytest -v --cov=mpp --cov-report=term-missing --cov-fail-under=90
+        run: |
+          COV_REPORTS="--cov-report=term-missing"
+          if [[ "${{ matrix.python-version }}" == "3.12" ]]; then
+            COV_REPORTS="$COV_REPORTS --cov-report=xml:coverage.xml --cov-report=html:htmlcov"
+          fi
+          uv run pytest -v --cov=mpp $COV_REPORTS --cov-fail-under=90
+
+      - name: Upload coverage artifacts
+        if: always() && matrix.python-version == '3.12'
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: |
+            coverage.xml
+            htmlcov/
+          if-no-files-found: ignore
 
   package:
     runs-on: ubuntu-latest

--- a/tests/test_mpp_create.py
+++ b/tests/test_mpp_create.py
@@ -263,3 +263,74 @@ class TestMppCharge:
         )
         with pytest.raises(ValueError, match="recipient must be set"):
             await srv.charge(authorization=None, amount="1.00")
+
+    @pytest.mark.asyncio
+    async def test_charge_missing_currency_raises(self) -> None:
+        class MockMethod:
+            name = "tempo"
+            currency = None
+            recipient = "0xRecipient"
+            decimals = 6
+            intents = {"charge": ChargeIntent()}
+
+        srv = Mpp(method=MockMethod(), realm="test.com", secret_key="test-secret")  # type: ignore[arg-type]
+        with pytest.raises(ValueError, match="currency must be set"):
+            await srv.charge(authorization=None, amount="1.00")
+
+    @pytest.mark.asyncio
+    async def test_charge_without_charge_intent_raises(self) -> None:
+        class MockMethod:
+            name = "tempo"
+            currency = "0xCurrency"
+            recipient = "0xRecipient"
+            decimals = 6
+            intents: dict[str, object] = {}
+
+        srv = Mpp(method=MockMethod(), realm="test.com", secret_key="test-secret")  # type: ignore[arg-type]
+        with pytest.raises(ValueError, match="does not support charge intent"):
+            await srv.charge(authorization=None, amount="1.00")
+
+    @pytest.mark.asyncio
+    async def test_charge_rejects_non_string_extra_values(self) -> None:
+        srv = Mpp.create(
+            method=tempo(
+                currency="0x20c0000000000000000000000000000000000000",
+                recipient="0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
+                intents={"charge": ChargeIntent()},
+            ),
+            realm="test.com",
+            secret_key="test-secret",
+        )
+
+        with pytest.raises(ValueError, match=r"extra must be a dict\[str, str\]"):
+            await srv.charge(
+                authorization=None,
+                amount="1.00",
+                extra={"attempts": "1", "invalid": 2},  # type: ignore[dict-item]
+            )
+
+    @pytest.mark.asyncio
+    async def test_charge_includes_extra_memo_and_fee_payer(self) -> None:
+        srv = Mpp.create(
+            method=tempo(
+                currency="0x20c0000000000000000000000000000000000000",
+                recipient="0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
+                intents={"charge": ChargeIntent()},
+            ),
+            realm="test.com",
+            secret_key="test-secret",
+        )
+
+        memo = "0x" + "ab" * 32
+        result = await srv.charge(
+            authorization=None,
+            amount="1.00",
+            memo=memo,
+            fee_payer=True,
+            extra={"plan": "pro"},
+        )
+
+        assert isinstance(result, Challenge)
+        assert result.request["extra"] == {"plan": "pro"}
+        assert result.request["methodDetails"]["memo"] == memo
+        assert result.request["methodDetails"]["feePayer"] is True

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -1,11 +1,13 @@
 """Tests for header parsing and formatting."""
 
+import base64
+import json
 from datetime import UTC, datetime
 
 import pytest
 
-from mpp import Challenge, Credential, Receipt
-from mpp._parsing import ParseError
+from mpp import Challenge, ChallengeEcho, Credential, Receipt
+from mpp._parsing import MAX_HEADER_PAYLOAD_SIZE, ParseError
 from tests import make_credential
 
 
@@ -103,6 +105,57 @@ class TestChallenge:
         assert parsed.digest == challenge.digest
         assert parsed.description == challenge.description
 
+    def test_roundtrip_with_opaque(self) -> None:
+        challenge = Challenge(
+            id="test-id-opaque",
+            method="tempo",
+            intent="charge",
+            request={"amount": "1000"},
+            opaque={"pi": "pi_123"},
+        )
+
+        header = challenge.to_www_authenticate("api.example.com")
+        parsed = Challenge.from_www_authenticate(header)
+
+        assert parsed.opaque == {"pi": "pi_123"}
+
+    def test_parse_duplicate_param_raises(self) -> None:
+        header = (
+            'Payment id="test", realm="api.example.com", method="tempo", '
+            'intent="charge", intent="session", request="e30"'
+        )
+        with pytest.raises(ParseError, match="Duplicate parameter: intent"):
+            Challenge.from_www_authenticate(header)
+
+    def test_parse_request_too_large(self) -> None:
+        oversized = "a" * (MAX_HEADER_PAYLOAD_SIZE + 1)
+        header = (
+            'Payment id="test", realm="api.example.com", method="tempo", '
+            f'intent="charge", request="{oversized}"'
+        )
+        with pytest.raises(ParseError, match="Header payload exceeds maximum size"):
+            Challenge.from_www_authenticate(header)
+
+    def test_parse_invalid_opaque_base64(self) -> None:
+        header = (
+            'Payment id="test", realm="api.example.com", method="tempo", '
+            'intent="charge", request="e30", opaque="not!valid!base64"'
+        )
+        with pytest.raises(ParseError, match="Invalid base64 or JSON encoding"):
+            Challenge.from_www_authenticate(header)
+
+    def test_format_rejects_crlf_in_description(self) -> None:
+        challenge = Challenge(
+            id="test-id-123",
+            method="tempo",
+            intent="charge",
+            request={"amount": "1000"},
+            description="bad\nvalue",
+        )
+
+        with pytest.raises(ParseError, match="invalid CRLF"):
+            challenge.to_www_authenticate("api.example.com")
+
 
 class TestCredential:
     def test_roundtrip(self) -> None:
@@ -145,6 +198,67 @@ class TestCredential:
         with pytest.raises(ParseError):
             Credential.from_authorization(header)
 
+    def test_parse_missing_payload(self) -> None:
+        data = {
+            "challenge": {
+                "id": "test-id",
+                "realm": "api.example.com",
+                "method": "tempo",
+                "intent": "charge",
+                "request": "e30",
+            }
+        }
+        header = "Payment " + base64.urlsafe_b64encode(json.dumps(data).encode()).decode().rstrip(
+            "="
+        )
+        with pytest.raises(ParseError, match="Credential missing required field: payload"):
+            Credential.from_authorization(header)
+
+    def test_parse_challenge_not_object(self) -> None:
+        data = {"challenge": "not-an-object", "payload": {}}
+        header = "Payment " + base64.urlsafe_b64encode(json.dumps(data).encode()).decode().rstrip(
+            "="
+        )
+        with pytest.raises(ParseError, match="Credential challenge must be an object"):
+            Credential.from_authorization(header)
+
+    def test_parse_challenge_missing_id(self) -> None:
+        data = {
+            "challenge": {
+                "realm": "api.example.com",
+                "method": "tempo",
+                "intent": "charge",
+                "request": "e30",
+            },
+            "payload": {},
+        }
+        header = "Payment " + base64.urlsafe_b64encode(json.dumps(data).encode()).decode().rstrip(
+            "="
+        )
+        with pytest.raises(ParseError, match="Credential challenge missing required field: id"):
+            Credential.from_authorization(header)
+
+    def test_roundtrip_with_optional_challenge_fields(self) -> None:
+        credential = Credential(
+            challenge=ChallengeEcho(
+                id="test-id",
+                realm="api.example.com",
+                method="tempo",
+                intent="charge",
+                request="e30",
+                digest="sha-256=:abc123:",
+                opaque="eyJwaSI6InBpXzEyMyJ9",
+            ),
+            payload={"hash": "0xabc123"},
+            source="did:example:client",
+        )
+
+        header = credential.to_authorization()
+        parsed = Credential.from_authorization(header)
+
+        assert parsed.challenge.digest == credential.challenge.digest
+        assert parsed.challenge.opaque == credential.challenge.opaque
+
 
 class TestReceipt:
     def test_roundtrip(self) -> None:
@@ -179,4 +293,33 @@ class TestReceipt:
             "MFoiLCJyZWZlcmVuY2UiOiIweCJ9"
         )
         with pytest.raises(ParseError):
+            Receipt.from_payment_receipt(b64)
+
+    def test_roundtrip_with_optional_fields(self) -> None:
+        timestamp = datetime(2024, 1, 20, 12, 0, 0, tzinfo=UTC)
+        receipt = Receipt(
+            status="success",
+            timestamp=timestamp,
+            reference="0xabc123def456",
+            method="tempo",
+            external_id="order-123",
+            extra={"plan": "pro"},
+        )
+
+        header = receipt.to_payment_receipt()
+        parsed = Receipt.from_payment_receipt(header)
+
+        assert parsed.method == "tempo"
+        assert parsed.external_id == "order-123"
+        assert parsed.extra == {"plan": "pro"}
+
+    def test_parse_invalid_timestamp(self) -> None:
+        payload = {
+            "status": "success",
+            "timestamp": "not-a-timestamp",
+            "reference": "0xabc",
+            "method": "tempo",
+        }
+        b64 = base64.urlsafe_b64encode(json.dumps(payload).encode()).decode().rstrip("=")
+        with pytest.raises(ParseError, match="Invalid timestamp format"):
             Receipt.from_payment_receipt(b64)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -917,6 +917,109 @@ class TestMppPay:
         with pytest.raises(ValueError, match="does not support nonexistent intent"):
             server.pay(amount="0.50", intent="nonexistent")
 
+    @pytest.mark.asyncio
+    async def test_raises_when_method_has_no_currency(self) -> None:
+        @intent(name="charge")
+        async def test_intent(credential: Credential, request: dict) -> Receipt:
+            return Receipt.success("0x123")
+
+        class MockMethod:
+            name = "tempo"
+            currency = None
+            recipient = "0xRecipient"
+            decimals = 6
+            intents = {"charge": test_intent}
+
+        server = Mpp(
+            method=MockMethod(),  # type: ignore[arg-type]
+            realm="api.example.com",
+            secret_key="test-secret",
+        )
+
+        @server.pay(amount="0.50")
+        async def handler(req: MockRequest, credential: Credential, receipt: Receipt) -> dict:
+            return {"data": "paid"}
+
+        with pytest.raises(
+            ValueError, match=r"currency must be set on the method or passed to pay\(\)"
+        ):
+            await handler(MockRequest())
+
+    @pytest.mark.asyncio
+    async def test_raises_when_method_has_no_recipient(self) -> None:
+        @intent(name="charge")
+        async def test_intent(credential: Credential, request: dict) -> Receipt:
+            return Receipt.success("0x123")
+
+        class MockMethod:
+            name = "tempo"
+            currency = "0xUSD"
+            recipient = None
+            decimals = 6
+            intents = {"charge": test_intent}
+
+        server = Mpp(
+            method=MockMethod(),  # type: ignore[arg-type]
+            realm="api.example.com",
+            secret_key="test-secret",
+        )
+
+        @server.pay(amount="0.50")
+        async def handler(req: MockRequest, credential: Credential, receipt: Receipt) -> dict:
+            return {"data": "paid"}
+
+        with pytest.raises(
+            ValueError, match=r"recipient must be set on the method or passed to pay\(\)"
+        ):
+            await handler(MockRequest())
+
+    @pytest.mark.asyncio
+    async def test_passes_expires_and_extra_into_challenge(self) -> None:
+        from datetime import UTC, datetime, timedelta
+
+        @intent(name="charge")
+        async def test_intent(credential: Credential, request: dict) -> Receipt:
+            return Receipt.success("0x123")
+
+        server = _make_server(test_intent)
+
+        @server.pay(amount="0.50", extra={"plan": "pro"}, expires_in=timedelta(minutes=1))
+        async def handler(req: MockRequest, credential: Credential, receipt: Receipt) -> dict:
+            return {"data": "paid"}
+
+        before = datetime.now(UTC)
+        result = await handler(MockRequest())
+        after = datetime.now(UTC)
+
+        if HAS_STARLETTE:
+            assert StarletteResponse is not None
+            assert isinstance(result, StarletteResponse)
+            www_auth = result.headers["WWW-Authenticate"]
+        else:
+            assert isinstance(result, dict)
+            www_auth = result["headers"]["WWW-Authenticate"]
+
+        challenge = Challenge.from_www_authenticate(www_auth)
+        assert challenge.request["extra"] == {"plan": "pro"}
+        assert challenge.expires is not None
+        expires = datetime.fromisoformat(challenge.expires)
+        assert before + timedelta(seconds=59) < expires < after + timedelta(seconds=61)
+
+    @pytest.mark.asyncio
+    async def test_rejects_non_string_extra_values(self) -> None:
+        @intent(name="charge")
+        async def test_intent(credential: Credential, request: dict) -> Receipt:
+            return Receipt.success("0x123")
+
+        server = _make_server(test_intent)
+
+        @server.pay(amount="0.50", extra={"plan": "pro", "attempts": 1})  # type: ignore[dict-item]
+        async def handler(req: MockRequest, credential: Credential, receipt: Receipt) -> dict:
+            return {"data": "paid"}
+
+        with pytest.raises(ValueError, match=r"extra must be a dict\[str, str\]"):
+            await handler(MockRequest())
+
 
 class TestMppChainIdAutoEmit:
     """Tests for Mpp auto-emitting chainId from the method's chain_id."""

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,0 +1,27 @@
+"""Tests for the in-memory replay protection store."""
+
+from __future__ import annotations
+
+import pytest
+
+from mpp.store import MemoryStore
+
+
+class TestMemoryStore:
+    @pytest.mark.asyncio
+    async def test_put_get_delete_roundtrip(self) -> None:
+        store = MemoryStore()
+
+        await store.put("receipt:1", {"status": "ok"})
+        assert await store.get("receipt:1") == {"status": "ok"}
+
+        await store.delete("receipt:1")
+        assert await store.get("receipt:1") is None
+
+    @pytest.mark.asyncio
+    async def test_put_if_absent_rejects_duplicates(self) -> None:
+        store = MemoryStore()
+
+        assert await store.put_if_absent("receipt:1", "first") is True
+        assert await store.put_if_absent("receipt:1", "second") is False
+        assert await store.get("receipt:1") == "first"


### PR DESCRIPTION
## Summary

Adds focused coverage tests around server request shaping and protocol parsing, and publishes coverage artifacts from CI for easier inspection.

## What changed

- adds `Mpp.charge()` validation tests for missing currency, missing charge intent, invalid `extra`, and memo / fee payer request shaping
- adds `server.pay()` tests for missing currency / recipient, explicit `expires_in`, valid `extra`, and invalid `extra`
- adds parser edge-case tests for duplicate auth params, oversized payloads, invalid opaque, malformed credentials, CRLF rejection, and receipt optional fields
- adds `MemoryStore` tests for `put`, `get`, `delete`, and `put_if_absent`
- keeps the existing CI coverage gate at `--cov-fail-under=90`
- adds `coverage.xml` and `htmlcov/` artifacts to the Python 3.12 CI job

## Coverage

Local coverage moved from `94.10%` to `95.90%`.

Notable file-level improvements:

- `src/mpp/server/mpp.py`: `84%` -> `100%`
- `src/mpp/_parsing.py`: `88%` -> `98%`
- `src/mpp/store.py`: `89%` -> `100%`

## Verification

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright`
- `uv run pytest -v --cov=mpp --cov-report=term-missing --cov-report=xml:coverage.xml --cov-fail-under=90`
- `uv run python -m build`
- `uv run twine check --strict dist/*`