### PR TITLE
fix: deserialize key_authorization in fee payer envelope decode

### DIFF
--- a/.changelog/kind-sharks-shout.md
+++ b/.changelog/kind-sharks-shout.md
@@ -1,0 +1,5 @@
+---
+pympp: patch
+---
+
+Fixed `decode_fee_payer_envelope` to return a `SignedKeyAuthorization` object instead of raw RLP bytes when a key authorization is present in the fee payer envelope.

--- a/src/mpp/methods/tempo/fee_payer_envelope.py
+++ b/src/mpp/methods/tempo/fee_payer_envelope.py
@@ -22,7 +22,7 @@ from typing import TYPE_CHECKING
 import rlp
 
 if TYPE_CHECKING:
-    from pytempo import TempoTransaction
+    from pytempo import SignedKeyAuthorization, TempoTransaction
 
 FEE_PAYER_ENVELOPE_TYPE_ID = 0x78
 
@@ -67,7 +67,9 @@ def encode_fee_payer_envelope(signed_tx: TempoTransaction) -> bytes:
     return bytes([FEE_PAYER_ENVELOPE_TYPE_ID]) + rlp.encode(fields)
 
 
-def decode_fee_payer_envelope(data: bytes) -> tuple[list, bytes, bytes, bytes | None]:
+def decode_fee_payer_envelope(
+    data: bytes,
+) -> tuple[list, bytes, bytes, SignedKeyAuthorization | None]:
     """Decode a 0x78 fee payer envelope.
 
     Args:
@@ -75,7 +77,7 @@ def decode_fee_payer_envelope(data: bytes) -> tuple[list, bytes, bytes, bytes | 
 
     Returns:
         Tuple of (decoded RLP fields, sender_address bytes,
-        sender_signature bytes, key_authorization RLP bytes or None).
+        sender_signature bytes, SignedKeyAuthorization or None).
 
     Raises:
         ValueError: If the data doesn't start with ``0x78`` or is malformed.
@@ -93,8 +95,38 @@ def decode_fee_payer_envelope(data: bytes) -> tuple[list, bytes, bytes, bytes | 
     # 15 fields = key_authorization present (index 13), signature at 14
     # 14 fields = no key_authorization, signature at 13
     if len(decoded) == 15:
-        key_authorization = rlp.encode(decoded[13])
+        key_authorization = _decode_signed_key_authorization(decoded[13])
     else:
         key_authorization = None
 
     return decoded, bytes(sender_address), bytes(sender_signature), key_authorization  # type: ignore[arg-type]
+
+
+def _decode_signed_key_authorization(rlp_fields: list) -> SignedKeyAuthorization:
+    """Reconstruct a SignedKeyAuthorization from decoded RLP fields."""
+    from pytempo import KeyAuthorization, SignatureType, SignedKeyAuthorization
+    from pytempo.models import Signature
+
+    auth_fields = rlp_fields[0]
+    sig_bytes = bytes(rlp_fields[1])
+
+    chain_id = int.from_bytes(auth_fields[0], "big") if auth_fields[0] else 0
+    key_type = SignatureType(int.from_bytes(auth_fields[1], "big") if auth_fields[1] else 0)
+    key_id = bytes(auth_fields[2])
+
+    expiry = (
+        int.from_bytes(auth_fields[3], "big") if len(auth_fields) > 3 and auth_fields[3] else None
+    )
+
+    authorization = KeyAuthorization(
+        key_id=key_id,
+        chain_id=chain_id,
+        key_type=key_type,
+        expiry=expiry,
+    )
+
+    r = int.from_bytes(sig_bytes[:32], "big")
+    s = int.from_bytes(sig_bytes[32:64], "big")
+    v = sig_bytes[64]
+
+    return SignedKeyAuthorization(authorization=authorization, signature=Signature(r=r, s=s, v=v))

--- a/src/mpp/methods/tempo/intents.py
+++ b/src/mpp/methods/tempo/intents.py
@@ -685,7 +685,7 @@ class ChargeIntent:
         Returns the fully co-signed 0x76 transaction hex.
         """
         from pytempo import Call, TempoTransaction
-        from pytempo.models import as_address
+        from pytempo.models import Signature, as_address
 
         from mpp.methods.tempo.fee_payer_envelope import decode_fee_payer_envelope
 
@@ -752,7 +752,11 @@ class ChargeIntent:
 
         tx_to_sign = attrs.evolve(
             tx_for_recovery,
-            sender_signature=sender_sig,
+            sender_signature=Signature(
+                r=int.from_bytes(sender_sig[:32], "big"),
+                s=int.from_bytes(sender_sig[32:64], "big"),
+                v=sender_sig[64],
+            ),
             sender_address=as_address(recovered_address),
             fee_token=fee_token or PATH_USD,
         )

--- a/tests/test_fee_payer_envelope.py
+++ b/tests/test_fee_payer_envelope.py
@@ -1,8 +1,10 @@
 """Tests for fee payer envelope encoding/decoding (0x78 wire format)."""
 
+import attrs
 import pytest
 import rlp
 from pytempo import Call, TempoTransaction
+from pytempo.models import Signature
 
 from mpp.methods.tempo.fee_payer_envelope import (
     decode_fee_payer_envelope,
@@ -117,13 +119,11 @@ class TestEncodeFeePayerEnvelope:
 
     def test_differs_from_0x76_encode(self) -> None:
         """0x78 envelope must differ from standard 0x76 encode."""
-        import attrs
-
         signed = _make_signed_tx()
         envelope = encode_fee_payer_envelope(signed)
 
         # For 0x76 we need a fee_payer_signature
-        tx_76 = attrs.evolve(signed, fee_payer_signature=b"\x00")
+        tx_76 = attrs.evolve(signed, fee_payer_signature=Signature(r=1, s=1, v=27))
         encoded_76 = tx_76.encode()
 
         assert envelope[0] == 0x78
@@ -168,10 +168,8 @@ class TestDecodeFeePayerEnvelope:
 
     def test_rejects_0x76_prefix(self) -> None:
         """Should reject a standard 0x76 transaction."""
-        import attrs
-
         signed = _make_signed_tx()
-        tx_76 = attrs.evolve(signed, fee_payer_signature=b"\x00")
+        tx_76 = attrs.evolve(signed, fee_payer_signature=Signature(r=1, s=1, v=27))
         encoded_76 = tx_76.encode()
         with pytest.raises(ValueError, match="expected 0x78 prefix"):
             decode_fee_payer_envelope(encoded_76)

--- a/tests/test_tempo.py
+++ b/tests/test_tempo.py
@@ -1701,6 +1701,7 @@ class TestValidateTransactionPayload:
         """Build a standard 0x76 transaction."""
         import attrs
         from pytempo import Call, TempoTransaction
+        from pytempo.models import Signature
 
         selector = "a9059cbb"
         to_padded = recipient[2:].lower().zfill(64)
@@ -1718,7 +1719,7 @@ class TestValidateTransactionPayload:
             calls=(Call.create(to=currency, value=0, data=transfer_data),),
         )
         signed = tx.sign(TEST_PRIVATE_KEY)
-        signed = attrs.evolve(signed, fee_payer_signature=b"\x00")
+        signed = attrs.evolve(signed, fee_payer_signature=Signature(r=1, s=1, v=27))
         return "0x" + signed.encode().hex()
 
     def test_accepts_0x78_with_matching_call(self) -> None:


### PR DESCRIPTION
- Deserialize `key_authorization` RLP bytes to `SignedKeyAuthorization` in `decode_fee_payer_envelope`
- Deserialize `sender_sig` bytes to `Signature` in `_cosign_as_fee_payer`
- Update test fixtures to use typed `Signature` objects instead of raw bytes
- Fixes pyright CI and 6 pre-existing test failures on main

Prompted by: georgen