### PR TITLE
fix: align sponsored tempo tx fees with policy

### DIFF
--- a/src/mpp/methods/tempo/client.py
+++ b/src/mpp/methods/tempo/client.py
@@ -301,9 +301,7 @@ class TempoMethod:
             resolved_nonce = 0
             valid_before = int(time.time()) + FEE_PAYER_VALID_BEFORE_SECS
             # Keep sponsored envelopes inside the server's default policy.
-            max_priority_fee_per_gas = min(
-                gas_price, get_policy(chain_id).max_priority_fee_per_gas
-            )
+            max_priority_fee_per_gas = min(gas_price, get_policy(chain_id).max_priority_fee_per_gas)
         else:
             resolved_nonce_key = nonce_key
             resolved_nonce = on_chain_nonce

--- a/src/mpp/methods/tempo/client.py
+++ b/src/mpp/methods/tempo/client.py
@@ -19,6 +19,7 @@ from mpp.methods.tempo._defaults import (
     rpc_url_for_chain,
 )
 from mpp.methods.tempo._rpc import _rpc_call, estimate_gas
+from mpp.methods.tempo.fee_payer_policy import get_policy
 
 if TYPE_CHECKING:
     from mpp.methods.tempo.account import TempoAccount
@@ -287,6 +288,7 @@ class TempoMethod:
         )
         on_chain_nonce = int(nonce_hex, 16)
         gas_price = int(gas_price_hex, 16)
+        max_priority_fee_per_gas = gas_price
 
         if expected_chain_id is not None and chain_id != expected_chain_id:
             raise TransactionError(
@@ -298,6 +300,10 @@ class TempoMethod:
             resolved_nonce_key = EXPIRING_NONCE_KEY
             resolved_nonce = 0
             valid_before = int(time.time()) + FEE_PAYER_VALID_BEFORE_SECS
+            # Keep sponsored envelopes inside the server's default policy.
+            max_priority_fee_per_gas = min(
+                gas_price, get_policy(chain_id).max_priority_fee_per_gas
+            )
         else:
             resolved_nonce_key = nonce_key
             resolved_nonce = on_chain_nonce
@@ -324,7 +330,7 @@ class TempoMethod:
             chain_id=chain_id,
             gas_limit=gas_limit,
             max_fee_per_gas=gas_price,
-            max_priority_fee_per_gas=gas_price,
+            max_priority_fee_per_gas=max_priority_fee_per_gas,
             nonce=resolved_nonce,
             nonce_key=resolved_nonce_key,
             fee_token=None if awaiting_fee_payer else currency,

--- a/tests/test_fee_payer_envelope.py
+++ b/tests/test_fee_payer_envelope.py
@@ -1,5 +1,7 @@
 """Tests for fee payer envelope encoding/decoding (0x78 wire format)."""
 
+import time
+
 import attrs
 import pytest
 import rlp
@@ -195,7 +197,7 @@ class TestEncoderDecoderIntegration:
         from mpp.methods.tempo import TempoAccount, tempo
         from mpp.methods.tempo.intents import ChargeIntent
 
-        signed = _make_signed_tx()
+        signed = _make_signed_tx(valid_before=int(time.time()) + 300)
         envelope_hex = "0x" + encode_fee_payer_envelope(signed).hex()
 
         fee_payer_key = "0x" + "ab" * 32
@@ -221,7 +223,7 @@ class TestEncoderDecoderIntegration:
         from mpp.methods.tempo.intents import ChargeIntent
         from mpp.server.intent import VerificationError
 
-        signed = _make_signed_tx()
+        signed = _make_signed_tx(valid_before=int(time.time()) + 300)
         encoded = encode_fee_payer_envelope(signed)
 
         # Tamper with sender_address (index 11) by replacing it

--- a/tests/test_tempo.py
+++ b/tests/test_tempo.py
@@ -22,6 +22,8 @@ from mpp.methods.tempo import (
 from mpp.methods.tempo._attribution import encode as encode_attribution
 from mpp.methods.tempo._defaults import CHAIN_RPC_URLS
 from mpp.methods.tempo.client import TempoMethod
+from mpp.methods.tempo.fee_payer_envelope import decode_fee_payer_envelope
+from mpp.methods.tempo.fee_payer_policy import get_policy
 from mpp.methods.tempo.intents import (
     APPROVE_SELECTOR,
     STABLECOIN_DEX,
@@ -370,6 +372,58 @@ class TestTempoMethod:
         await_args = build_mock.await_args
         assert await_args is not None
         assert await_args.kwargs["memo"] == "0x" + "22" * 32
+
+    @pytest.mark.asyncio
+    async def test_create_credential_caps_fee_payer_priority_fee_to_policy(self) -> None:
+        account = TempoAccount.from_key(TEST_PRIVATE_KEY)
+        method = tempo(
+            account=account,
+            chain_id=1337,
+            rpc_url="https://rpc.test",
+            intents={"charge": ChargeIntent()},
+        )
+        challenge = Challenge(
+            id="test-sponsored-priority-cap",
+            method="tempo",
+            intent="charge",
+            request={
+                "amount": "1000000",
+                "currency": "0x20c0000000000000000000000000000000000000",
+                "recipient": "0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
+                "methodDetails": {"feePayer": True, "chainId": 1337},
+            },
+            realm="test.example.com",
+            request_b64="e30",
+        )
+
+        async def fake_rpc_call(
+            rpc_url: str,
+            method_name: str,
+            params: list[object],
+            *,
+            client: object | None = None,
+        ) -> str:
+            del params, client
+            assert rpc_url == "https://rpc.test"
+            if method_name == "eth_chainId":
+                return hex(1337)
+            if method_name == "eth_getTransactionCount":
+                return "0x1"
+            if method_name == "eth_gasPrice":
+                return hex(20_000_000_000)
+            raise AssertionError(f"Unexpected RPC method: {method_name}")
+
+        with (
+            patch("mpp.methods.tempo.client._rpc_call", side_effect=fake_rpc_call),
+            patch("mpp.methods.tempo.client.estimate_gas", new=AsyncMock(return_value=0x186A0)),
+        ):
+            credential = await method.create_credential(challenge)
+
+        decoded, _, _, _ = decode_fee_payer_envelope(
+            bytes.fromhex(credential.payload["signature"][2:])
+        )
+        max_priority_fee_per_gas = int.from_bytes(decoded[1], "big") if decoded[1] else 0
+        assert max_priority_fee_per_gas == get_policy(1337).max_priority_fee_per_gas
 
 
 class TestChargeIntent:

--- a/tests/test_tempo_integration.py
+++ b/tests/test_tempo_integration.py
@@ -132,7 +132,6 @@ class TestChargeIntegration:
         assert credential.payload["signature"].startswith("0x76")
         assert funded_payer.address in credential.source
 
-    @pytest.mark.xfail(reason="pre-existing: transaction validation mismatch on devnet")
     async def test_verify_transaction_credential(
         self, rpc_url, funded_payer, funded_recipient, currency, charge_intent, chain_id
     ):
@@ -193,6 +192,59 @@ class TestChargeIntegration:
 
         assert receipt.status == "success"
         assert receipt.reference == tx_hash
+
+    async def test_verify_hash_rejects_plain_transfer_without_challenge_bound_memo(
+        self, rpc_url, funded_payer, funded_recipient, currency, charge_intent
+    ):
+        challenge_id = "test-hash-no-memo"
+        tx_hash = await _send_transfer(
+            rpc_url, funded_payer, currency, funded_recipient.address, 1000000
+        )
+
+        expires = _future_expires()
+        request_dict = {
+            "amount": "1000000",
+            "currency": currency,
+            "recipient": funded_recipient.address,
+            "expires": expires,
+        }
+        credential = make_credential(
+            payload={"type": "hash", "hash": tx_hash},
+            challenge_id=challenge_id,
+            expires=expires,
+        )
+
+        with pytest.raises(VerificationError, match="memo is not bound to this challenge"):
+            await charge_intent.verify(credential, request_dict)
+
+    async def test_verify_hash_rejects_wrong_challenge_binding(
+        self, rpc_url, funded_payer, funded_recipient, currency, charge_intent
+    ):
+        challenge_id = "test-hash-wrong-binding"
+        tx_hash = await _send_transfer(
+            rpc_url,
+            funded_payer,
+            currency,
+            funded_recipient.address,
+            1000000,
+            memo=encode_attribution(challenge_id="different-challenge", server_id=TEST_REALM),
+        )
+
+        expires = _future_expires()
+        request_dict = {
+            "amount": "1000000",
+            "currency": currency,
+            "recipient": funded_recipient.address,
+            "expires": expires,
+        }
+        credential = make_credential(
+            payload={"type": "hash", "hash": tx_hash},
+            challenge_id=challenge_id,
+            expires=expires,
+        )
+
+        with pytest.raises(VerificationError, match="memo is not bound to this challenge"):
+            await charge_intent.verify(credential, request_dict)
 
     async def test_verify_rejects_insufficient_transfer(
         self, rpc_url, funded_payer, funded_recipient, currency, charge_intent
@@ -571,7 +623,6 @@ class TestChargeIntegration:
         with pytest.raises(VerificationError, match="Transaction not found"):
             await charge_intent.verify(credential, request_dict)
 
-    @pytest.mark.xfail(reason="pre-existing: transaction validation mismatch on devnet")
     async def test_verify_external_id_propagated(
         self, rpc_url, funded_payer, funded_recipient, currency, chain_id
     ):

--- a/tests/test_tempo_integration.py
+++ b/tests/test_tempo_integration.py
@@ -285,10 +285,10 @@ class TestChargeIntegration:
         with pytest.raises(VerificationError):
             await charge_intent.verify(credential, request_dict)
 
-    @pytest.mark.xfail(reason="pre-existing: transaction validation mismatch on devnet")
     async def test_verify_premium_charge(
         self, rpc_url, funded_payer, funded_recipient, currency, charge_intent, chain_id
     ):
+        premium_amount = "900000000"
         method = tempo(
             account=funded_payer,
             chain_id=chain_id,
@@ -297,7 +297,9 @@ class TestChargeIntegration:
         )
         expires = _future_expires()
         request_dict = {
-            "amount": "1000000000",
+            # The dev faucet funds exactly 1_000_000_000 units, and gas is paid
+            # in the same token. Leave headroom so the payment can settle.
+            "amount": premium_amount,
             "currency": currency,
             "recipient": funded_recipient.address,
             "expires": expires,
@@ -322,7 +324,6 @@ class TestChargeIntegration:
         assert receipt.reference.startswith("0x")
         assert len(receipt.reference) >= 66
 
-    @pytest.mark.xfail(reason="pre-existing: transaction validation mismatch on devnet")
     async def test_e2e_charge_with_fee_payer(
         self, rpc_url, funded_payer, funded_recipient, currency, chain_id
     ):
@@ -410,7 +411,6 @@ class TestChargeIntegration:
         assert receipt.status == "success"
         assert receipt.reference.startswith("0x")
 
-    @pytest.mark.xfail(reason="pre-existing: transaction validation mismatch on devnet")
     async def test_verify_rejects_wrong_memo(
         self, rpc_url, funded_payer, funded_recipient, currency, charge_intent, chain_id
     ):
@@ -458,21 +458,13 @@ class TestChargeIntegration:
                 "memo": server_memo,
             },
         }
-        with pytest.raises(VerificationError, match="Transfer log"):
+        with pytest.raises(VerificationError, match="no matching payment call found"):
             await charge_intent.verify(credential, server_request)
 
-    @pytest.mark.xfail(reason="pre-existing: transaction validation mismatch on devnet")
     async def test_default_memo_accepted_when_server_omits_memo(
         self, rpc_url, funded_payer, funded_recipient, currency, charge_intent, chain_id
     ):
-        """Verification fails when client defaults a memo but server omits one.
-
-        Known incompatibility: the client always adds a memo (via
-        encode_attribution) when the server doesn't specify one, so the tx
-        emits TRANSFER_WITH_MEMO_TOPIC. The server's _verify_transfer_logs
-        without memo requires TRANSFER_TOPIC, causing a topic mismatch and
-        verification failure.
-        """
+        """Auto-generated attribution memos should still verify without a server memo."""
         method = tempo(
             account=funded_payer,
             chain_id=chain_id,
@@ -501,11 +493,10 @@ class TestChargeIntegration:
         )
 
         credential = await method.create_credential(challenge)
+        receipt = await charge_intent.verify(credential, request_dict)
 
-        # Verification must fail: server looks for TRANSFER_TOPIC but the tx
-        # emits TRANSFER_WITH_MEMO_TOPIC due to the client-defaulted memo.
-        with pytest.raises(VerificationError, match="Transfer log"):
-            await charge_intent.verify(credential, request_dict)
+        assert receipt.status == "success"
+        assert receipt.reference.startswith("0x")
 
     async def test_verify_hash_replay_rejected_with_store(
         self, rpc_url, funded_payer, funded_recipient, currency


### PR DESCRIPTION
## Summary

Align sponsored Tempo transaction construction with fee-payer policy limits, and finish the live integration harness cleanup.

### What changed
- Cap sponsored `max_priority_fee_per_gas` to the chain's fee-payer policy when building `0x78` envelopes
- Add a regression test covering sponsored priority fee capping on a custom/dev chain
- Extend live integration coverage for hash verification memo binding
- Remove stale `xfail`s now that the live devnet behavior has changed
- Fix the premium integration scenario to leave room for gas when the faucet-funded account pays fees in the same token

### Why
- The live fee-payer integration was failing on devnet because the client copied `eth_gasPrice` into `max_priority_fee_per_gas`, which exceeded the sponsor policy on chain `1337`
- Two integration `xfail`s had become stale: wrong-memo rejection now fails earlier during payload validation, and auto-generated attribution memos now verify successfully when the server omits an explicit memo
- The premium integration test was spending the full faucet balance, so the transaction reverted once gas was included

### Validation
- `uv run ruff check src/mpp/methods/tempo/client.py tests/test_tempo.py tests/test_tempo_integration.py`
- `uv run pyright`
- `uv run pytest tests/test_tempo.py -v`
- `TEMPO_RPC_URL=http://localhost:8545 uv run pytest tests/test_tempo_integration.py -m integration -v`

Integration result: `18 passed`
