### PR TITLE
chore: standardize dependabot cooldowns to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,7 @@ updates:
     schedule:
       interval: weekly
     cooldown:
-      default-days: 3
-      semver-major-days: 7
+      default-days: 7
     groups:
       python-deps:
         patterns: ["*"]
@@ -16,7 +15,7 @@ updates:
     schedule:
       interval: weekly
     cooldown:
-      default-days: 3
+      default-days: 7
     groups:
       actions:
         patterns: ["*"]


### PR DESCRIPTION
Standardize dependabot cooldowns to 7 days across all ecosystems for consistency with other MPP repos. Groups were already configured.

Prompted by: brendan

Co-Authored-By: Brendan Ryan <1572504+brendanjryan@users.noreply.github.com>