### PR TITLE
fix: accept attribution memos in pull-mode preflight

### DIFF
--- a/.changelog/fix-pull-mode-attribution-memo.md
+++ b/.changelog/fix-pull-mode-attribution-memo.md
@@ -2,4 +2,4 @@
 pympp: patch
 ---
 
-Allowed Tempo pull-mode preflight validation to accept client attribution memos while still rejecting truncated `transferWithMemo` calldata.
+Allowed Tempo pull-mode validation to accept client attribution memos in both preflight calldata checks and split receipt matching while still rejecting truncated `transferWithMemo` calldata.

--- a/.changelog/fix-pull-mode-attribution-memo.md
+++ b/.changelog/fix-pull-mode-attribution-memo.md
@@ -1,0 +1,5 @@
+---
+pympp: patch
+---
+
+Allowed Tempo pull-mode preflight validation to accept client attribution memos while still rejecting truncated `transferWithMemo` calldata.

--- a/.changelog/happy-whales-eat.md
+++ b/.changelog/happy-whales-eat.md
@@ -1,0 +1,5 @@
+---
+pympp: patch
+---
+
+Allowed Tempo pull-mode preflight validation to accept client attribution memos (`transferWithMemo` calldata) while still rejecting truncated `transferWithMemo` calldata without a memo payload.

--- a/.changelog/happy-whales-eat.md
+++ b/.changelog/happy-whales-eat.md
@@ -1,5 +1,0 @@
----
-pympp: patch
----
-
-Allowed Tempo pull-mode preflight validation to accept client attribution memos (`transferWithMemo` calldata) while still rejecting truncated `transferWithMemo` calldata without a memo payload.

--- a/src/mpp/methods/tempo/intents.py
+++ b/src/mpp/methods/tempo/intents.py
@@ -139,6 +139,9 @@ def _match_single_transfer_calldata(
     if memo is not None:
         if selector != TRANSFER_WITH_MEMO_SELECTOR:
             return False
+    elif selector == TRANSFER_WITH_MEMO_SELECTOR:
+        if len(call_data_hex) < 200:
+            return False
     elif selector != TRANSFER_SELECTOR:
         return False
 
@@ -186,6 +189,9 @@ def _match_transfer_calldata(call_data_hex: str, request: ChargeRequest) -> bool
 
     if expected_memo:
         if selector != TRANSFER_WITH_MEMO_SELECTOR:
+            return False
+    elif selector == TRANSFER_WITH_MEMO_SELECTOR:
+        if len(call_data_hex) < 200:
             return False
     elif selector != TRANSFER_SELECTOR:
         return False

--- a/src/mpp/methods/tempo/intents.py
+++ b/src/mpp/methods/tempo/intents.py
@@ -537,9 +537,9 @@ class ChargeIntent:
         # Prefer memo logs so memo-less transfers still preserve attribution
         # memos for challenge binding verification when both log types exist.
         indexed_logs.sort(
-            key=lambda item: 0
-            if item[1].get("topics", [None])[0] == TRANSFER_WITH_MEMO_TOPIC
-            else 1
+            key=lambda item: (
+                0 if item[1].get("topics", [None])[0] == TRANSFER_WITH_MEMO_TOPIC else 1
+            )
         )
         used_logs: set[int] = set()
         all_matches: list[MatchedTransferLog] = []

--- a/src/mpp/methods/tempo/intents.py
+++ b/src/mpp/methods/tempo/intents.py
@@ -533,13 +533,20 @@ class ChargeIntent:
 
         # Multi-transfer: order-insensitive matching
         sorted_expected = sorted(expected, key=lambda t: 0 if t.memo else 1)
-        logs = receipt.get("logs", [])
+        indexed_logs = list(enumerate(receipt.get("logs", [])))
+        # Prefer memo logs so memo-less transfers still preserve attribution
+        # memos for challenge binding verification when both log types exist.
+        indexed_logs.sort(
+            key=lambda item: 0
+            if item[1].get("topics", [None])[0] == TRANSFER_WITH_MEMO_TOPIC
+            else 1
+        )
         used_logs: set[int] = set()
         all_matches: list[MatchedTransferLog] = []
 
         for transfer in sorted_expected:
             found = False
-            for log_idx, log in enumerate(logs):
+            for log_idx, log in indexed_logs:
                 if log_idx in used_logs:
                     continue
                 if log.get("address", "").lower() != request.currency.lower():
@@ -575,10 +582,21 @@ class ChargeIntent:
                         found = True
                         break
                 else:
-                    if event_topic != TRANSFER_TOPIC:
-                        continue
                     data = log.get("data", "0x")
-                    if len(data) >= 66:
+                    if event_topic == TRANSFER_WITH_MEMO_TOPIC:
+                        if len(topics) < 4:
+                            continue
+                        if len(data) < 66:
+                            continue
+                        log_amount = int(data[2:66], 16)
+                        if log_amount == transfer.amount:
+                            used_logs.add(log_idx)
+                            all_matches.append(MatchedTransferLog(kind="memo", memo=topics[3]))
+                            found = True
+                            break
+                    elif event_topic == TRANSFER_TOPIC:
+                        if len(data) < 66:
+                            continue
                         log_amount = int(data, 16)
                         if log_amount == transfer.amount:
                             used_logs.add(log_idx)

--- a/tests/test_tempo.py
+++ b/tests/test_tempo.py
@@ -2839,7 +2839,7 @@ class TestMatchSingleTransferCalldata:
 
 
 class TestSplitLogMemoStrictness:
-    """Tests that memo-less split logs reject transferWithMemo events."""
+    """Tests that memo-less split logs can still preserve attribution memos."""
 
     CURRENCY = "0x20c0000000000000000000000000000000000000"
     RECIPIENT = "0x742d35Cc6634c0532925a3b844bC9e7595F8fE00"
@@ -2884,8 +2884,8 @@ class TestSplitLogMemoStrictness:
         }
         assert intent._verify_transfer_logs(receipt, request)
 
-    def test_multi_split_rejects_transfer_with_memo_log_for_memoless(self) -> None:
-        """Memo-less split legs must reject TransferWithMemo logs."""
+    def test_multi_split_accepts_transfer_with_memo_log_for_memoless(self) -> None:
+        """Memo-less split legs should accept TransferWithMemo logs."""
         intent = ChargeIntent(rpc_url="https://rpc.test")
         request = ChargeRequest(
             amount=str(self.AMOUNT),
@@ -2899,7 +2899,7 @@ class TestSplitLogMemoStrictness:
             "logs": [
                 # primary as Transfer (correct)
                 self._make_log(TRANSFER_TOPIC, self.RECIPIENT, 700000),
-                # split as TransferWithMemo (should be rejected)
+                # split as TransferWithMemo (accepted; challenge binding is checked later)
                 self._make_log(
                     TRANSFER_WITH_MEMO_TOPIC,
                     self.SPLIT_RECIPIENT,
@@ -2908,7 +2908,34 @@ class TestSplitLogMemoStrictness:
                 ),
             ],
         }
-        assert not intent._verify_transfer_logs(receipt, request)
+        matched_logs = intent._verify_transfer_logs(receipt, request)
+        assert [matched_log.kind for matched_log in matched_logs] == ["transfer", "memo"]
+
+    def test_multi_split_prefers_transfer_with_memo_log_for_memoless(self) -> None:
+        """Memo-less split legs should prefer memo logs over plain transfers when both exist."""
+        intent = ChargeIntent(rpc_url="https://rpc.test")
+        request = ChargeRequest(
+            amount=str(self.AMOUNT),
+            currency=self.CURRENCY,
+            recipient=self.RECIPIENT,
+            methodDetails=MethodDetails(
+                splits=[Split(amount="300000", recipient=self.SPLIT_RECIPIENT)]
+            ),
+        )
+        receipt = {
+            "logs": [
+                self._make_log(TRANSFER_TOPIC, self.RECIPIENT, 700000),
+                self._make_log(TRANSFER_TOPIC, self.SPLIT_RECIPIENT, 300000),
+                self._make_log(
+                    TRANSFER_WITH_MEMO_TOPIC,
+                    self.SPLIT_RECIPIENT,
+                    300000,
+                    memo="0x" + "ee" * 32,
+                ),
+            ],
+        }
+        matched_logs = intent._verify_transfer_logs(receipt, request)
+        assert [matched_log.kind for matched_log in matched_logs] == ["transfer", "memo"]
 
 
 class TestSplitsFeePayerRejection:

--- a/tests/test_tempo.py
+++ b/tests/test_tempo.py
@@ -1418,16 +1418,19 @@ class TestValidateTransactionPayload:
         currency: str = "0x20c0000000000000000000000000000000000000",
         recipient: str = "0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
         amount: int = 1000000,
+        memo: str | None = None,
     ) -> str:
         """Build a 0x78 fee payer envelope."""
         from pytempo import Call, TempoTransaction
 
         from mpp.methods.tempo.fee_payer_envelope import encode_fee_payer_envelope
 
-        selector = "a9059cbb"
+        selector = TRANSFER_WITH_MEMO_SELECTOR if memo is not None else TRANSFER_SELECTOR
         to_padded = recipient[2:].lower().zfill(64)
         amount_padded = hex(amount)[2:].zfill(64)
         transfer_data = f"0x{selector}{to_padded}{amount_padded}"
+        if memo is not None:
+            transfer_data += memo[2:] if memo.startswith("0x") else memo
 
         tx = TempoTransaction.create(
             chain_id=42431,
@@ -1449,16 +1452,19 @@ class TestValidateTransactionPayload:
         currency: str = "0x20c0000000000000000000000000000000000000",
         recipient: str = "0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
         amount: int = 1000000,
+        memo: str | None = None,
     ) -> str:
         """Build a standard 0x76 transaction."""
         import attrs
         from pytempo import Call, TempoTransaction
         from pytempo.models import Signature
 
-        selector = "a9059cbb"
+        selector = TRANSFER_WITH_MEMO_SELECTOR if memo is not None else TRANSFER_SELECTOR
         to_padded = recipient[2:].lower().zfill(64)
         amount_padded = hex(amount)[2:].zfill(64)
         transfer_data = f"0x{selector}{to_padded}{amount_padded}"
+        if memo is not None:
+            transfer_data += memo[2:] if memo.startswith("0x") else memo
 
         tx = TempoTransaction.create(
             chain_id=42431,
@@ -1484,6 +1490,19 @@ class TestValidateTransactionPayload:
         )
         sig = self._build_0x78_envelope()
         # Should not raise
+        intent._validate_transaction_payload(sig, request)
+
+    def test_accepts_0x78_with_transfer_with_memo_when_no_server_memo(self) -> None:
+        """Should accept 0x78 envelopes with client attribution memos."""
+        intent = ChargeIntent(rpc_url="https://rpc.test")
+        request = ChargeRequest(
+            amount="1000000",
+            currency="0x20c0000000000000000000000000000000000000",
+            recipient="0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
+        )
+        memo = encode_attribution(challenge_id="challenge-123", server_id="api.example.com")
+        sig = self._build_0x78_envelope(memo=memo)
+
         intent._validate_transaction_payload(sig, request)
 
     def test_rejects_0x78_with_wrong_amount(self) -> None:
@@ -2092,15 +2111,21 @@ class TestMatchTransferCalldataWithMemo:
         )
         assert _match_transfer_calldata(calldata, request) is True
 
-    def test_no_memo_accepts_only_transfer_selector(self) -> None:
-        """When no memo, only plain transfer selector should be accepted."""
+    def test_no_memo_accepts_plain_transfer_and_transfer_with_memo(self) -> None:
+        """When no memo, plain transfer and transferWithMemo should be accepted."""
         request = self._make_request(memo=None)
         calldata_plain = self._build_calldata(TRANSFER_SELECTOR, self.RECIPIENT, self.AMOUNT)
         calldata_memo = self._build_calldata(
-            TRANSFER_WITH_MEMO_SELECTOR, self.RECIPIENT, self.AMOUNT
+            TRANSFER_WITH_MEMO_SELECTOR, self.RECIPIENT, self.AMOUNT, self.MEMO
         )
         assert _match_transfer_calldata(calldata_plain, request) is True
-        assert _match_transfer_calldata(calldata_memo, request) is False
+        assert _match_transfer_calldata(calldata_memo, request) is True
+
+    def test_no_memo_rejects_short_transfer_with_memo_calldata(self) -> None:
+        """When no memo, truncated transferWithMemo calldata should still be rejected."""
+        request = self._make_request(memo=None)
+        calldata = self._build_calldata(TRANSFER_WITH_MEMO_SELECTOR, self.RECIPIENT, self.AMOUNT)
+        assert _match_transfer_calldata(calldata, request) is False
 
     def test_short_calldata_rejected(self) -> None:
         """Calldata shorter than 136 chars should always be rejected."""
@@ -2326,6 +2351,25 @@ class TestValidateTransactionPayload0x76:
         to_padded = bytes.fromhex(self.RECIPIENT[2:].lower().zfill(64))
         amount_padded = bytes.fromhex(hex(1000000)[2:].zfill(64))
         call_data = selector + to_padded + amount_padded
+
+        currency_bytes = bytes.fromhex(self.CURRENCY[2:])
+        call = [currency_bytes, b"", call_data]
+        decoded = [b"\x01", b"\x01", b"\x01", b"\x01", [call], b"", b"", b"\x00", b"", b"", b""]
+        payload = b"\x76" + rlp.encode(decoded)  # type: ignore[operator]
+        sig = "0x" + payload.hex()
+
+        intent._validate_transaction_payload(sig, request)
+
+    def test_valid_tx_with_transfer_with_memo_passes_when_no_server_memo(self) -> None:
+        """Transaction credentials should allow client attribution memos."""
+        intent = ChargeIntent(rpc_url="https://rpc.test")
+        request = self._make_request()
+        memo = encode_attribution(challenge_id="challenge-123", server_id="api.example.com")
+
+        selector = bytes.fromhex(TRANSFER_WITH_MEMO_SELECTOR)
+        to_padded = bytes.fromhex(self.RECIPIENT[2:].lower().zfill(64))
+        amount_padded = bytes.fromhex(hex(1000000)[2:].zfill(64))
+        call_data = selector + to_padded + amount_padded + bytes.fromhex(memo[2:])
 
         currency_bytes = bytes.fromhex(self.CURRENCY[2:])
         call = [currency_bytes, b"", call_data]
@@ -2774,8 +2818,18 @@ class TestMatchSingleTransferCalldata:
             is True
         )
 
-    def test_no_memo_rejects_transfer_with_memo_selector(self) -> None:
-        """When no memo expected, transferWithMemo calldata must be rejected."""
+    def test_no_memo_accepts_transfer_with_memo_selector(self) -> None:
+        """When no memo expected, transferWithMemo calldata should be accepted."""
+        calldata = self._build_calldata(
+            TRANSFER_WITH_MEMO_SELECTOR,
+            self.RECIPIENT,
+            self.AMOUNT,
+            "ab" * 32,
+        )
+        assert _match_single_transfer_calldata(calldata, self.RECIPIENT, self.AMOUNT, None) is True
+
+    def test_no_memo_rejects_short_transfer_with_memo_calldata(self) -> None:
+        """When no memo expected, truncated transferWithMemo calldata should be rejected."""
         calldata = self._build_calldata(TRANSFER_WITH_MEMO_SELECTOR, self.RECIPIENT, self.AMOUNT)
         assert _match_single_transfer_calldata(calldata, self.RECIPIENT, self.AMOUNT, None) is False
 


### PR DESCRIPTION
Fixes #128.

## Summary
- allow Tempo preflight calldata validation to accept `transferWithMemo` when the server challenge did not set an explicit memo
- keep memo-specific validation strict when the server does set a memo
- reject truncated `transferWithMemo` calldata so the broader selector acceptance only applies to real memo-bearing calls
- add regression coverage for raw `0x76` transactions, `0x78` fee-payer envelopes, and the lower-level calldata matchers