### PR TITLE
ci: fix PyPI publish 403 by granting OIDC perms to changelogs job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,9 +12,11 @@ jobs:
   release:
     name: Version
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
     outputs:
       published: ${{ steps.changelogs.outputs.published }}
     steps:


### PR DESCRIPTION
## Problem

Every release commit since `v0.6.0` has failed to publish to PyPI with `403 Forbidden`:

```
pympp v0.7.0 ... ✗
  publish failed: twine upload failed (exit code exit status: 1):
  ERROR    HTTPError: 403 Forbidden from https://upload.pypi.org/legacy/
```

PyPI shows `0.6.0` (Apr 7) as the last published version — `0.6.2`, `0.6.3`, and `0.7.0` never landed.

## Root cause

The `wevm/changelogs` action runs `twine upload` itself from inside the `release` job. PyPI Trusted Publishing requires:

- `id-token: write` permission (to mint an OIDC token)
- The job to run in the `release` environment (matching the publisher entry)

The `release` job had neither — only `contents: write` and `pull-requests: write`. So the OIDC claim either wasn't issued or didn't match the trusted publisher entry, and PyPI returned 403.

The separate `publish` job below was correctly configured but never ran because `release` errored out, and is redundant since changelogs already handles the upload.

## Fix

Add `environment: release` and `id-token: write` to the `release` job so the OIDC token issued matches the PyPI trusted publisher entry (`tempoxyz/pympp` + `publish.yml` + `release`).