### PR TITLE
fee-payer: enforce call pattern and gas policy

### DIFF
--- a/.changelog/merry-wolves-dry.md
+++ b/.changelog/merry-wolves-dry.md
@@ -1,0 +1,5 @@
+---
+pympp: minor
+---
+
+Added fee payer policy enforcement for sponsored Tempo transactions, validating gas limits, fee caps, total fee budgets, validity windows, and access lists against per-chain policy defaults. Added call pattern validation to restrict sponsored transactions to approved selectors (transfers, and optionally an approve+swap prefix via the stablecoin DEX).

--- a/src/mpp/methods/tempo/fee_payer_policy.py
+++ b/src/mpp/methods/tempo/fee_payer_policy.py
@@ -1,0 +1,56 @@
+"""Fee payer policy defaults for sponsored Tempo transactions."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+from mpp.methods.tempo._defaults import CHAIN_ID, TESTNET_CHAIN_ID
+
+
+@dataclass(frozen=True, slots=True)
+class Policy:
+    max_gas: int
+    max_fee_per_gas: int
+    max_priority_fee_per_gas: int
+    max_total_fee: int
+    max_validity_window_seconds: int
+
+
+DEFAULT_POLICY = Policy(
+    max_gas=2_000_000,
+    max_fee_per_gas=100_000_000_000,
+    max_priority_fee_per_gas=10_000_000_000,
+    max_total_fee=50_000_000_000_000_000,
+    max_validity_window_seconds=15 * 60,
+)
+
+
+POLICY_BY_CHAIN_ID: dict[int, Policy] = {
+    CHAIN_ID: DEFAULT_POLICY,
+    TESTNET_CHAIN_ID: Policy(
+        max_gas=DEFAULT_POLICY.max_gas,
+        max_fee_per_gas=DEFAULT_POLICY.max_fee_per_gas,
+        max_priority_fee_per_gas=50_000_000_000,
+        max_total_fee=DEFAULT_POLICY.max_total_fee,
+        max_validity_window_seconds=DEFAULT_POLICY.max_validity_window_seconds,
+    ),
+}
+
+
+def get_policy(chain_id: int, overrides: Mapping[str, int] | None = None) -> Policy:
+    base = POLICY_BY_CHAIN_ID.get(chain_id, DEFAULT_POLICY)
+    if not overrides:
+        return base
+
+    return Policy(
+        max_gas=overrides.get("max_gas", base.max_gas),
+        max_fee_per_gas=overrides.get("max_fee_per_gas", base.max_fee_per_gas),
+        max_priority_fee_per_gas=overrides.get(
+            "max_priority_fee_per_gas", base.max_priority_fee_per_gas
+        ),
+        max_total_fee=overrides.get("max_total_fee", base.max_total_fee),
+        max_validity_window_seconds=overrides.get(
+            "max_validity_window_seconds", base.max_validity_window_seconds
+        ),
+    )

--- a/src/mpp/methods/tempo/intents.py
+++ b/src/mpp/methods/tempo/intents.py
@@ -16,6 +16,7 @@ from mpp import Credential, Receipt
 from mpp._defaults import DEFAULT_TIMEOUT
 from mpp.errors import VerificationError
 from mpp.methods.tempo._defaults import PATH_USD, rpc_url_for_chain
+from mpp.methods.tempo.fee_payer_policy import get_policy
 from mpp.methods.tempo.schemas import (
     ChargeRequest,
     CredentialPayload,
@@ -32,13 +33,17 @@ if TYPE_CHECKING:
 
 TRANSFER_SELECTOR = "a9059cbb"
 TRANSFER_WITH_MEMO_SELECTOR = "95777d59"
+APPROVE_SELECTOR = "095ea7b3"
+SWAP_EXACT_AMOUNT_OUT_SELECTOR = "b30d91d5"
 
 TRANSFER_TOPIC = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
 TRANSFER_WITH_MEMO_TOPIC = "0x57bc7354aa85aed339e000bccffabbc529466af35f0772c8f8ee1145927de7f0"
 
 ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
+STABLECOIN_DEX = "0xdec0000000000000000000000000000000000000"
 
 MAX_SPLITS = 10
+MAX_TRANSFERS = MAX_SPLITS + 1
 
 
 def _parse_memo_bytes(memo: str | None) -> bytes | None:
@@ -215,6 +220,97 @@ def _match_transfer_calldata(call_data_hex: str, request: ChargeRequest) -> bool
             return False
 
     return True
+
+
+def _decode_call_address_arg(call_data_hex: str, arg_index: int) -> str:
+    start = 8 + (arg_index * 64)
+    end = start + 64
+    if len(call_data_hex) < end:
+        raise VerificationError("Invalid transaction: malformed call data")
+    return "0x" + call_data_hex[start + 24 : end]
+
+
+def _validate_call_scope(calls: list[tuple[str, int, str]]) -> int:
+    if not calls:
+        raise VerificationError("Transaction contains no calls")
+
+    selectors = [call_data[:8].lower() for _, _, call_data in calls]
+    has_swap_prefix = selectors[0] == APPROVE_SELECTOR
+
+    if has_swap_prefix:
+        if len(selectors) < 3 or selectors[1] != SWAP_EXACT_AMOUNT_OUT_SELECTOR:
+            raise VerificationError("Invalid transaction: disallowed call pattern")
+        transfer_selectors = selectors[2:]
+    else:
+        if selectors[0] == SWAP_EXACT_AMOUNT_OUT_SELECTOR:
+            raise VerificationError("Invalid transaction: disallowed call pattern")
+        transfer_selectors = selectors
+
+    if (
+        not transfer_selectors
+        or len(transfer_selectors) > MAX_TRANSFERS
+        or any(
+            selector not in (TRANSFER_SELECTOR, TRANSFER_WITH_MEMO_SELECTOR)
+            for selector in transfer_selectors
+        )
+    ):
+        raise VerificationError("Invalid transaction: disallowed call pattern")
+
+    if has_swap_prefix:
+        approve_to, _, approve_data = calls[0]
+        swap_to, _, swap_data = calls[1]
+        approve_spender = _decode_call_address_arg(approve_data, 0)
+        swap_token_in = _decode_call_address_arg(swap_data, 0)
+
+        if approve_to.lower() != swap_token_in.lower():
+            raise VerificationError("Invalid transaction: approve target does not match swap token")
+        if approve_spender.lower() != STABLECOIN_DEX.lower():
+            raise VerificationError(
+                "Invalid transaction: approve spender is not the stablecoin DEX"
+            )
+        if swap_to.lower() != STABLECOIN_DEX.lower():
+            raise VerificationError("Invalid transaction: swap target is not the stablecoin DEX")
+
+    return 2 if has_swap_prefix else 0
+
+
+def _validate_normalized_calls(calls: list[tuple[str, int, str]], request: ChargeRequest) -> None:
+    prefix_len = _validate_call_scope(calls)
+    payment_calls = calls[prefix_len:]
+
+    expected = get_transfers(
+        int(request.amount),
+        request.recipient,
+        request.methodDetails.memo,
+        request.methodDetails.splits,
+    )
+
+    if len(payment_calls) != len(expected):
+        raise VerificationError("Invalid transaction: contains unauthorized extra calls")
+
+    sorted_expected = sorted(expected, key=lambda t: 0 if t.memo else 1)
+    used_calls: set[int] = set()
+
+    for transfer in sorted_expected:
+        found = False
+        for call_idx, (call_to, call_value, call_data) in enumerate(payment_calls):
+            if call_idx in used_calls:
+                continue
+            if call_to.lower() != request.currency.lower():
+                continue
+            if call_value:
+                continue
+            if _match_single_transfer_calldata(
+                call_data, transfer.recipient, transfer.amount, transfer.memo
+            ):
+                used_calls.add(call_idx)
+                found = True
+                break
+        if not found:
+            raise VerificationError("Invalid transaction: no matching payment call found")
+
+    if len(used_calls) != len(payment_calls):
+        raise VerificationError("Invalid transaction: contains unauthorized extra calls")
 
 
 # ──────────────────────────────────────────────────────────────────
@@ -744,16 +840,43 @@ class ChargeIntent:
                 f"Fee payer envelope expired: valid_before ({valid_before}) is not in the future"
             )
 
+        chain_id = _int(decoded[0])
+        policy = get_policy(chain_id)
+
+        gas_limit = _int(decoded[3])
+        if gas_limit > policy.max_gas:
+            raise VerificationError("Invalid transaction: gas limit exceeds sponsor policy")
+
+        max_priority_fee_per_gas = _int(decoded[1])
+        max_fee_per_gas = _int(decoded[2])
+        if max_fee_per_gas > policy.max_fee_per_gas:
+            raise VerificationError("Invalid transaction: max fee per gas exceeds sponsor policy")
+        if max_priority_fee_per_gas > max_fee_per_gas:
+            raise VerificationError(
+                "Invalid transaction: max priority fee per gas exceeds max fee per gas"
+            )
+        if max_priority_fee_per_gas > policy.max_priority_fee_per_gas:
+            raise VerificationError(
+                "Invalid transaction: max priority fee per gas exceeds sponsor policy"
+            )
+        if gas_limit * max_fee_per_gas > policy.max_total_fee:
+            raise VerificationError("Invalid transaction: total fee budget exceeds sponsor policy")
+        if valid_before > int(time.time()) + policy.max_validity_window_seconds:
+            raise VerificationError("Invalid transaction: validity window exceeds sponsor policy")
+
+        if decoded[5]:
+            raise VerificationError("Invalid transaction: access list is not allowed")
+
         calls = tuple(Call(to=c[0], value=_int(c[1]), data=c[2]) for c in decoded[4])
 
         if request is not None:
             self._validate_calls(calls, request)
 
         tx_for_recovery = TempoTransaction(
-            chain_id=_int(decoded[0]),
-            max_priority_fee_per_gas=_int(decoded[1]),
-            max_fee_per_gas=_int(decoded[2]),
-            gas_limit=_int(decoded[3]),
+            chain_id=chain_id,
+            max_priority_fee_per_gas=max_priority_fee_per_gas,
+            max_fee_per_gas=max_fee_per_gas,
+            gas_limit=gas_limit,
             calls=calls,
             access_list=(),
             nonce_key=_int(decoded[6]),
@@ -794,34 +917,10 @@ class ChargeIntent:
 
     def _validate_calls(self, calls: tuple, request: ChargeRequest) -> None:
         """Validate that calls match all expected transfers."""
-        expected = get_transfers(
-            int(request.amount),
-            request.recipient,
-            request.methodDetails.memo,
-            request.methodDetails.splits,
-        )
-
-        sorted_expected = sorted(expected, key=lambda t: 0 if t.memo else 1)
-        used_calls: set[int] = set()
-
-        for transfer in sorted_expected:
-            found = False
-            for call_idx, call in enumerate(calls):
-                if call_idx in used_calls:
-                    continue
-                call_to = "0x" + bytes(call.to).hex()
-                if call_to.lower() != request.currency.lower():
-                    continue
-                if call.value:
-                    continue
-                if _match_single_transfer_calldata(
-                    call.data.hex(), transfer.recipient, transfer.amount, transfer.memo
-                ):
-                    used_calls.add(call_idx)
-                    found = True
-                    break
-            if not found:
-                raise VerificationError("Invalid transaction: no matching payment call found")
+        normalized_calls = [
+            ("0x" + bytes(call.to).hex(), int(call.value), call.data.hex()) for call in calls
+        ]
+        _validate_normalized_calls(normalized_calls, request)
 
     def _validate_transaction_payload(self, signature: str, request: ChargeRequest) -> None:
         """Best-effort pre-broadcast check. Silently skips if decoding fails."""
@@ -846,38 +945,22 @@ class ChargeIntent:
         if not calls_data:
             raise VerificationError("Transaction contains no calls")
 
-        expected = get_transfers(
-            int(request.amount),
-            request.recipient,
-            request.methodDetails.memo,
-            request.methodDetails.splits,
-        )
+        normalized_calls: list[tuple[str, int, str]] = []
+        for call_item in calls_data:
+            if not isinstance(call_item, (list, tuple)) or len(call_item) < 3:
+                raise VerificationError("Invalid transaction: malformed call data")
 
-        sorted_expected = sorted(expected, key=lambda t: 0 if t.memo else 1)
-        used_calls: set[int] = set()
+            call_to_raw, call_value_raw, call_data_raw = call_item[0], call_item[1], call_item[2]
+            if not isinstance(call_to_raw, bytes) or not isinstance(call_data_raw, bytes):
+                raise VerificationError("Invalid transaction: malformed call data")
 
-        for transfer in sorted_expected:
-            found = False
-            for call_idx, call_item in enumerate(calls_data):
-                if call_idx in used_calls:
-                    continue
-                if not isinstance(call_item, (list, tuple)) or len(call_item) < 3:
-                    continue
-                call_to_bytes, call_data_bytes = call_item[0], call_item[2]
-                if not call_to_bytes or not call_data_bytes:
-                    continue
-                to_hex = (
-                    call_to_bytes.hex() if isinstance(call_to_bytes, bytes) else str(call_to_bytes)
-                )
-                if ("0x" + to_hex).lower() != request.currency.lower():
-                    continue
-                raw = call_data_bytes
-                data_hex = raw.hex() if isinstance(raw, bytes) else str(raw)
-                if _match_single_transfer_calldata(
-                    data_hex, transfer.recipient, transfer.amount, transfer.memo
-                ):
-                    used_calls.add(call_idx)
-                    found = True
-                    break
-            if not found:
-                raise VerificationError("Invalid transaction: no matching payment call found")
+            if isinstance(call_value_raw, bytes):
+                call_value = int.from_bytes(call_value_raw, "big") if call_value_raw else 0
+            elif isinstance(call_value_raw, int):
+                call_value = call_value_raw
+            else:
+                raise VerificationError("Invalid transaction: malformed call data")
+
+            normalized_calls.append(("0x" + call_to_raw.hex(), call_value, call_data_raw.hex()))
+
+        _validate_normalized_calls(normalized_calls, request)

--- a/tests/test_tempo.py
+++ b/tests/test_tempo.py
@@ -23,6 +23,9 @@ from mpp.methods.tempo._attribution import encode as encode_attribution
 from mpp.methods.tempo._defaults import CHAIN_RPC_URLS
 from mpp.methods.tempo.client import TempoMethod
 from mpp.methods.tempo.intents import (
+    APPROVE_SELECTOR,
+    STABLECOIN_DEX,
+    SWAP_EXACT_AMOUNT_OUT_SELECTOR,
     TRANSFER_SELECTOR,
     TRANSFER_TOPIC,
     TRANSFER_WITH_MEMO_SELECTOR,
@@ -1249,40 +1252,87 @@ class TestSponsoredTransfer:
 class TestCosignAsFeePayer:
     """Tests for local fee payer co-signing."""
 
+    def _make_intent(self) -> ChargeIntent:
+        fee_payer = TempoAccount.from_key("0x" + "ab" * 32)
+        intent = ChargeIntent(rpc_url="https://rpc.test")
+        tempo(fee_payer=fee_payer, rpc_url="https://rpc.test", intents={"charge": intent})
+        return intent
+
+    def _encode_transfer_data(
+        self,
+        recipient: str,
+        amount: int,
+        memo: str | None = None,
+    ) -> str:
+        selector = TRANSFER_WITH_MEMO_SELECTOR if memo is not None else TRANSFER_SELECTOR
+        to_padded = recipient[2:].lower().zfill(64)
+        amount_padded = hex(amount)[2:].zfill(64)
+        data = f"0x{selector}{to_padded}{amount_padded}"
+        if memo is not None:
+            data += memo[2:] if memo.startswith("0x") else memo
+        return data
+
+    def _encode_approve_data(self, spender: str, amount: int) -> str:
+        spender_padded = spender[2:].lower().zfill(64)
+        amount_padded = hex(amount)[2:].zfill(64)
+        return f"0x{APPROVE_SELECTOR}{spender_padded}{amount_padded}"
+
+    def _encode_swap_data(
+        self,
+        token_in: str,
+        token_out: str,
+        amount_out: int,
+        max_amount_in: int,
+    ) -> str:
+        return (
+            f"0x{SWAP_EXACT_AMOUNT_OUT_SELECTOR}"
+            f"{token_in[2:].lower().zfill(64)}"
+            f"{token_out[2:].lower().zfill(64)}"
+            f"{hex(amount_out)[2:].zfill(64)}"
+            f"{hex(max_amount_in)[2:].zfill(64)}"
+        )
+
     def _build_client_tx(
         self,
         currency: str = "0x20c0000000000000000000000000000000000000",
         recipient: str = "0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
         amount: int = 1000000,
         chain_id: int = 42431,
+        calls: tuple | None = None,
+        access_list: tuple = (),
+        gas_limit: int = 100000,
+        max_fee_per_gas: int = 1,
+        max_priority_fee_per_gas: int = 1,
+        valid_before: int | None = None,
         with_memo: str | None = None,
     ) -> str:
         """Build a client-signed fee-payer-awaiting transaction."""
         from pytempo import Call, TempoTransaction
 
-        if with_memo:
-            selector = "95777d59"
-            to_padded = recipient[2:].lower().zfill(64)
-            amount_padded = hex(amount)[2:].zfill(64)
-            memo_clean = with_memo[2:] if with_memo.startswith("0x") else with_memo
-            transfer_data = f"0x{selector}{to_padded}{amount_padded}{memo_clean.lower()}"
-        else:
-            selector = "a9059cbb"
-            to_padded = recipient[2:].lower().zfill(64)
-            amount_padded = hex(amount)[2:].zfill(64)
-            transfer_data = f"0x{selector}{to_padded}{amount_padded}"
+        if calls is None:
+            calls = (
+                Call.create(
+                    to=currency,
+                    value=0,
+                    data=self._encode_transfer_data(recipient, amount, with_memo),
+                ),
+            )
+
+        if valid_before is None:
+            valid_before = int(datetime.now(UTC).timestamp()) + 300
 
         tx = TempoTransaction.create(
             chain_id=chain_id,
-            gas_limit=100000,
-            max_fee_per_gas=1,
-            max_priority_fee_per_gas=1,
+            gas_limit=gas_limit,
+            max_fee_per_gas=max_fee_per_gas,
+            max_priority_fee_per_gas=max_priority_fee_per_gas,
             nonce=0,
             nonce_key=(1 << 256) - 1,
             fee_token=None,
             awaiting_fee_payer=True,
-            valid_before=9999999999,
-            calls=(Call.create(to=currency, value=0, data=transfer_data),),
+            valid_before=valid_before,
+            calls=calls,
+            access_list=access_list,
         )
 
         signed = tx.sign(TEST_PRIVATE_KEY)
@@ -1293,15 +1343,7 @@ class TestCosignAsFeePayer:
 
     def test_cosign_roundtrip(self) -> None:
         """Should successfully co-sign a valid client transaction."""
-        fee_payer_key = "0x" + "ab" * 32
-        fee_payer = TempoAccount.from_key(fee_payer_key)
-
-        intent = ChargeIntent(rpc_url="https://rpc.test")
-        tempo(
-            fee_payer=fee_payer,
-            rpc_url="https://rpc.test",
-            intents={"charge": intent},
-        )
+        intent = self._make_intent()
 
         raw_tx = self._build_client_tx()
         result = intent._cosign_as_fee_payer(raw_tx, "0x20c0000000000000000000000000000000000000")
@@ -1311,18 +1353,14 @@ class TestCosignAsFeePayer:
 
     def test_cosign_rejects_wrong_tx_type(self) -> None:
         """Should reject transactions that aren't type 0x78."""
-        fee_payer = TempoAccount.from_key("0x" + "ab" * 32)
-        intent = ChargeIntent(rpc_url="https://rpc.test")
-        tempo(fee_payer=fee_payer, rpc_url="https://rpc.test", intents={"charge": intent})
+        intent = self._make_intent()
 
         with pytest.raises(VerificationError, match="Failed to deserialize"):
             intent._cosign_as_fee_payer("0x02abcdef", "0x20c0000000000000000000000000000000000000")
 
     def test_cosign_rejects_malformed_hex(self) -> None:
         """Should reject non-hex input."""
-        fee_payer = TempoAccount.from_key("0x" + "ab" * 32)
-        intent = ChargeIntent(rpc_url="https://rpc.test")
-        tempo(fee_payer=fee_payer, rpc_url="https://rpc.test", intents={"charge": intent})
+        intent = self._make_intent()
 
         with pytest.raises(VerificationError, match="Failed to deserialize"):
             intent._cosign_as_fee_payer("0xZZZZ", "0x20c0000000000000000000000000000000000000")
@@ -1336,9 +1374,7 @@ class TestCosignAsFeePayer:
 
     def test_cosign_validates_call_target(self) -> None:
         """Should reject tx targeting wrong currency when request is provided."""
-        fee_payer = TempoAccount.from_key("0x" + "ab" * 32)
-        intent = ChargeIntent(rpc_url="https://rpc.test")
-        tempo(fee_payer=fee_payer, rpc_url="https://rpc.test", intents={"charge": intent})
+        intent = self._make_intent()
 
         raw_tx = self._build_client_tx(
             currency="0x20c0000000000000000000000000000000000000",
@@ -1356,9 +1392,7 @@ class TestCosignAsFeePayer:
 
     def test_cosign_validates_amount(self) -> None:
         """Should reject tx with wrong amount when request is provided."""
-        fee_payer = TempoAccount.from_key("0x" + "ab" * 32)
-        intent = ChargeIntent(rpc_url="https://rpc.test")
-        tempo(fee_payer=fee_payer, rpc_url="https://rpc.test", intents={"charge": intent})
+        intent = self._make_intent()
 
         raw_tx = self._build_client_tx(amount=1000000)
 
@@ -1373,9 +1407,7 @@ class TestCosignAsFeePayer:
 
     def test_cosign_validates_recipient(self) -> None:
         """Should reject tx with wrong recipient when request is provided."""
-        fee_payer = TempoAccount.from_key("0x" + "ab" * 32)
-        intent = ChargeIntent(rpc_url="https://rpc.test")
-        tempo(fee_payer=fee_payer, rpc_url="https://rpc.test", intents={"charge": intent})
+        intent = self._make_intent()
 
         raw_tx = self._build_client_tx(recipient="0x742d35Cc6634c0532925a3b844bC9e7595F8fE00")
 
@@ -1390,9 +1422,7 @@ class TestCosignAsFeePayer:
 
     def test_cosign_accepts_matching_request(self) -> None:
         """Should succeed when tx matches request parameters."""
-        fee_payer = TempoAccount.from_key("0x" + "ab" * 32)
-        intent = ChargeIntent(rpc_url="https://rpc.test")
-        tempo(fee_payer=fee_payer, rpc_url="https://rpc.test", intents={"charge": intent})
+        intent = self._make_intent()
 
         raw_tx = self._build_client_tx(
             currency="0x20c0000000000000000000000000000000000000",
@@ -1409,9 +1439,248 @@ class TestCosignAsFeePayer:
         result = intent._cosign_as_fee_payer(raw_tx, request.currency, request=request)
         assert result.startswith("0x76")
 
+    def test_cosign_rejects_extra_trailing_call(self) -> None:
+        """Should reject sponsored transactions with extra trailing calls."""
+        from pytempo import Call
+
+        intent = self._make_intent()
+        raw_tx = self._build_client_tx(
+            calls=(
+                Call.create(
+                    to="0x20c0000000000000000000000000000000000000",
+                    value=0,
+                    data=self._encode_transfer_data(
+                        "0x742d35Cc6634c0532925a3b844bC9e7595F8fE00", 1000000
+                    ),
+                ),
+                Call.create(
+                    to="0x20c0000000000000000000000000000000000000",
+                    value=0,
+                    data=self._encode_transfer_data(
+                        "0x1111111111111111111111111111111111111111", 1
+                    ),
+                ),
+            )
+        )
+        request = ChargeRequest(
+            amount="1000000",
+            currency="0x20c0000000000000000000000000000000000000",
+            recipient="0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
+        )
+
+        with pytest.raises(VerificationError, match="unauthorized extra calls"):
+            intent._cosign_as_fee_payer(raw_tx, request.currency, request=request)
+
+    def test_cosign_rejects_extra_leading_call(self) -> None:
+        """Should reject sponsored transactions with extra leading calls."""
+        from pytempo import Call
+
+        intent = self._make_intent()
+        raw_tx = self._build_client_tx(
+            calls=(
+                Call.create(
+                    to="0x20c0000000000000000000000000000000000000",
+                    value=0,
+                    data=self._encode_transfer_data(
+                        "0x1111111111111111111111111111111111111111", 1
+                    ),
+                ),
+                Call.create(
+                    to="0x20c0000000000000000000000000000000000000",
+                    value=0,
+                    data=self._encode_transfer_data(
+                        "0x742d35Cc6634c0532925a3b844bC9e7595F8fE00", 1000000
+                    ),
+                ),
+            )
+        )
+        request = ChargeRequest(
+            amount="1000000",
+            currency="0x20c0000000000000000000000000000000000000",
+            recipient="0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
+        )
+
+        with pytest.raises(VerificationError, match="unauthorized extra calls"):
+            intent._cosign_as_fee_payer(raw_tx, request.currency, request=request)
+
+    def test_cosign_rejects_disallowed_selector(self) -> None:
+        """Should reject sponsored transactions with non-payment selectors."""
+        from pytempo import Call
+
+        intent = self._make_intent()
+        raw_tx = self._build_client_tx(
+            calls=(
+                Call.create(
+                    to="0x20c0000000000000000000000000000000000000",
+                    value=0,
+                    data="0xdeadbeef",
+                ),
+            )
+        )
+        request = ChargeRequest(
+            amount="1000000",
+            currency="0x20c0000000000000000000000000000000000000",
+            recipient="0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
+        )
+
+        with pytest.raises(VerificationError, match="disallowed call pattern"):
+            intent._cosign_as_fee_payer(raw_tx, request.currency, request=request)
+
+    def test_cosign_rejects_approve_binding_mismatch(self) -> None:
+        """Should reject swap prefixes whose approval is bound to the wrong token."""
+        from pytempo import Call
+
+        intent = self._make_intent()
+        raw_tx = self._build_client_tx(
+            calls=(
+                Call.create(
+                    to="0x0000000000000000000000000000000000000004",
+                    value=0,
+                    data=self._encode_approve_data(STABLECOIN_DEX, 2000000),
+                ),
+                Call.create(
+                    to=STABLECOIN_DEX,
+                    value=0,
+                    data=self._encode_swap_data(
+                        "0x0000000000000000000000000000000000000003",
+                        "0x20c0000000000000000000000000000000000000",
+                        1000000,
+                        2000000,
+                    ),
+                ),
+                Call.create(
+                    to="0x20c0000000000000000000000000000000000000",
+                    value=0,
+                    data=self._encode_transfer_data(
+                        "0x742d35Cc6634c0532925a3b844bC9e7595F8fE00", 1000000
+                    ),
+                ),
+            )
+        )
+        request = ChargeRequest(
+            amount="1000000",
+            currency="0x20c0000000000000000000000000000000000000",
+            recipient="0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
+        )
+
+        with pytest.raises(VerificationError, match="approve target does not match"):
+            intent._cosign_as_fee_payer(raw_tx, request.currency, request=request)
+
+    def test_cosign_rejects_gas_over_policy(self) -> None:
+        """Should reject sponsored transactions above the gas limit policy."""
+        intent = self._make_intent()
+        raw_tx = self._build_client_tx(gas_limit=2_000_001)
+
+        with pytest.raises(VerificationError, match="gas limit exceeds sponsor policy"):
+            intent._cosign_as_fee_payer(raw_tx, "0x20c0000000000000000000000000000000000000")
+
+    def test_cosign_rejects_max_fee_over_policy(self) -> None:
+        """Should reject sponsored transactions above the max fee per gas policy."""
+        intent = self._make_intent()
+        raw_tx = self._build_client_tx(max_fee_per_gas=100_000_000_001)
+
+        with pytest.raises(VerificationError, match="max fee per gas exceeds sponsor policy"):
+            intent._cosign_as_fee_payer(raw_tx, "0x20c0000000000000000000000000000000000000")
+
+    def test_cosign_rejects_priority_fee_above_max_fee(self) -> None:
+        """Should reject inconsistent fee caps."""
+        intent = self._make_intent()
+        with patch("pytempo.models.TempoTransaction.validate", return_value=None):
+            raw_tx = self._build_client_tx(max_fee_per_gas=5, max_priority_fee_per_gas=6)
+
+        with pytest.raises(VerificationError, match="max priority fee per gas exceeds max fee"):
+            intent._cosign_as_fee_payer(raw_tx, "0x20c0000000000000000000000000000000000000")
+
+    def test_cosign_rejects_total_fee_budget_over_policy(self) -> None:
+        """Should reject sponsored transactions above the total fee budget."""
+        intent = self._make_intent()
+        raw_tx = self._build_client_tx(gas_limit=1_000_000, max_fee_per_gas=60_000_000_000)
+
+        with pytest.raises(VerificationError, match="total fee budget exceeds sponsor policy"):
+            intent._cosign_as_fee_payer(raw_tx, "0x20c0000000000000000000000000000000000000")
+
+    def test_cosign_rejects_validity_window_over_policy(self) -> None:
+        """Should reject sponsored transactions whose validity window is too long."""
+        intent = self._make_intent()
+        with patch("mpp.methods.tempo.intents.time.time", return_value=1_700_000_000):
+            raw_tx = self._build_client_tx(valid_before=1_700_000_000 + 901)
+            with pytest.raises(VerificationError, match="validity window exceeds sponsor policy"):
+                intent._cosign_as_fee_payer(raw_tx, "0x20c0000000000000000000000000000000000000")
+
+    def test_cosign_rejects_non_empty_access_list(self) -> None:
+        """Should reject sponsored transactions with access lists."""
+        from pytempo import AccessListItem
+
+        intent = self._make_intent()
+        raw_tx = self._build_client_tx(
+            access_list=(
+                AccessListItem.create(
+                    address="0x1111111111111111111111111111111111111111",
+                    storage_keys=(b"\x00" * 32,),
+                ),
+            )
+        )
+
+        with pytest.raises(VerificationError, match="access list is not allowed"):
+            intent._cosign_as_fee_payer(raw_tx, "0x20c0000000000000000000000000000000000000")
+
+    def test_cosign_accepts_swap_prefix_when_bound_correctly(self) -> None:
+        """Should accept approve + swap + transfer when the swap is bound correctly."""
+        from pytempo import Call
+
+        intent = self._make_intent()
+        raw_tx = self._build_client_tx(
+            calls=(
+                Call.create(
+                    to="0x0000000000000000000000000000000000000003",
+                    value=0,
+                    data=self._encode_approve_data(STABLECOIN_DEX, 2000000),
+                ),
+                Call.create(
+                    to=STABLECOIN_DEX,
+                    value=0,
+                    data=self._encode_swap_data(
+                        "0x0000000000000000000000000000000000000003",
+                        "0x20c0000000000000000000000000000000000000",
+                        1000000,
+                        2000000,
+                    ),
+                ),
+                Call.create(
+                    to="0x20c0000000000000000000000000000000000000",
+                    value=0,
+                    data=self._encode_transfer_data(
+                        "0x742d35Cc6634c0532925a3b844bC9e7595F8fE00", 1000000
+                    ),
+                ),
+            )
+        )
+        request = ChargeRequest(
+            amount="1000000",
+            currency="0x20c0000000000000000000000000000000000000",
+            recipient="0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
+        )
+
+        result = intent._cosign_as_fee_payer(raw_tx, request.currency, request=request)
+        assert result.startswith("0x76")
+
 
 class TestValidateTransactionPayload:
     """Tests for _validate_transaction_payload with both 0x76 and 0x78."""
+
+    def _encode_transfer_data(
+        self,
+        recipient: str,
+        amount: int,
+        memo: str | None = None,
+    ) -> str:
+        selector = TRANSFER_WITH_MEMO_SELECTOR if memo is not None else TRANSFER_SELECTOR
+        to_padded = recipient[2:].lower().zfill(64)
+        amount_padded = hex(amount)[2:].zfill(64)
+        data = f"0x{selector}{to_padded}{amount_padded}"
+        if memo is not None:
+            data += memo[2:] if memo.startswith("0x") else memo
+        return data
 
     def _build_0x78_envelope(
         self,
@@ -1425,12 +1694,7 @@ class TestValidateTransactionPayload:
 
         from mpp.methods.tempo.fee_payer_envelope import encode_fee_payer_envelope
 
-        selector = TRANSFER_WITH_MEMO_SELECTOR if memo is not None else TRANSFER_SELECTOR
-        to_padded = recipient[2:].lower().zfill(64)
-        amount_padded = hex(amount)[2:].zfill(64)
-        transfer_data = f"0x{selector}{to_padded}{amount_padded}"
-        if memo is not None:
-            transfer_data += memo[2:] if memo.startswith("0x") else memo
+        transfer_data = self._encode_transfer_data(recipient, amount, memo)
 
         tx = TempoTransaction.create(
             chain_id=42431,
@@ -1459,12 +1723,7 @@ class TestValidateTransactionPayload:
         from pytempo import Call, TempoTransaction
         from pytempo.models import Signature
 
-        selector = TRANSFER_WITH_MEMO_SELECTOR if memo is not None else TRANSFER_SELECTOR
-        to_padded = recipient[2:].lower().zfill(64)
-        amount_padded = hex(amount)[2:].zfill(64)
-        transfer_data = f"0x{selector}{to_padded}{amount_padded}"
-        if memo is not None:
-            transfer_data += memo[2:] if memo.startswith("0x") else memo
+        transfer_data = self._encode_transfer_data(recipient, amount, memo)
 
         tx = TempoTransaction.create(
             chain_id=42431,
@@ -1527,6 +1786,48 @@ class TestValidateTransactionPayload:
         )
         sig = self._build_0x78_envelope()
         with pytest.raises(VerificationError, match="no matching payment call"):
+            intent._validate_transaction_payload(sig, request)
+
+    def test_rejects_0x78_with_extra_call(self) -> None:
+        """Should reject a 0x78 envelope with unauthorized extra calls."""
+        from pytempo import Call, TempoTransaction
+
+        from mpp.methods.tempo.fee_payer_envelope import encode_fee_payer_envelope
+
+        intent = ChargeIntent(rpc_url="https://rpc.test")
+        request = ChargeRequest(
+            amount="1000000",
+            currency="0x20c0000000000000000000000000000000000000",
+            recipient="0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
+        )
+        tx = TempoTransaction.create(
+            chain_id=42431,
+            gas_limit=100000,
+            max_fee_per_gas=1,
+            max_priority_fee_per_gas=1,
+            nonce=0,
+            nonce_key=(1 << 256) - 1,
+            fee_token=None,
+            awaiting_fee_payer=True,
+            valid_before=9999999999,
+            calls=(
+                Call.create(
+                    to=request.currency,
+                    value=0,
+                    data=self._encode_transfer_data(request.recipient, 1000000),
+                ),
+                Call.create(
+                    to=request.currency,
+                    value=0,
+                    data=self._encode_transfer_data(
+                        "0x1111111111111111111111111111111111111111", 1
+                    ),
+                ),
+            ),
+        )
+        sig = "0x" + encode_fee_payer_envelope(tx.sign(TEST_PRIVATE_KEY)).hex()
+
+        with pytest.raises(VerificationError, match="unauthorized extra calls"):
             intent._validate_transaction_payload(sig, request)
 
     def test_accepts_0x76_with_matching_call(self) -> None:


### PR DESCRIPTION
## Summary
- add a chain-aware fee-payer policy module for gas, fee, and validity window limits
- reject unauthorized extra calls and enforce the allowed approve/swap/transfer sponsorship scope
- validate DEX binding, reject non-empty access lists, and cover the new security checks with regression tests