### PR TITLE
chore: harden CI workflows and add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 3
+      semver-major-days: 7
+    groups:
+      python-deps:
+        patterns: ["*"]
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 3
+    groups:
+      actions:
+        patterns: ["*"]

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -9,27 +9,31 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           ref: ${{ github.head_ref }}
       - name: Install changelogs
-        run: curl -sSL https://changelogs.sh | sh
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          curl -fsSL "https://github.com/wevm/changelogs-rs/releases/download/changelogs%400.6.3/changelogs-linux-amd64" \
+            -o "$HOME/.local/bin/changelogs"
+          chmod +x "$HOME/.local/bin/changelogs"
       - name: Install Claude CLI
-        run: npm install -g @anthropic-ai/claude-code
+        run: npm install -g @anthropic-ai/claude-code@2.1.97
       - name: Generate changelog
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          BASE_REF: ${{ github.base_ref }}
         run: |
-          CHANGED=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
+          CHANGED=$(git diff --name-only "origin/${BASE_REF}...HEAD")
           CODE_CHANGES=$(echo "$CHANGED" | grep -vE '^(\.changelog/|\.github/|\.gitignore|README\.md|AGENTS\.md)' || true)
           if [ -z "$CODE_CHANGES" ]; then
             echo "No code changes requiring changelog, skipping"
             exit 0
           fi
-          ~/.local/bin/changelogs add --ecosystem python --ai "claude -p" --ref origin/${{ github.base_ref }}
+          ~/.local/bin/changelogs add --ecosystem python --ai "claude -p" --ref "origin/${BASE_REF}"
       - name: Commit changelog
         run: |
           if [ -n "$(git status --porcelain .changelog/)" ]; then

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -10,15 +10,17 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
           ref: ${{ github.head_ref }}
+          persist-credentials: false
       - name: Install changelogs
         run: |
           mkdir -p "$HOME/.local/bin"
           curl -fsSL "https://github.com/wevm/changelogs-rs/releases/download/changelogs%400.6.3/changelogs-linux-amd64" \
             -o "$HOME/.local/bin/changelogs"
+          echo "d4168ee68b612224a26a39e86bfd2c923ac3dd2de12ee43d2bb65a5ea19df6b6  $HOME/.local/bin/changelogs" | sha256sum -c
           chmod +x "$HOME/.local/bin/changelogs"
       - name: Install Claude CLI
         run: npm install -g @anthropic-ai/claude-code@2.1.97
@@ -35,10 +37,14 @@ jobs:
           fi
           ~/.local/bin/changelogs add --ecosystem python --ai "claude -p" --ref "origin/${BASE_REF}"
       - name: Commit changelog
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
         run: |
           if [ -n "$(git status --porcelain .changelog/)" ]; then
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
+            git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${REPO}"
             git add .changelog/
             git commit -m "chore: add changelog"
             git push

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,12 +36,12 @@ jobs:
         python-version: ["3.12", "3.13", "3.14"]
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4.2.0
         with:
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
@@ -66,7 +66,7 @@ jobs:
 
       - name: Type check
         if: matrix.python-version == '3.12'
-        uses: jakebailey/pyright-action@8ec14b5cfe41f26e5f41686a31eb6012758217ef # v3
+        uses: jakebailey/pyright-action@8ec14b5cfe41f26e5f41686a31eb6012758217ef # v3.0.2
         with:
           version: PATH
 
@@ -82,7 +82,7 @@ jobs:
 
       - name: Upload coverage artifacts
         if: always() && matrix.python-version == '3.12'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: coverage-report
           path: |
@@ -93,12 +93,12 @@ jobs:
   package:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4.2.0
         with:
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
@@ -115,7 +115,7 @@ jobs:
           uv run twine check --strict dist/*
 
       - name: Upload package artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: package-dist
           path: dist/*
@@ -130,12 +130,12 @@ jobs:
         profile: [base, tempo, mcp]
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4.2.0
         with:
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
@@ -144,7 +144,7 @@ jobs:
         run: uv python install 3.12
 
       - name: Download package artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: package-dist
           path: dist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main, master]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -17,8 +20,10 @@ jobs:
     needs: [test, package, install-smoke]
     runs-on: ubuntu-latest
     steps:
-      - run: |
-          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+      - env:
+          ANY_FAILED: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: |
+          if [[ "$ANY_FAILED" == "true" ]]; then
             echo "One or more required jobs failed or were cancelled"
             exit 1
           fi
@@ -31,16 +36,20 @@ jobs:
         python-version: ["3.12", "3.13", "3.14"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
         with:
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
 
       - name: Set up Python ${{ matrix.python-version }}
-        run: uv python install ${{ matrix.python-version }}
+        run: uv python install "$PYTHON_VERSION"
+        env:
+          PYTHON_VERSION: ${{ matrix.python-version }}
 
       - name: Install dependencies
         run: uv sync --all-extras --dev
@@ -57,21 +66,23 @@ jobs:
 
       - name: Type check
         if: matrix.python-version == '3.12'
-        uses: jakebailey/pyright-action@v3
+        uses: jakebailey/pyright-action@8ec14b5cfe41f26e5f41686a31eb6012758217ef # v3
         with:
           version: PATH
 
       - name: Run tests
+        env:
+          PYTHON_VERSION: ${{ matrix.python-version }}
         run: |
           COV_REPORTS="--cov-report=term-missing"
-          if [[ "${{ matrix.python-version }}" == "3.12" ]]; then
+          if [[ "$PYTHON_VERSION" == "3.12" ]]; then
             COV_REPORTS="$COV_REPORTS --cov-report=xml:coverage.xml --cov-report=html:htmlcov"
           fi
           uv run pytest -v --cov=mpp $COV_REPORTS --cov-fail-under=90
 
       - name: Upload coverage artifacts
         if: always() && matrix.python-version == '3.12'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: coverage-report
           path: |
@@ -82,10 +93,12 @@ jobs:
   package:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
         with:
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
@@ -102,7 +115,7 @@ jobs:
           uv run twine check --strict dist/*
 
       - name: Upload package artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: package-dist
           path: dist/*
@@ -117,10 +130,12 @@ jobs:
         profile: [base, tempo, mcp]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
         with:
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
@@ -129,7 +144,7 @@ jobs:
         run: uv python install 3.12
 
       - name: Download package artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: package-dist
           path: dist
@@ -138,9 +153,11 @@ jobs:
         run: uv venv .smoke-venv --python 3.12
 
       - name: Install built wheel
+        env:
+          PROFILE: ${{ matrix.profile }}
         run: |
           WHEEL=$(echo dist/*.whl)
-          case "${{ matrix.profile }}" in
+          case "$PROFILE" in
             base)
               INSTALL_TARGET="$WHEEL"
               ;;

--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [labeled]
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -12,29 +15,38 @@ jobs:
       - name: Check admin permission
         env:
           GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          SENDER: ${{ github.event.sender.login }}
         run: |
-          PERM=$(gh api repos/${{ github.repository }}/collaborators/${{ github.event.sender.login }}/permission --jq '.permission')
+          PERM=$(gh api "repos/${REPO}/collaborators/${SENDER}/permission" --jq '.permission')
           if [[ "$PERM" != "admin" ]]; then
             echo "::error::Only admins can trigger pr-audit (got: $PERM)"
             exit 1
           fi
 
       - name: Publish event
+        env:
+          EVENTS_KEY: ${{ secrets.EVENTS_KEY }}
+          EVENTS_CERT: ${{ secrets.EVENTS_CERT }}
+          EVENTS_ARGS: ${{ secrets.EVENTS_ARGS }}
+          REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
 
-          echo "${{ secrets.EVENTS_KEY }}" > "${{ runner.temp }}/key"
-          echo "${{ secrets.EVENTS_CERT }}" > "${{ runner.temp }}/cert"
+          echo "$EVENTS_KEY" > "$RUNNER_TEMP/key"
+          echo "$EVENTS_CERT" > "$RUNNER_TEMP/cert"
 
-          curl -sf -o /dev/null -X POST ${{ secrets.EVENTS_ARGS }} \
+          curl -sf -o /dev/null -X POST ${EVENTS_ARGS} \
             -H "Content-Type: application/json" \
-            --key "${{ runner.temp }}/key" \
-            --cert "${{ runner.temp }}/cert" \
-            -d '{
-              "repository": "${{ github.repository }}",
-              "event": "pr_audit",
-              "data": {
-                "pr_number": ${{ github.event.pull_request.number }},
-                "sha": "${{ github.event.pull_request.head.sha }}"
+            --key "$RUNNER_TEMP/key" \
+            --cert "$RUNNER_TEMP/cert" \
+            -d "{
+              \"repository\": \"${REPOSITORY}\",
+              \"event\": \"pr_audit\",
+              \"data\": {
+                \"pr_number\": ${PR_NUMBER},
+                \"sha\": \"${PR_SHA}\"
               }
-            }'
+            }"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,11 +14,11 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: true
 
-      - uses: wevm/changelogs@master
+      - uses: wevm/changelogs@a160c1637ff9cf1529cddedd17cca47a276423e8 # changelogs@0.6.3
         with:
           ecosystem: python
           python-version: '3.12'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: true
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   redis:
-    image: redis:7-alpine
+    image: redis:7.4.8-alpine
     ports:
       - "6379:6379"
     healthcheck:
@@ -10,7 +10,7 @@ services:
       retries: 10
 
   tempo:
-    image: ghcr.io/tempoxyz/tempo:latest
+    image: ghcr.io/tempoxyz/tempo:v1.5.2
     ports:
       - "8545:8545"
     command: >


### PR DESCRIPTION
- SHA-pin all GitHub Actions with exact version comments
- Fix template injection in workflow run blocks
- Add `persist-credentials: false` to all checkout steps (including changelog.yml)
- Add explicit minimal permissions
- Pin changelogs binary and Claude CLI versions
- Add SHA256 checksum verification for changelogs binary download
- Pin docker-compose images (`redis:7.4.8-alpine`, `tempo:v1.5.2`)
- Use explicit token for changelog push step
- Add Dependabot config for pip and github-actions