### PR TITLE
fix: enforce pympp client chain policy

### DIFF
--- a/.changelog/ugly-sheep-whisper.md
+++ b/.changelog/ugly-sheep-whisper.md
@@ -1,0 +1,5 @@
+---
+pympp: patch
+---
+
+Fixed client chain policy enforcement to reject challenges that attempt to switch the client to a different chain. Clients pinned to a chain (via `chain_id` or `rpc_url`) now raise a `ValueError` immediately instead of silently following the challenge's `chainId`.

--- a/src/mpp/methods/tempo/client.py
+++ b/src/mpp/methods/tempo/client.py
@@ -8,13 +8,12 @@ from __future__ import annotations
 import asyncio
 import time
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from mpp import Challenge, Credential
 from mpp.methods.tempo._attribution import encode as encode_attribution
 from mpp.methods.tempo._defaults import (
     CHAIN_ID,
-    CHAIN_RPC_URLS,
     RPC_URL,
     default_currency_for_chain,
     rpc_url_for_chain,
@@ -32,6 +31,7 @@ if TYPE_CHECKING:
 DEFAULT_GAS_LIMIT = 1_000_000
 EXPIRING_NONCE_KEY = (1 << 256) - 1  # U256::MAX
 FEE_PAYER_VALID_BEFORE_SECS = 25
+_CHAIN_ID_UNSET = object()
 
 
 class TransactionError(Exception):
@@ -75,7 +75,9 @@ class TempoMethod:
     client_id: str | None = None
     _intents: dict[str, Intent] = field(default_factory=dict)
     _cached_chain_ids: dict[str, int] = field(default_factory=dict, init=False, repr=False)
+    _chain_id_explicit: bool = field(default=False, init=False, repr=False)
     _chain_id_lock: asyncio.Lock | None = field(default=None, init=False, repr=False)
+    _rpc_url_explicit: bool = field(default=False, init=False, repr=False)
 
     @property
     def intents(self) -> dict[str, Intent]:
@@ -100,6 +102,21 @@ class TempoMethod:
             chain_id = int(chain_id_hex, 16)
             self._cached_chain_ids[rpc_url] = chain_id
             return chain_id
+
+    async def _resolve_expected_chain_id(self) -> int | None:
+        """Return the chain ID pinned by local client configuration.
+
+        A client may pin the chain explicitly via ``chain_id`` or implicitly by
+        supplying a custom ``rpc_url``. In the latter case, trust the chain
+        reported by that RPC instead of the server challenge.
+        """
+        if self._rpc_url_explicit and not self._chain_id_explicit:
+            return await self._get_chain_id(self.rpc_url)
+        if self.chain_id is not None:
+            return self.chain_id
+        if self.rpc_url:
+            return await self._get_chain_id(self.rpc_url)
+        return None
 
     async def create_credential(self, challenge: Challenge) -> Credential:
         """Create a credential to satisfy the given challenge.
@@ -149,10 +166,8 @@ class TempoMethod:
 
         splits = method_details.get("splits") if isinstance(method_details, dict) else None
 
-        # Resolve RPC URL from challenge's chainId (like mppx), falling back
-        # to the method-level rpc_url.
         rpc_url = self.rpc_url
-        expected_chain_id: int | None = None
+        expected_chain_id = await self._resolve_expected_chain_id()
         challenge_chain_id = (
             method_details.get("chainId") if isinstance(method_details, dict) else None
         )
@@ -162,17 +177,13 @@ class TempoMethod:
             except (TypeError, ValueError):
                 pass
             else:
-                resolved = CHAIN_RPC_URLS.get(parsed_chain_id)
-                if resolved is not None:
-                    rpc_url = resolved
-                    # Only enforce mismatch check when we resolved to a known
-                    # RPC URL — for unknown chains we fall back to the user's
-                    # custom rpc_url and can't verify the chain ID.
+                if expected_chain_id is not None and parsed_chain_id != expected_chain_id:
+                    raise ValueError(
+                        f"Challenge requests chain ID {parsed_chain_id}, "
+                        f"but client is restricted to {expected_chain_id}"
+                    )
+                if expected_chain_id is None:
                     expected_chain_id = parsed_chain_id
-
-        # Also check against the method-level chain_id if set.
-        if expected_chain_id is None and self.chain_id is not None:
-            expected_chain_id = self.chain_id
 
         raw_tx, chain_id = await self._build_tempo_transfer(
             amount=request["amount"],
@@ -280,7 +291,7 @@ class TempoMethod:
         if expected_chain_id is not None and chain_id != expected_chain_id:
             raise TransactionError(
                 f"Chain ID mismatch: RPC returned {chain_id}, "
-                f"expected {expected_chain_id} from challenge"
+                f"expected {expected_chain_id} from client policy"
             )
 
         if awaiting_fee_payer:
@@ -371,7 +382,7 @@ def tempo(
     intents: dict[str, Intent],
     account: TempoAccount | None = None,
     fee_payer: TempoAccount | None = None,
-    chain_id: int = CHAIN_ID,
+    chain_id: int | None | object = _CHAIN_ID_UNSET,
     rpc_url: str | None = None,
     root_account: str | None = None,
     currency: str | None = None,
@@ -391,7 +402,9 @@ def tempo(
         chain_id: Tempo chain ID (default: 4217 for mainnet, use 42431
             for testnet). Resolves the RPC URL automatically from known chains.
         rpc_url: Tempo RPC endpoint URL. Overrides the URL resolved
-            from ``chain_id``. Defaults to mainnet if neither is set.
+            from ``chain_id``. When provided without ``chain_id``, the client
+            pins itself to whatever chain that RPC reports. Defaults to mainnet
+            if neither is set.
         root_account: Root account address for access key signing.
         currency: Default currency address for charges.
         recipient: Default recipient address for charges.
@@ -417,23 +430,35 @@ def tempo(
             intents={"charge": ChargeIntent()},
         )
     """
+    chain_id_explicit = chain_id is not _CHAIN_ID_UNSET
+    resolved_chain_id: int | None
+    if chain_id is _CHAIN_ID_UNSET:
+        resolved_chain_id = CHAIN_ID
+    else:
+        resolved_chain_id = cast("int | None", chain_id)
+
+    rpc_url_explicit = rpc_url is not None
     if rpc_url is None:
-        rpc_url = rpc_url_for_chain(chain_id)
+        if resolved_chain_id is None:
+            raise ValueError("chain_id or rpc_url is required")
+        rpc_url = rpc_url_for_chain(resolved_chain_id)
 
     if currency is None:
-        currency = default_currency_for_chain(chain_id)
+        currency = default_currency_for_chain(resolved_chain_id)
 
     method = TempoMethod(
         account=account,
         fee_payer=fee_payer,
         rpc_url=rpc_url,
-        chain_id=chain_id,
+        chain_id=resolved_chain_id,
         root_account=root_account,
         currency=currency,
         recipient=recipient,
         decimals=decimals,
         client_id=client_id,
     )
+    method._chain_id_explicit = chain_id_explicit
+    method._rpc_url_explicit = rpc_url_explicit
     for intent in intents.values():
         if hasattr(intent, "rpc_url") and intent.rpc_url is None:  # type: ignore[union-attr]
             intent.rpc_url = rpc_url  # type: ignore[union-attr]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -216,6 +216,37 @@ class TestPaymentTransport:
         assert len(inner.requests) == 2
         method.create_credential.assert_called_once()
 
+    @pytest.mark.asyncio
+    async def test_does_not_retry_when_method_rejects_challenge(self) -> None:
+        """Should not send an Authorization retry when the method rejects the challenge."""
+        challenge = Challenge(
+            id="test-id",
+            method="tempo",
+            intent="charge",
+            request={"amount": "1000", "methodDetails": {"chainId": 42431}},
+        )
+        www_auth = challenge.to_www_authenticate("example.com")
+
+        inner = MockTransport(
+            [
+                httpx.Response(402, headers={"www-authenticate": www_auth}),
+            ]
+        )
+
+        method = MockMethod()
+        method.create_credential.side_effect = ValueError(
+            "Challenge requests chain ID 42431, but client is restricted to 4217"
+        )
+        transport = PaymentTransport(methods=[method], inner=inner)
+
+        request = httpx.Request("GET", "https://example.com")
+
+        with pytest.raises(ValueError, match="client is restricted to 4217"):
+            await transport.handle_async_request(request)
+
+        assert len(inner.requests) == 1
+        method.create_credential.assert_called_once()
+
 
 class TestClient:
     @pytest.mark.asyncio

--- a/tests/test_tempo.py
+++ b/tests/test_tempo.py
@@ -226,15 +226,15 @@ class TestTempoMethod:
         assert rpc_methods.count("eth_gasPrice") == 2
 
     @pytest.mark.asyncio
-    async def test_create_credential_caches_chain_id_separately_per_rpc_url(self) -> None:
-        """Should keep separate chain ID caches for different resolved RPC URLs."""
+    async def test_create_credential_reuses_cached_rpc_chain_id_for_rejected_switch(self) -> None:
+        """Should reject switched chains without refetching an already-cached RPC chain ID."""
         account = TempoAccount.from_key(TEST_PRIVATE_KEY)
         method = tempo(
             account=account,
             rpc_url="https://rpc.main",
             intents={"charge": ChargeIntent()},
         )
-        mainnet_challenge = Challenge(
+        initial_challenge = Challenge(
             id="test-mainnet-cache",
             method="tempo",
             intent="charge",
@@ -246,7 +246,7 @@ class TestTempoMethod:
             realm="test.example.com",
             request_b64="e30",
         )
-        testnet_challenge = Challenge(
+        switched_challenge = Challenge(
             id="test-testnet-cache",
             method="tempo",
             intent="charge",
@@ -261,8 +261,7 @@ class TestTempoMethod:
         )
 
         rpc_calls: list[tuple[str, str]] = []
-        mainnet_nonces = iter(["0x1", "0x2"])
-        testnet_nonces = iter(["0x5", "0x6"])
+        nonces = iter(["0x1"])
 
         async def fake_rpc_call(
             rpc_url: str,
@@ -274,15 +273,9 @@ class TestTempoMethod:
             del params, client
             rpc_calls.append((rpc_url, method_name))
             if method_name == "eth_chainId":
-                if rpc_url == "https://rpc.main":
-                    return "0x1079"
-                if rpc_url == CHAIN_RPC_URLS[TESTNET_CHAIN_ID]:
-                    return hex(TESTNET_CHAIN_ID)
+                return "0x1079"
             if method_name == "eth_getTransactionCount":
-                if rpc_url == "https://rpc.main":
-                    return next(mainnet_nonces)
-                if rpc_url == CHAIN_RPC_URLS[TESTNET_CHAIN_ID]:
-                    return next(testnet_nonces)
+                return next(nonces)
             if method_name == "eth_gasPrice":
                 return "0x1"
             raise AssertionError(f"Unexpected RPC call: {rpc_url} {method_name}")
@@ -291,14 +284,12 @@ class TestTempoMethod:
             patch("mpp.methods.tempo.client._rpc_call", side_effect=fake_rpc_call),
             patch("mpp.methods.tempo.client.estimate_gas", new=AsyncMock(return_value=0x186A0)),
         ):
-            await method.create_credential(mainnet_challenge)
-            await method.create_credential(mainnet_challenge)
-            await method.create_credential(testnet_challenge)
-            await method.create_credential(testnet_challenge)
+            await method.create_credential(initial_challenge)
+            with pytest.raises(ValueError, match="client is restricted to 4217"):
+                await method.create_credential(switched_challenge)
 
         chain_id_calls = [call for call in rpc_calls if call[1] == "eth_chainId"]
-        assert chain_id_calls.count(("https://rpc.main", "eth_chainId")) == 1
-        assert chain_id_calls.count((CHAIN_RPC_URLS[TESTNET_CHAIN_ID], "eth_chainId")) == 1
+        assert chain_id_calls == [("https://rpc.main", "eth_chainId")]
 
     @pytest.mark.asyncio
     async def test_create_credential_binds_auto_memo_to_challenge(self) -> None:
@@ -1953,37 +1944,17 @@ class TestChainIdPropagation:
         assert method.rpc_url == "https://custom.rpc"
 
     @pytest.mark.asyncio
-    async def test_client_resolves_rpc_from_challenge_chain_id(self, httpx_mock: HTTPXMock) -> None:
-        """Client should use RPC URL matching challenge's methodDetails.chainId."""
+    async def test_client_rejects_challenge_chain_id_that_switches_default_network(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        """Client should reject challenges that try to switch away from its default chain."""
         account = TempoAccount.from_key(TEST_PRIVATE_KEY)
-        # Method defaults to mainnet RPC
         method = tempo(
             account=account,
             intents={"charge": ChargeIntent()},
         )
-        assert method.rpc_url == "https://rpc.tempo.xyz"
-
-        # Mock testnet RPC responses (chain_id, nonce, gas_price, estimateGas)
-        httpx_mock.add_response(
-            url="https://rpc.moderato.tempo.xyz",
-            json={"jsonrpc": "2.0", "result": "0xa5bf", "id": 1},  # chain_id 42431
-        )
-        httpx_mock.add_response(
-            url="https://rpc.moderato.tempo.xyz",
-            json={"jsonrpc": "2.0", "result": "0x1", "id": 1},
-        )
-        httpx_mock.add_response(
-            url="https://rpc.moderato.tempo.xyz",
-            json={"jsonrpc": "2.0", "result": "0x1", "id": 1},
-        )
-        httpx_mock.add_response(
-            url="https://rpc.moderato.tempo.xyz",
-            json={"jsonrpc": "2.0", "result": "0x186a0", "id": 1},
-        )
-
-        # Challenge says chainId=42431 in methodDetails
         challenge = Challenge(
-            id="test-chain-resolve",
+            id="test-chain-switch-default",
             method="tempo",
             intent="charge",
             request={
@@ -1996,65 +1967,43 @@ class TestChainIdPropagation:
             request_b64="e30",
         )
 
-        credential = await method.create_credential(challenge)
+        with pytest.raises(ValueError, match="client is restricted to 4217"):
+            await method.create_credential(challenge)
 
-        # Should have called testnet RPC, not mainnet
-        requests = httpx_mock.get_requests()
-        assert len(requests) > 0
-        for r in requests:
-            assert "rpc.moderato.tempo.xyz" in str(r.url)
-        assert credential.payload["type"] == "transaction"
+        assert httpx_mock.get_requests() == []
 
     @pytest.mark.asyncio
-    async def test_client_falls_back_to_method_rpc_for_unknown_chain(
-        self, httpx_mock: HTTPXMock
+    async def test_client_rejects_challenge_chain_id_that_switches_explicit_rpc(
+        self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Client should fall back to method's rpc_url for unknown chainIds."""
+        """Client should reject challenges that try to switch away from a pinned RPC."""
         account = TempoAccount.from_key(TEST_PRIVATE_KEY)
         method = tempo(
             account=account,
             rpc_url="https://rpc.custom",
             intents={"charge": ChargeIntent()},
         )
-
-        # eth_chainId
-        httpx_mock.add_response(
-            url="https://rpc.custom",
-            json={"jsonrpc": "2.0", "result": "0x1079", "id": 1},
-        )
-        httpx_mock.add_response(
-            url="https://rpc.custom",
-            json={"jsonrpc": "2.0", "result": "0x1", "id": 1},
-        )
-        httpx_mock.add_response(
-            url="https://rpc.custom",
-            json={"jsonrpc": "2.0", "result": "0x1", "id": 1},
-        )
-        httpx_mock.add_response(
-            url="https://rpc.custom",
-            json={"jsonrpc": "2.0", "result": "0x186a0", "id": 1},
-        )
+        get_chain_id = AsyncMock(return_value=TESTNET_CHAIN_ID)
+        monkeypatch.setattr(method, "_get_chain_id", get_chain_id)
 
         challenge = Challenge(
-            id="test-unknown-chain",
+            id="test-chain-switch-explicit-rpc",
             method="tempo",
             intent="charge",
             request={
                 "amount": "1000000",
                 "currency": "0x20c0000000000000000000000000000000000000",
                 "recipient": "0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
-                "methodDetails": {"chainId": 99999},
+                "methodDetails": {"chainId": CHAIN_ID},
             },
             realm="test.example.com",
             request_b64="e30",
         )
 
-        credential = await method.create_credential(challenge)
-        requests = httpx_mock.get_requests()
-        assert len(requests) > 0
-        for r in requests:
-            assert "rpc.custom" in str(r.url)
-        assert credential.payload["type"] == "transaction"
+        with pytest.raises(ValueError, match=rf"client is restricted to {TESTNET_CHAIN_ID}"):
+            await method.create_credential(challenge)
+
+        get_chain_id.assert_awaited_once_with("https://rpc.custom")
 
     @pytest.mark.asyncio
     async def test_client_ignores_non_numeric_chain_id(self, httpx_mock: HTTPXMock) -> None:
@@ -2109,20 +2058,21 @@ class TestChainIdPropagation:
         account = TempoAccount.from_key(TEST_PRIVATE_KEY)
         method = tempo(
             account=account,
+            chain_id=TESTNET_CHAIN_ID,
+            rpc_url="https://rpc.custom",
             intents={"charge": ChargeIntent()},
         )
 
-        # RPC returns chain_id=4217 (mainnet) but challenge says 42431 (testnet)
         httpx_mock.add_response(
-            url="https://rpc.moderato.tempo.xyz",
+            url="https://rpc.custom",
             json={"jsonrpc": "2.0", "result": "0x1079", "id": 1},  # 4217, wrong!
         )
         httpx_mock.add_response(
-            url="https://rpc.moderato.tempo.xyz",
+            url="https://rpc.custom",
             json={"jsonrpc": "2.0", "result": "0x1", "id": 1},
         )
         httpx_mock.add_response(
-            url="https://rpc.moderato.tempo.xyz",
+            url="https://rpc.custom",
             json={"jsonrpc": "2.0", "result": "0x1", "id": 1},
         )
 
@@ -2134,7 +2084,7 @@ class TestChainIdPropagation:
                 "amount": "1000000",
                 "currency": "0x20c0000000000000000000000000000000000000",
                 "recipient": "0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
-                "methodDetails": {"chainId": 42431},
+                "methodDetails": {"chainId": TESTNET_CHAIN_ID},
             },
             realm="test.example.com",
             request_b64="e30",
@@ -2204,14 +2154,13 @@ class TestAccessKeySigning:
         )
 
         # Mock RPC: chain_id (4217=0x1079), nonce, gas_price, estimateGas
-        # Challenge chainId=4217 resolves to rpc.tempo.xyz
         httpx_mock.add_response(
-            url="https://rpc.tempo.xyz",
+            url="https://rpc.test",
             json={"jsonrpc": "2.0", "result": "0x1079", "id": 1},
         )
         for _ in range(3):
             httpx_mock.add_response(
-                url="https://rpc.tempo.xyz",
+                url="https://rpc.test",
                 json={"jsonrpc": "2.0", "result": "0x1", "id": 1},
             )
 


### PR DESCRIPTION
## Summary
- stop Tempo client credential creation from switching RPC networks based on server-supplied `methodDetails.chainId`
- pin signing to the client's configured `chain_id`, or to the chain reported by an explicit `rpc_url`
- replace the old chain-switching tests with regression coverage for default-chain, explicit-RPC, cached-policy, and transport retry behavior