### PR TITLE
fix: default chain_id to 4217 (mainnet), remove hardcoded fee payer

### DIFF
--- a/.changelog/easy-bats-bark.md
+++ b/.changelog/easy-bats-bark.md
@@ -1,0 +1,5 @@
+---
+pympp: patch
+---
+
+Defaulted `chain_id` to 4217 (mainnet) in the `tempo()` function, removing the need to pass it explicitly. Removed the hardcoded testnet fee payer URL fallback, requiring explicit fee payer configuration on mainnet. Updated tests and docs accordingly.

--- a/.changelog/gentle-eagles-whisper.md
+++ b/.changelog/gentle-eagles-whisper.md
@@ -1,0 +1,5 @@
+---
+pympp: patch
+---
+
+Defaulted `chain_id` to 4217 (mainnet) in the `tempo()` function, removing the need to pass it explicitly. Updated docs and example code accordingly.

--- a/src/mpp/methods/tempo/__init__.py
+++ b/src/mpp/methods/tempo/__init__.py
@@ -20,7 +20,6 @@ Example:
 
     server = Mpp.create(
         method=tempo(
-            chain_id=42431,
             intents={"charge": ChargeIntent()},
         ),
     )

--- a/src/mpp/methods/tempo/_defaults.py
+++ b/src/mpp/methods/tempo/_defaults.py
@@ -13,10 +13,6 @@ PATH_USD_DECIMALS = 6
 TESTNET_CHAIN_ID = 42431
 TESTNET_RPC_URL = "https://rpc.moderato.tempo.xyz"
 
-# Testnet only — the fee payer service sponsors gas on testnet.
-# On mainnet, the server itself must pay gas or provide its own fee payer.
-DEFAULT_FEE_PAYER_URL = "https://sponsor.moderato.tempo.xyz"
-
 # Chain ID -> default currency mapping
 # Mainnet defaults to USDC, testnet defaults to pathUSD
 DEFAULT_CURRENCIES: MappingProxyType[int, str] = MappingProxyType(

--- a/src/mpp/methods/tempo/client.py
+++ b/src/mpp/methods/tempo/client.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 from mpp import Challenge, Credential
 from mpp.methods.tempo._attribution import encode as encode_attribution
 from mpp.methods.tempo._defaults import (
+    CHAIN_ID,
     CHAIN_RPC_URLS,
     RPC_URL,
     default_currency_for_chain,
@@ -303,7 +304,7 @@ def tempo(
     intents: dict[str, Intent],
     account: TempoAccount | None = None,
     fee_payer: TempoAccount | None = None,
-    chain_id: int | None = None,
+    chain_id: int = CHAIN_ID,
     rpc_url: str | None = None,
     root_account: str | None = None,
     currency: str | None = None,
@@ -320,8 +321,8 @@ def tempo(
             (server-side). When set, the server signs with domain
             ``0x78`` and broadcasts directly — no external fee payer
             service needed.
-        chain_id: Tempo chain ID (4217 for mainnet, 42431 for testnet).
-            Resolves the RPC URL automatically from known chains.
+        chain_id: Tempo chain ID (default: 4217 for mainnet, use 42431
+            for testnet). Resolves the RPC URL automatically from known chains.
         rpc_url: Tempo RPC endpoint URL. Overrides the URL resolved
             from ``chain_id``. Defaults to mainnet if neither is set.
         root_account: Root account address for access key signing.
@@ -350,7 +351,7 @@ def tempo(
         )
     """
     if rpc_url is None:
-        rpc_url = rpc_url_for_chain(chain_id) if chain_id else RPC_URL
+        rpc_url = rpc_url_for_chain(chain_id)
 
     if currency is None:
         currency = default_currency_for_chain(chain_id)

--- a/src/mpp/methods/tempo/intents.py
+++ b/src/mpp/methods/tempo/intents.py
@@ -14,7 +14,7 @@ import attrs
 
 from mpp import Credential, Receipt
 from mpp.errors import VerificationError
-from mpp.methods.tempo._defaults import DEFAULT_FEE_PAYER_URL, PATH_USD, rpc_url_for_chain
+from mpp.methods.tempo._defaults import PATH_USD, rpc_url_for_chain
 from mpp.methods.tempo.schemas import (
     ChargeRequest,
     CredentialPayload,
@@ -366,7 +366,12 @@ class ChargeIntent:
             if self.fee_payer is not None:
                 raw_tx = self._cosign_as_fee_payer(raw_tx, request.currency, request=request)
             else:
-                fee_payer_url = request.methodDetails.feePayerUrl or DEFAULT_FEE_PAYER_URL
+                fee_payer_url = request.methodDetails.feePayerUrl
+                if not fee_payer_url:
+                    raise VerificationError(
+                        "No fee payer configured: set feePayer on the tempo() method "
+                        "or provide a feePayerUrl in methodDetails"
+                    )
 
                 sign_response = await client.post(
                     fee_payer_url,

--- a/tests/test_mpp_create.py
+++ b/tests/test_mpp_create.py
@@ -239,12 +239,12 @@ class TestMppCharge:
         assert result.request["recipient"] == "0xother"
 
     @pytest.mark.asyncio
-    async def test_charge_defaults_currency_to_pathusd(self) -> None:
-        """Currency defaults to pathUSD when chain_id is not set."""
-        from mpp.methods.tempo import PATH_USD
+    async def test_charge_defaults_currency_to_usdc(self) -> None:
+        """Currency defaults to USDC when chain_id defaults to mainnet (4217)."""
+        from mpp.methods.tempo import USDC
 
         method = tempo(intents={"charge": ChargeIntent()})
-        assert method.currency == PATH_USD
+        assert method.currency == USDC
 
     @pytest.mark.asyncio
     async def test_charge_defaults_currency_to_usdc_on_mainnet(self) -> None:

--- a/tests/test_tempo.py
+++ b/tests/test_tempo.py
@@ -612,9 +612,10 @@ class TestSponsoredTransfer:
             intents={"charge": ChargeIntent()},
         )
 
+        # eth_chainId
         httpx_mock.add_response(
             url="https://rpc.test",
-            json={"jsonrpc": "2.0", "result": "0x1", "id": 1},
+            json={"jsonrpc": "2.0", "result": "0x1079", "id": 1},
         )
         httpx_mock.add_response(
             url="https://rpc.test",
@@ -1191,10 +1192,10 @@ class TestChainIdPropagation:
         method = tempo(chain_id=42431, intents={"charge": ChargeIntent()})
         assert method.chain_id == 42431
 
-    def test_tempo_factory_chain_id_defaults_none(self) -> None:
-        """tempo() without chain_id should default to None."""
+    def test_tempo_factory_chain_id_defaults_mainnet(self) -> None:
+        """tempo() without chain_id should default to 4217 (mainnet)."""
         method = tempo(intents={"charge": ChargeIntent()})
-        assert method.chain_id is None
+        assert method.chain_id == 4217
 
     def test_tempo_factory_chain_id_resolves_rpc(self) -> None:
         """tempo(chain_id=42431) should resolve testnet RPC URL."""
@@ -1275,9 +1276,10 @@ class TestChainIdPropagation:
             intents={"charge": ChargeIntent()},
         )
 
+        # eth_chainId
         httpx_mock.add_response(
             url="https://rpc.custom",
-            json={"jsonrpc": "2.0", "result": "0x1", "id": 1},
+            json={"jsonrpc": "2.0", "result": "0x1079", "id": 1},
         )
         httpx_mock.add_response(
             url="https://rpc.custom",
@@ -1323,9 +1325,10 @@ class TestChainIdPropagation:
             intents={"charge": ChargeIntent()},
         )
 
+        # eth_chainId
         httpx_mock.add_response(
             url="https://rpc.custom",
-            json={"jsonrpc": "2.0", "result": "0x1", "id": 1},
+            json={"jsonrpc": "2.0", "result": "0x1079", "id": 1},
         )
         httpx_mock.add_response(
             url="https://rpc.custom",
@@ -1415,8 +1418,12 @@ class TestAccessKeySigning:
             intents={"charge": ChargeIntent()},
         )
 
-        # Mock RPC: chain_id, nonce, gas_price, estimateGas
-        for _ in range(4):
+        # Mock RPC: chain_id (4217=0x1079), nonce, gas_price, estimateGas
+        httpx_mock.add_response(
+            url="https://rpc.test",
+            json={"jsonrpc": "2.0", "result": "0x1079", "id": 1},
+        )
+        for _ in range(3):
             httpx_mock.add_response(
                 url="https://rpc.test",
                 json={"jsonrpc": "2.0", "result": "0x1", "id": 1},
@@ -1455,9 +1462,15 @@ class TestAccessKeySigning:
             intents={"charge": ChargeIntent()},
         )
 
-        for _ in range(4):
+        # Mock RPC: chain_id (4217=0x1079), nonce, gas_price, estimateGas
+        # Challenge chainId=4217 resolves to rpc.tempo.xyz
+        httpx_mock.add_response(
+            url="https://rpc.tempo.xyz",
+            json={"jsonrpc": "2.0", "result": "0x1079", "id": 1},
+        )
+        for _ in range(3):
             httpx_mock.add_response(
-                url="https://rpc.test",
+                url="https://rpc.tempo.xyz",
                 json={"jsonrpc": "2.0", "result": "0x1", "id": 1},
             )
 
@@ -1469,7 +1482,7 @@ class TestAccessKeySigning:
                 "amount": "1000000",
                 "currency": "0x20c0000000000000000000000000000000000000",
                 "recipient": "0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
-                "methodDetails": {"feePayer": True, "chainId": 1},
+                "methodDetails": {"feePayer": True, "chainId": 4217},
             },
             realm="test.example.com",
             request_b64="e30",
@@ -1492,7 +1505,12 @@ class TestAccessKeySigning:
             intents={"charge": ChargeIntent()},
         )
 
-        for _ in range(4):
+        # Mock RPC: chain_id (4217=0x1079), nonce, gas_price, estimateGas
+        httpx_mock.add_response(
+            url="https://rpc.test",
+            json={"jsonrpc": "2.0", "result": "0x1079", "id": 1},
+        )
+        for _ in range(3):
             httpx_mock.add_response(
                 url="https://rpc.test",
                 json={"jsonrpc": "2.0", "result": "0x1", "id": 1},


### PR DESCRIPTION
## Summary

Default `chain_id` to 4217 (mainnet) in the `tempo()` function, matching mppx and mpp-rs. Remove the hardcoded testnet fee payer URL — callers must now explicitly configure a fee payer.

### Changes
- Default `chain_id` parameter from `None` to `CHAIN_ID` (4217)
- Remove `DEFAULT_FEE_PAYER_URL` constant — raise `VerificationError` if no fee payer is configured
- Remove `chain_id=42431` from docstring example (no longer needed)
- Update default currency test: mainnet default is now USDC, not pathUSD
- Update mock RPC responses to return `0x1079` (4217) for `eth_chainId`
- Add changelog entry