### PR TITLE
fix: support Python 3.11 to prevent squatter install

### DIFF
--- a/.changelog/plain-mules-fix.md
+++ b/.changelog/plain-mules-fix.md
@@ -1,0 +1,5 @@
+---
+pympp: patch
+---
+
+Added Python 3.11 support by lowering the `requires-python` constraint from `>=3.12` to `>=3.11`, updating tooling targets accordingly, and replacing PEP 695 generic syntax with `TypeVar` for compatibility.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "pympp"
 version = "0.5.2"
 description = "Python SDK for the Machine Payments Protocol (MPP)"
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = ">=3.11"
 dependencies = [
     "httpx>=0.27",
 ]
@@ -15,6 +15,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Typing :: Typed",
@@ -68,7 +69,7 @@ packages = ["src/mpp"]
 
 [tool.ruff]
 line-length = 100
-target-version = "py312"
+target-version = "py311"
 exclude = ["examples"]
 
 [tool.ruff.lint]
@@ -82,7 +83,7 @@ ignore = []
 quote-style = "double"
 
 [tool.pyright]
-pythonVersion = "3.12"
+pythonVersion = "3.11"
 typeCheckingMode = "standard"
 include = ["src", "tests"]
 

--- a/src/mpp/server/decorator.py
+++ b/src/mpp/server/decorator.py
@@ -6,7 +6,7 @@ import inspect
 import json as _json
 from collections.abc import Awaitable, Callable
 from functools import wraps
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from mpp import Challenge, Credential, Receipt
 from mpp.errors import PaymentRequiredError
@@ -15,6 +15,8 @@ from mpp.server.verify import verify_or_challenge
 
 if TYPE_CHECKING:
     from mpp.server.intent import Intent
+
+R = TypeVar("R")
 
 RequestParamsType = dict[str, Any] | Callable[[Any], dict[str, Any]]
 
@@ -63,7 +65,7 @@ def make_challenge_response(challenge: Challenge, realm: str) -> Any:
         }
 
 
-def wrap_payment_handler[R](
+def wrap_payment_handler(
     handler: Callable[..., Awaitable[R]],
     verify_fn: Callable[[str | None, Any], Awaitable[Challenge | tuple[Credential, Receipt]]],
     realm_fn: Callable[[], str],
@@ -117,7 +119,7 @@ def wrap_payment_handler[R](
     return wrapper
 
 
-def pay[R](
+def pay(
     *,
     intent: Intent,
     request: RequestParamsType,


### PR DESCRIPTION
## Problem

On Python 3.11, `pip install pympp` installs version 0.0.1 — a PyPI name squatter — because `requires-python >= 3.12` causes pip to silently skip all real versions.

## Fix

- Lower `requires-python` to `>= 3.11` (`datetime.UTC` and `X | Y` union syntax both work on 3.11)
- Replace PEP 695 generic syntax (`def func[R](...)`) with `TypeVar` — the only 3.12-specific syntax in the codebase
- Update ruff and pyright targets to `py311`