### PR TITLE
fix: reject invalid payment method ids

### DIFF
--- a/.changelog/vast-mules-draw.md
+++ b/.changelog/vast-mules-draw.md
@@ -1,0 +1,5 @@
+---
+pympp: patch
+---
+
+Added strict validation for payment method IDs, requiring them to match `1*LOWERALPHA` (lowercase letters only). Updated `Receipt` default method from empty string to `"tempo"` and fixed test fixtures to use valid method IDs.

--- a/src/mpp/__init__.py
+++ b/src/mpp/__init__.py
@@ -378,7 +378,7 @@ class Receipt:
     status: Literal["success"]
     timestamp: datetime
     reference: str
-    method: str = ""
+    method: str = "tempo"
     external_id: str | None = None
     extra: dict[str, Any] | None = None
 

--- a/src/mpp/_parsing.py
+++ b/src/mpp/_parsing.py
@@ -27,6 +27,7 @@ MAX_HEADER_PAYLOAD_SIZE = 16 * 1024
 # RFC 9110 auth-param: token BWS "=" BWS ( token / quoted-string )
 # Matches: key="value" or key=token, handles escaped quotes in quoted strings
 _AUTH_PARAM_RE = re.compile(r'([a-zA-Z_][\w-]*)\s*=\s*(?:"((?:[^"\\]|\\.)*)"|([^\s,]+))')
+_PAYMENT_METHOD_ID_RE = re.compile(r"^[a-z]+$")
 
 
 class ParseError(Exception):
@@ -75,6 +76,12 @@ def _unescape_quoted(s: str) -> str:
     return re.sub(r"\\(.)", r"\1", s)
 
 
+def _validate_payment_method_id(method: str) -> None:
+    """Validate payment-method-id = 1*LOWERALPHA."""
+    if not _PAYMENT_METHOD_ID_RE.fullmatch(method):
+        raise ParseError(f"Invalid payment method id: {method!r}")
+
+
 def _parse_auth_params(params_str: str) -> dict[str, str]:
     """Parse RFC 9110 auth-params: key="value" or key=token pairs."""
     params: dict[str, str] = {}
@@ -119,6 +126,7 @@ def parse_www_authenticate(header: str) -> Challenge:
     method = params.get("method")
     if not method:
         raise ParseError("Missing 'method' field")
+    _validate_payment_method_id(method)
 
     intent = params.get("intent")
     if not intent:
@@ -214,10 +222,13 @@ def parse_authorization(header: str) -> Credential:
     if "id" not in challenge_data:
         raise ParseError("Credential challenge missing required field: id")
 
+    method = str(challenge_data.get("method", ""))
+    _validate_payment_method_id(method)
+
     echo = ChallengeEcho(
         id=str(challenge_data["id"]),
         realm=str(challenge_data.get("realm", "")),
-        method=str(challenge_data.get("method", "")),
+        method=method,
         intent=str(challenge_data.get("intent", "")),
         request=str(challenge_data.get("request", "")),
         expires=str(challenge_data["expires"]) if challenge_data.get("expires") else None,
@@ -302,6 +313,8 @@ def parse_payment_receipt(header: str) -> Receipt:
         raise ParseError("Invalid receipt status")
 
     timestamp = _parse_timestamp(str(data["timestamp"]))
+    method = str(data["method"])
+    _validate_payment_method_id(method)
 
     extra = data.get("extra")
 
@@ -309,7 +322,7 @@ def parse_payment_receipt(header: str) -> Receipt:
         status=status,
         timestamp=timestamp,
         reference=str(data["reference"]),
-        method=str(data.get("method", "")),
+        method=method,
         external_id=str(data["externalId"]) if data.get("externalId") else None,
         extra=extra if isinstance(extra, dict) else None,
     )

--- a/src/mpp/_parsing.py
+++ b/src/mpp/_parsing.py
@@ -27,6 +27,7 @@ MAX_HEADER_PAYLOAD_SIZE = 16 * 1024
 # RFC 9110 auth-param: token BWS "=" BWS ( token / quoted-string )
 # Matches: key="value" or key=token, handles escaped quotes in quoted strings
 _AUTH_PARAM_RE = re.compile(r'([a-zA-Z_][\w-]*)\s*=\s*(?:"((?:[^"\\]|\\.)*)"|([^\s,]+))')
+# Syntax-level Payment Auth grammar. Supported-method dispatch is handled after parsing.
 _PAYMENT_METHOD_ID_RE = re.compile(r"^[a-z]+$")
 
 

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -2,6 +2,7 @@
 
 import base64
 import json
+from collections.abc import Mapping
 from datetime import UTC, datetime
 
 import pytest
@@ -9,6 +10,12 @@ import pytest
 from mpp import Challenge, ChallengeEcho, Credential, Receipt
 from mpp._parsing import MAX_HEADER_PAYLOAD_SIZE, ParseError
 from tests import make_credential
+
+INVALID_PAYMENT_METHOD_IDS = ("Tempo", "tempo2", "tempo-pay", "tempo_pay", "tempo.pay")
+
+
+def _b64_json(data: Mapping[str, object]) -> str:
+    return base64.urlsafe_b64encode(json.dumps(data).encode()).decode().rstrip("=")
 
 
 class TestChallenge:
@@ -80,6 +87,16 @@ class TestChallenge:
         # Missing method field
         header = 'Payment id="test", realm="test", intent="charge", request="e30"'
         with pytest.raises(ParseError, match="Missing 'method' field"):
+            Challenge.from_www_authenticate(header)
+
+    @pytest.mark.parametrize("method", INVALID_PAYMENT_METHOD_IDS)
+    def test_parse_rejects_invalid_method_id(self, method: str) -> None:
+        header = (
+            f'Payment id="test", realm="api.example.com", method="{method}", '
+            'intent="charge", request="e30"'
+        )
+
+        with pytest.raises(ParseError, match="Invalid payment method id"):
             Challenge.from_www_authenticate(header)
 
     def test_roundtrip_with_optional_fields(self) -> None:
@@ -238,6 +255,23 @@ class TestCredential:
         with pytest.raises(ParseError, match="Credential challenge missing required field: id"):
             Credential.from_authorization(header)
 
+    @pytest.mark.parametrize("method", INVALID_PAYMENT_METHOD_IDS)
+    def test_parse_rejects_invalid_challenge_method_id(self, method: str) -> None:
+        data = {
+            "challenge": {
+                "id": "test-id",
+                "realm": "api.example.com",
+                "method": method,
+                "intent": "charge",
+                "request": "e30",
+            },
+            "payload": {},
+        }
+        header = "Payment " + _b64_json(data)
+
+        with pytest.raises(ParseError, match="Invalid payment method id"):
+            Credential.from_authorization(header)
+
     def test_roundtrip_with_optional_challenge_fields(self) -> None:
         credential = Credential(
             challenge=ChallengeEcho(
@@ -322,4 +356,17 @@ class TestReceipt:
         }
         b64 = base64.urlsafe_b64encode(json.dumps(payload).encode()).decode().rstrip("=")
         with pytest.raises(ParseError, match="Invalid timestamp format"):
+            Receipt.from_payment_receipt(b64)
+
+    @pytest.mark.parametrize("method", INVALID_PAYMENT_METHOD_IDS)
+    def test_parse_rejects_invalid_method_id(self, method: str) -> None:
+        payload = {
+            "status": "success",
+            "timestamp": "2024-01-20T12:00:00Z",
+            "reference": "0xabc",
+            "method": method,
+        }
+        b64 = _b64_json(payload)
+
+        with pytest.raises(ParseError, match="Invalid payment method id"):
             Receipt.from_payment_receipt(b64)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -186,7 +186,7 @@ class TestClassBasedIntent:
             request={},
             realm="test",
             secret_key="test-secret",
-            method="custom-method",
+            method="custompay",
             intent="custom",
         )
         auth_header = credential.to_authorization()
@@ -197,7 +197,7 @@ class TestClassBasedIntent:
             request={},
             realm="test",
             secret_key="test-secret",
-            method="custom-method",
+            method="custompay",
         )
 
         assert isinstance(result, tuple)
@@ -779,7 +779,7 @@ class TestPay:
             request={"amount": "1000"},
             realm="api.example.com",
             secret_key="test-secret",
-            method="custom-method",
+            method="custompay",
         )
         async def handler(req: MockRequest, credential: Credential, receipt: Receipt) -> dict:
             return {"data": "paid"}
@@ -796,7 +796,7 @@ class TestPay:
             assert result["_mpp_challenge"] is True
             www_auth = result["headers"]["WWW-Authenticate"]
         challenge = Challenge.from_www_authenticate(www_auth)
-        assert challenge.method == "custom-method"
+        assert challenge.method == "custompay"
 
 
 def _make_server(test_intent):


### PR DESCRIPTION
## Summary

- Rejects payment method IDs outside `1*LOWERALPHA` while parsing `WWW-Authenticate`, `Authorization`, and `Payment-Receipt` headers.
- Adds parser coverage for uppercase, digit, dash, underscore, and dot method IDs.
- Aligns default receipts and custom-method test fixtures with valid lowercase method IDs.
- Local checks passed: `uv run ruff check .`, `uv run ruff format --check .`, `uv run pyright`, `uv run pytest -q`.