### PR TITLE
chore: switch to OIDC trusted publishing and harden workflows

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     types: [opened]
 
+permissions: {}
+
 jobs:
   changelog:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,8 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
+permissions: {}
+
 jobs:
   release:
     name: Version

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,16 +15,44 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+    outputs:
+      published: ${{ steps.changelogs.outputs.published }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: true
 
-      - uses: wevm/changelogs@a160c1637ff9cf1529cddedd17cca47a276423e8 # changelogs@0.6.3
+      - id: changelogs
+        uses: wevm/changelogs@a160c1637ff9cf1529cddedd17cca47a276423e8 # changelogs@0.6.3
         with:
           ecosystem: python
           python-version: '3.12'
-          pypi-token: ${{ secrets.PYPI_TOKEN }}
           conventional-commit: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish:
+    name: Publish to PyPI
+    needs: release
+    if: needs.release.outputs.published == 'true'
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: '3.12'
+
+      - name: Build package
+        run: |
+          pip install build
+          python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0


### PR DESCRIPTION
- Add `permissions: {}` to `publish.yml` and `changelog.yml`
- Replace `PYPI_TOKEN` with OIDC trusted publishing via `pypa/gh-action-pypi-publish`
- Split publish into dedicated job with `id-token: write` and `environment: release`

Prompted by: georgen