### PR TITLE
ci: use OIDC trusted publishing via wevm/changelogs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,45 +16,16 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-      id-token: write
-    outputs:
-      published: ${{ steps.changelogs.outputs.published }}
+      id-token: write   # required for PyPI Trusted Publishing (OIDC)
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: true
 
-      - id: changelogs
-        uses: wevm/changelogs@056ab043d7affcd6871e8d972b5b5362e7349b57 # changelogs@0.6.3
+      - uses: wevm/changelogs@de0250123a1d70a2b64a458bd5efcf313986df7a # OIDC trusted publishing
         with:
           ecosystem: python
           python-version: '3.12'
           conventional-commit: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  publish:
-    name: Publish to PyPI
-    needs: release
-    if: needs.release.outputs.published == 'true'
-    runs-on: ubuntu-latest
-    environment: release
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: '3.12'
-
-      - name: Build package
-        run: |
-          pip install build
-          python -m build
-
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0


### PR DESCRIPTION
## Problem

Releases since `v0.6.0` have been failing with `403 Forbidden` from PyPI:

```
ERROR    HTTPError: 403 Forbidden from https://upload.pypi.org/legacy/
```

Root cause: `wevm/changelogs` did not support PyPI Trusted Publishing — it required a static `pypi-token` input, which we had not configured.

## Fix

Two-part fix:

1. Upstream: [tempoxyz/changelogs#116](https://github.com/tempoxyz/changelogs/pull/116) added native OIDC trusted publishing to the action. When `pypi-token` is empty and the workflow has `id-token: write`, it mints a short-lived PyPI API token via PyPI's `_/oidc/mint-token` endpoint and uses it as `TWINE_PASSWORD` for the existing twine upload.
2. This PR: bump the action ref to the merge commit and grant `id-token: write` + `environment: release` so the OIDC mint flow runs.