### PR TITLE
fix: harden tempo transaction verification

### DIFF
--- a/.changelog/dull-ants-read.md
+++ b/.changelog/dull-ants-read.md
@@ -1,0 +1,5 @@
+---
+pympp: patch
+---
+
+Hardened Tempo transaction credential verification by enforcing challenge-bound attribution memos and reserving transaction hashes before broadcast to avoid duplicate rebroadcasts.

--- a/.changelog/dull-ants-read.md
+++ b/.changelog/dull-ants-read.md
@@ -1,5 +1,0 @@
----
-pympp: patch
----
-
-Hardened Tempo transaction credential verification by enforcing challenge-bound attribution memos and reserving transaction hashes before broadcast to avoid duplicate rebroadcasts.

--- a/.changelog/tempo-tx-verification-hardening.md
+++ b/.changelog/tempo-tx-verification-hardening.md
@@ -1,0 +1,5 @@
+---
+pympp: patch
+---
+
+Hardened Tempo transaction credential verification by enforcing challenge-bound attribution memos and reserving transaction hashes before broadcast to avoid duplicate rebroadcasts.

--- a/src/mpp/methods/tempo/intents.py
+++ b/src/mpp/methods/tempo/intents.py
@@ -46,6 +46,18 @@ MAX_SPLITS = 10
 MAX_TRANSFERS = MAX_SPLITS + 1
 
 
+def _raw_transaction_hash(raw_tx: str) -> str:
+    """Return the transaction hash for a raw signed transaction."""
+    from eth_hash.auto import keccak
+
+    try:
+        tx_bytes = bytes.fromhex(raw_tx[2:] if raw_tx.startswith("0x") else raw_tx)
+    except ValueError as err:
+        raise VerificationError("Invalid transaction signature") from err
+
+    return "0x" + keccak(tx_bytes).hex()
+
+
 def _parse_memo_bytes(memo: str | None) -> bytes | None:
     """Parse a hex memo string into 32 bytes.
 
@@ -461,7 +473,12 @@ class ChargeIntent:
                 realm=credential.challenge.realm,
             )
         else:
-            return await self._verify_transaction(payload, req)
+            return await self._verify_transaction(
+                payload,
+                req,
+                challenge_id=credential.challenge.id,
+                realm=credential.challenge.realm,
+            )
 
     async def _verify_hash(
         self,
@@ -473,45 +490,13 @@ class ChargeIntent:
         """Verify a credential with a transaction hash."""
         client = await self._get_client()
 
-        rpc_url = self._get_rpc_url()
-        response = await client.post(
-            rpc_url,
-            json={
-                "jsonrpc": "2.0",
-                "method": "eth_getTransactionReceipt",
-                "params": [payload.hash],
-                "id": 1,
-            },
+        receipt_data = await self._fetch_transaction_receipt(client, payload.hash)
+        self._verify_receipt_transfers(
+            receipt_data,
+            request,
+            challenge_id=challenge_id,
+            realm=realm,
         )
-        response.raise_for_status()
-        result = response.json()
-
-        if "error" in result:
-            raise VerificationError("RPC request failed")
-
-        receipt_data = result.get("result")
-        if not receipt_data:
-            raise VerificationError("Transaction not found")
-
-        if receipt_data.get("status") != "0x1":
-            raise VerificationError("Transaction reverted")
-
-        matched_logs = self._verify_transfer_logs(receipt_data, request)
-        if not matched_logs:
-            raise VerificationError(
-                "Transaction must contain a Transfer log matching request parameters"
-            )
-
-        # Only verify challenge binding when using auto-generated attribution memos.
-        # Explicit memos (set by the server) are strictly matched by _verify_transfer_logs
-        # but are NOT challenge-bound. Callers that set explicit memos are responsible
-        # for ensuring memo uniqueness per challenge to prevent cross-challenge hash reuse.
-        if request.methodDetails.memo is None:
-            self._assert_challenge_bound_memo(
-                matched_logs,
-                challenge_id=challenge_id,
-                realm=realm,
-            )
 
         if self._store is not None:
             store_key = f"mpp:charge:{payload.hash.lower()}"
@@ -539,6 +524,60 @@ class ChargeIntent:
             raise VerificationError(
                 "Payment verification failed: memo is not bound to this challenge."
             )
+
+    async def _fetch_transaction_receipt(self, client: Any, tx_hash: str) -> dict[str, Any]:
+        rpc_url = self._get_rpc_url()
+        response = await client.post(
+            rpc_url,
+            json={
+                "jsonrpc": "2.0",
+                "method": "eth_getTransactionReceipt",
+                "params": [tx_hash],
+                "id": 1,
+            },
+        )
+        response.raise_for_status()
+        result = response.json()
+
+        if "error" in result:
+            raise VerificationError("RPC request failed")
+
+        receipt_data = result.get("result")
+        if not receipt_data:
+            raise VerificationError("Transaction not found")
+        if not isinstance(receipt_data, dict):
+            raise VerificationError("Invalid transaction receipt")
+
+        return receipt_data
+
+    def _verify_receipt_transfers(
+        self,
+        receipt_data: dict[str, Any],
+        request: ChargeRequest,
+        challenge_id: str,
+        realm: str,
+    ) -> list[MatchedTransferLog]:
+        if receipt_data.get("status") != "0x1":
+            raise VerificationError("Transaction reverted")
+
+        matched_logs = self._verify_transfer_logs(receipt_data, request)
+        if not matched_logs:
+            raise VerificationError(
+                "Transaction must contain a Transfer log matching request parameters"
+            )
+
+        # Only verify challenge binding when using auto-generated attribution memos.
+        # Explicit memos (set by the server) are strictly matched by _verify_transfer_logs
+        # but are NOT challenge-bound. Callers that set explicit memos are responsible
+        # for ensuring memo uniqueness per challenge to prevent cross-challenge hash reuse.
+        if request.methodDetails.memo is None:
+            self._assert_challenge_bound_memo(
+                matched_logs,
+                challenge_id=challenge_id,
+                realm=realm,
+            )
+
+        return matched_logs
 
     def _verify_single_transfer_log(
         self,
@@ -709,6 +748,8 @@ class ChargeIntent:
         self,
         payload: TransactionCredentialPayload,
         request: ChargeRequest,
+        challenge_id: str,
+        realm: str,
     ) -> Receipt:
         """Verify and submit a signed transaction.
 
@@ -757,43 +798,66 @@ class ChargeIntent:
                     raise VerificationError("Fee payer returned no signed transaction")
 
         rpc_url = self._get_rpc_url()
-        response = await client.post(
-            rpc_url,
-            json={
-                "jsonrpc": "2.0",
-                "method": "eth_sendRawTransactionSync",
-                "params": [raw_tx],
-                "id": 1,
-            },
-        )
-        response.raise_for_status()
-        result = response.json()
+        reserved_tx_hash: str | None = None
+        store_key: str | None = None
+        if self._store is not None:
+            reserved_tx_hash = _raw_transaction_hash(raw_tx)
+            store_key = f"mpp:charge:{reserved_tx_hash.lower()}"
+            if not await self._store.put_if_absent(store_key, reserved_tx_hash):
+                receipt_data = await self._fetch_transaction_receipt(client, reserved_tx_hash)
+                self._verify_receipt_transfers(
+                    receipt_data,
+                    request,
+                    challenge_id=challenge_id,
+                    realm=realm,
+                )
+                return Receipt.success(reserved_tx_hash)
+
+        try:
+            response = await client.post(
+                rpc_url,
+                json={
+                    "jsonrpc": "2.0",
+                    "method": "eth_sendRawTransactionSync",
+                    "params": [raw_tx],
+                    "id": 1,
+                },
+            )
+            response.raise_for_status()
+            result = response.json()
+        except Exception:
+            if self._store is not None and store_key is not None:
+                await self._store.delete(store_key)
+            raise
 
         if "error" in result:
+            if self._store is not None and store_key is not None:
+                await self._store.delete(store_key)
             raise VerificationError(f"Transaction submission failed: {_rpc_error_msg(result)}")
 
         receipt_data = result.get("result")
         if not receipt_data:
             raise VerificationError("No transaction receipt returned")
+        if not isinstance(receipt_data, dict):
+            raise VerificationError("Invalid transaction receipt")
 
-        if receipt_data.get("status") != "0x1":
-            raise VerificationError("Transaction reverted")
+        self._verify_receipt_transfers(
+            receipt_data,
+            request,
+            challenge_id=challenge_id,
+            realm=realm,
+        )
 
-        if not self._verify_transfer_logs(receipt_data, request):
-            raise VerificationError(
-                "Transaction must contain a Transfer log matching request parameters"
-            )
-
-        tx_hash = receipt_data.get("transactionHash")
-        if not tx_hash:
+        receipt_tx_hash = receipt_data.get("transactionHash")
+        if not receipt_tx_hash:
             raise VerificationError("No transaction hash returned")
+        if not isinstance(receipt_tx_hash, str):
+            raise VerificationError("Invalid transaction hash returned")
 
-        if self._store is not None:
-            store_key = f"mpp:charge:{tx_hash.lower()}"
-            if not await self._store.put_if_absent(store_key, tx_hash):
-                raise VerificationError("Transaction hash already used")
+        if reserved_tx_hash is not None and receipt_tx_hash.lower() != reserved_tx_hash.lower():
+            raise VerificationError("Receipt transaction hash does not match submitted transaction")
 
-        return Receipt.success(tx_hash)
+        return Receipt.success(receipt_tx_hash)
 
     def _cosign_as_fee_payer(
         self, raw_tx: str, fee_token: str | None = None, request: ChargeRequest | None = None

--- a/src/mpp/methods/tempo/intents.py
+++ b/src/mpp/methods/tempo/intents.py
@@ -500,18 +500,24 @@ class ChargeIntent:
         """Verify a credential with a transaction hash."""
         client = await self._get_client()
 
-        receipt_data = await self._fetch_transaction_receipt(client, payload.hash)
-        self._verify_receipt_transfers(
-            receipt_data,
-            request,
-            challenge_id=challenge_id,
-            realm=realm,
-        )
-
+        store_key: str | None = None
         if self._store is not None:
             store_key = f"mpp:charge:{payload.hash.lower()}"
             if not await self._store.put_if_absent(store_key, payload.hash):
                 raise VerificationError("Transaction hash already used")
+
+        try:
+            receipt_data = await self._fetch_transaction_receipt(client, payload.hash)
+            self._verify_receipt_transfers(
+                receipt_data,
+                request,
+                challenge_id=challenge_id,
+                realm=realm,
+            )
+        except Exception:
+            if self._store is not None and store_key is not None:
+                await self._store.delete(store_key)
+            raise
 
         return Receipt.success(payload.hash)
 

--- a/src/mpp/methods/tempo/intents.py
+++ b/src/mpp/methods/tempo/intents.py
@@ -5,6 +5,7 @@ Implements the charge intent for Tempo payments.
 
 from __future__ import annotations
 
+import re
 import time
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -44,6 +45,7 @@ STABLECOIN_DEX = "0xdec0000000000000000000000000000000000000"
 
 MAX_SPLITS = 10
 MAX_TRANSFERS = MAX_SPLITS + 1
+ALREADY_KNOWN_TRANSACTION_RE = re.compile(r"\b(?:already known|known transaction)\b")
 
 
 def _raw_transaction_hash(raw_tx: str) -> str:
@@ -201,7 +203,7 @@ def _is_already_known_transaction_error(result: dict[str, Any]) -> bool:
     if "error" not in result:
         return False
     msg = _rpc_error_msg(result).lower()
-    return "already known" in msg or "known transaction" in msg
+    return ALREADY_KNOWN_TRANSACTION_RE.search(msg) is not None
 
 
 def _match_transfer_calldata(call_data_hex: str, request: ChargeRequest) -> bool:

--- a/src/mpp/methods/tempo/intents.py
+++ b/src/mpp/methods/tempo/intents.py
@@ -196,6 +196,14 @@ def _rpc_error_msg(result: dict) -> str:
     return str(error_obj)
 
 
+def _is_already_known_transaction_error(result: dict[str, Any]) -> bool:
+    """Return true when an RPC send error means the tx was already accepted."""
+    if "error" not in result:
+        return False
+    msg = _rpc_error_msg(result).lower()
+    return "already known" in msg or "known transaction" in msg
+
+
 def _match_transfer_calldata(call_data_hex: str, request: ChargeRequest) -> bool:
     """Check if ABI-encoded calldata matches the expected transfer parameters."""
     if len(call_data_hex) < 136:
@@ -831,6 +839,17 @@ class ChargeIntent:
             raise
 
         if "error" in result:
+            if _is_already_known_transaction_error(result):
+                tx_hash = reserved_tx_hash or _raw_transaction_hash(raw_tx)
+                receipt_data = await self._fetch_transaction_receipt(client, tx_hash)
+                self._verify_receipt_transfers(
+                    receipt_data,
+                    request,
+                    challenge_id=challenge_id,
+                    realm=realm,
+                )
+                return Receipt.success(tx_hash)
+
             if self._store is not None and store_key is not None:
                 await self._store.delete(store_key)
             raise VerificationError(f"Transaction submission failed: {_rpc_error_msg(result)}")

--- a/tests/test_tempo.py
+++ b/tests/test_tempo.py
@@ -880,6 +880,66 @@ class TestChargeIntent:
             )
 
     @pytest.mark.asyncio
+    async def test_verify_hash_duplicate_rejects_without_receipt_fetch(self) -> None:
+        from mpp.store import MemoryStore
+
+        future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
+        store = MemoryStore()
+        tx_hash = "0xabc123"
+        await store.put_if_absent(f"mpp:charge:{tx_hash}", tx_hash)
+        intent = ChargeIntent(rpc_url="https://rpc.test", store=store)
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock()
+        intent._http_client = mock_client
+
+        credential = make_credential(payload={"type": "hash", "hash": tx_hash}, expires=future)
+
+        with pytest.raises(VerificationError, match="Transaction hash already used"):
+            await intent.verify(
+                credential,
+                {
+                    "amount": "1000",
+                    "currency": "0x1234567890123456789012345678901234567890",
+                    "recipient": "0x4567890123456789012345678901234567890123",
+                },
+            )
+
+        mock_client.post.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_verify_hash_releases_reservation_on_validation_error(self) -> None:
+        from mpp.store import MemoryStore
+
+        future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
+        store = MemoryStore()
+        tx_hash = "0xabc123"
+        intent = ChargeIntent(rpc_url="https://rpc.test", store=store)
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(
+            return_value=mock_response(
+                200,
+                {"jsonrpc": "2.0", "result": {"status": "0x0", "logs": []}, "id": 1},
+            )
+        )
+        intent._http_client = mock_client
+
+        credential = make_credential(payload={"type": "hash", "hash": tx_hash}, expires=future)
+
+        with pytest.raises(VerificationError, match="Transaction reverted"):
+            await intent.verify(
+                credential,
+                {
+                    "amount": "1000",
+                    "currency": "0x1234567890123456789012345678901234567890",
+                    "recipient": "0x4567890123456789012345678901234567890123",
+                },
+            )
+
+        assert await store.get(f"mpp:charge:{tx_hash}") is None
+
+    @pytest.mark.asyncio
     async def test_verify_transaction_success(self) -> None:
         """Should verify transaction credential with matching transfer logs."""
         future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()

--- a/tests/test_tempo.py
+++ b/tests/test_tempo.py
@@ -36,6 +36,7 @@ from mpp.methods.tempo.intents import (
     _match_single_transfer_calldata,
     _match_transfer_calldata,
     _parse_memo_bytes,
+    _raw_transaction_hash,
     _rpc_error_msg,
     get_transfers,
 )
@@ -887,8 +888,10 @@ class TestChargeIntent:
         asset = "0x1234567890123456789012345678901234567890"
         destination = "0x4567890123456789012345678901234567890123"
         amount = 1000
+        challenge_id = "challenge-transaction-success"
+        realm = "api.example.com"
+        memo = encode_attribution(challenge_id=challenge_id, server_id=realm)
 
-        transfer_topic = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
         from_topic = "0x" + "0" * 24 + "abcd" * 10
         to_topic = "0x" + "0" * 24 + destination[2:]
 
@@ -898,7 +901,7 @@ class TestChargeIntent:
             "logs": [
                 {
                     "address": asset,
-                    "topics": [transfer_topic, from_topic, to_topic],
+                    "topics": [TRANSFER_WITH_MEMO_TOPIC, from_topic, to_topic, memo],
                     "data": "0x" + hex(amount)[2:].zfill(64),
                 }
             ],
@@ -914,7 +917,9 @@ class TestChargeIntent:
 
         credential = make_credential(
             payload={"type": "transaction", "signature": "0xabcdef1234567890"},
+            challenge_id=challenge_id,
             expires=future,
+            realm=realm,
         )
         receipt = await intent.verify(
             credential,
@@ -938,6 +943,7 @@ class TestChargeIntent:
         asset = "0x1234567890123456789012345678901234567890"
         destination = "0x4567890123456789012345678901234567890123"
         amount = 1000
+        explicit_memo = "0x" + "ab" * 32
 
         receipt_with_logs = {
             "transactionHash": "0xtxhash123",
@@ -949,7 +955,7 @@ class TestChargeIntent:
                         TRANSFER_WITH_MEMO_TOPIC,
                         "0x" + "0" * 24 + "abcd" * 10,
                         "0x" + "0" * 24 + destination[2:],
-                        "0x" + "ab" * 32,
+                        explicit_memo,
                     ],
                     "data": "0x" + hex(amount)[2:].zfill(64),
                 }
@@ -974,11 +980,116 @@ class TestChargeIntent:
                 "amount": str(amount),
                 "currency": asset,
                 "recipient": destination,
+                "methodDetails": {"memo": explicit_memo},
             },
         )
 
         assert receipt.status == "success"
         assert receipt.reference == "0xtxhash123"
+
+    @pytest.mark.asyncio
+    async def test_verify_transaction_rejects_plain_transfer_without_challenge_bound_memo(
+        self,
+    ) -> None:
+        future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
+        intent = ChargeIntent(rpc_url="https://rpc.test")
+
+        asset = "0x1234567890123456789012345678901234567890"
+        destination = "0x4567890123456789012345678901234567890123"
+        amount = 1000
+
+        receipt_with_logs = {
+            "transactionHash": "0xtxhash123",
+            "status": "0x1",
+            "logs": [
+                {
+                    "address": asset,
+                    "topics": [
+                        TRANSFER_TOPIC,
+                        "0x" + "0" * 24 + "abcd" * 10,
+                        "0x" + "0" * 24 + destination[2:],
+                    ],
+                    "data": "0x" + hex(amount)[2:].zfill(64),
+                }
+            ],
+        }
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(
+            return_value=mock_response(
+                200, {"jsonrpc": "2.0", "result": receipt_with_logs, "id": 1}
+            )
+        )
+        intent._http_client = mock_client
+
+        credential = make_credential(
+            payload={"type": "transaction", "signature": "0xabcdef1234567890"},
+            challenge_id="challenge-123",
+            expires=future,
+            realm="api.example.com",
+        )
+
+        with pytest.raises(VerificationError, match="memo is not bound to this challenge"):
+            await intent.verify(
+                credential,
+                {
+                    "amount": str(amount),
+                    "currency": asset,
+                    "recipient": destination,
+                },
+            )
+
+    @pytest.mark.asyncio
+    async def test_verify_transaction_rejects_wrong_challenge_bound_memo(self) -> None:
+        future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
+        intent = ChargeIntent(rpc_url="https://rpc.test")
+
+        asset = "0x1234567890123456789012345678901234567890"
+        destination = "0x4567890123456789012345678901234567890123"
+        amount = 1000
+        memo = encode_attribution(challenge_id="challenge-a", server_id="api.example.com")
+
+        receipt_with_logs = {
+            "transactionHash": "0xtxhash123",
+            "status": "0x1",
+            "logs": [
+                {
+                    "address": asset,
+                    "topics": [
+                        TRANSFER_WITH_MEMO_TOPIC,
+                        "0x" + "0" * 24 + "abcd" * 10,
+                        "0x" + "0" * 24 + destination[2:],
+                        memo,
+                    ],
+                    "data": "0x" + hex(amount)[2:].zfill(64),
+                }
+            ],
+        }
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(
+            return_value=mock_response(
+                200, {"jsonrpc": "2.0", "result": receipt_with_logs, "id": 1}
+            )
+        )
+        intent._http_client = mock_client
+
+        credential = make_credential(
+            payload={"type": "transaction", "signature": "0xabcdef1234567890"},
+            challenge_id="challenge-b",
+            expires=future,
+            realm="api.example.com",
+        )
+
+        with pytest.raises(VerificationError, match="memo is not bound to this challenge"):
+            await intent.verify(
+                credential,
+                {
+                    "amount": str(amount),
+                    "currency": asset,
+                    "recipient": destination,
+                },
+            )
 
     @pytest.mark.asyncio
     async def test_verify_transaction_records_hash_and_blocks_hash_reuse(self) -> None:
@@ -990,12 +1101,14 @@ class TestChargeIntent:
 
         asset = "0x1234567890123456789012345678901234567890"
         destination = "0x4567890123456789012345678901234567890123"
+        raw_signature = "0xabcdef1234567890"
+        tx_hash = _raw_transaction_hash(raw_signature)
         memo = encode_attribution(
             challenge_id="challenge-123",
             server_id="api.example.com",
         )
         receipt_with_logs = {
-            "transactionHash": "0xabc123",
+            "transactionHash": tx_hash,
             "status": "0x1",
             "logs": [
                 {
@@ -1021,7 +1134,7 @@ class TestChargeIntent:
         intent._http_client = mock_client
 
         transaction_credential = make_credential(
-            payload={"type": "transaction", "signature": "0xabcdef1234567890"},
+            payload={"type": "transaction", "signature": raw_signature},
             challenge_id="challenge-123",
             expires=future,
             realm="api.example.com",
@@ -1034,11 +1147,11 @@ class TestChargeIntent:
 
         receipt = await intent.verify(transaction_credential, request)
         assert receipt.status == "success"
-        assert receipt.reference == "0xabc123"
-        assert await store.get("mpp:charge:0xabc123") is not None
+        assert receipt.reference == tx_hash
+        assert await store.get(f"mpp:charge:{tx_hash}") is not None
 
         hash_credential = make_credential(
-            payload={"type": "hash", "hash": "0xabc123"},
+            payload={"type": "hash", "hash": tx_hash},
             challenge_id="challenge-123",
             expires=future,
             realm="api.example.com",
@@ -1048,12 +1161,77 @@ class TestChargeIntent:
             await intent.verify(hash_credential, request)
 
     @pytest.mark.asyncio
-    async def test_verify_transaction_does_not_record_hash_on_failure(self) -> None:
+    async def test_verify_transaction_duplicate_fetches_receipt_without_rebroadcast(
+        self,
+    ) -> None:
         from mpp.store import MemoryStore
 
         future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
         store = MemoryStore()
         intent = ChargeIntent(rpc_url="https://rpc.test", store=store)
+
+        asset = "0x1234567890123456789012345678901234567890"
+        destination = "0x4567890123456789012345678901234567890123"
+        raw_signature = "0xabcdef1234567890"
+        tx_hash = _raw_transaction_hash(raw_signature)
+        challenge_id = "challenge-123"
+        realm = "api.example.com"
+        memo = encode_attribution(challenge_id=challenge_id, server_id=realm)
+        receipt_with_logs = {
+            "transactionHash": tx_hash,
+            "status": "0x1",
+            "logs": [
+                {
+                    "address": asset,
+                    "topics": [
+                        TRANSFER_WITH_MEMO_TOPIC,
+                        "0x" + "0" * 24 + "abcd" * 10,
+                        "0x" + "0" * 24 + destination[2:],
+                        memo,
+                    ],
+                    "data": amount_data(1000),
+                }
+            ],
+        }
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(
+            side_effect=[
+                mock_response(200, {"jsonrpc": "2.0", "result": receipt_with_logs, "id": 1}),
+                mock_response(200, {"jsonrpc": "2.0", "result": receipt_with_logs, "id": 1}),
+            ]
+        )
+        intent._http_client = mock_client
+
+        credential = make_credential(
+            payload={"type": "transaction", "signature": raw_signature},
+            challenge_id=challenge_id,
+            expires=future,
+            realm=realm,
+        )
+        request = {
+            "amount": "1000",
+            "currency": asset,
+            "recipient": destination,
+        }
+
+        first_receipt = await intent.verify(credential, request)
+        second_receipt = await intent.verify(credential, request)
+
+        assert first_receipt.reference == tx_hash
+        assert second_receipt.reference == tx_hash
+        methods = [call.kwargs["json"]["method"] for call in mock_client.post.await_args_list]
+        assert methods == ["eth_sendRawTransactionSync", "eth_getTransactionReceipt"]
+
+    @pytest.mark.asyncio
+    async def test_verify_transaction_pre_reserves_hash_on_failed_receipt(self) -> None:
+        from mpp.store import MemoryStore
+
+        future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
+        store = MemoryStore()
+        intent = ChargeIntent(rpc_url="https://rpc.test", store=store)
+        raw_signature = "0xabcdef1234567890"
+        tx_hash = _raw_transaction_hash(raw_signature)
 
         mock_client = AsyncMock()
         mock_client.post = AsyncMock(
@@ -1061,7 +1239,7 @@ class TestChargeIntent:
                 200,
                 {
                     "jsonrpc": "2.0",
-                    "result": {"transactionHash": "0xtxhash123", "status": "0x0", "logs": []},
+                    "result": {"transactionHash": tx_hash, "status": "0x0", "logs": []},
                     "id": 1,
                 },
             )
@@ -1069,7 +1247,7 @@ class TestChargeIntent:
         intent._http_client = mock_client
 
         credential = make_credential(
-            payload={"type": "transaction", "signature": "0xabcdef1234567890"},
+            payload={"type": "transaction", "signature": raw_signature},
             expires=future,
         )
 
@@ -1083,7 +1261,7 @@ class TestChargeIntent:
                 },
             )
 
-        assert await store.get("mpp:charge:0xtxhash123") is None
+        assert await store.get(f"mpp:charge:{tx_hash}") is not None
 
     @pytest.mark.asyncio
     async def test_verify_transaction_rpc_error(self) -> None:
@@ -1113,6 +1291,42 @@ class TestChargeIntent:
                     "recipient": "0x4567890123456789012345678901234567890123",
                 },
             )
+
+    @pytest.mark.asyncio
+    async def test_verify_transaction_releases_reservation_on_rpc_error(self) -> None:
+        from mpp.store import MemoryStore
+
+        future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
+        store = MemoryStore()
+        intent = ChargeIntent(rpc_url="https://rpc.test", store=store)
+        raw_signature = "0xabcdef1234567890"
+        tx_hash = _raw_transaction_hash(raw_signature)
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(
+            return_value=mock_response(
+                200,
+                {"jsonrpc": "2.0", "error": {"message": "insufficient funds"}, "id": 1},
+            )
+        )
+        intent._http_client = mock_client
+
+        credential = make_credential(
+            payload={"type": "transaction", "signature": raw_signature},
+            expires=future,
+        )
+
+        with pytest.raises(VerificationError, match="Transaction submission failed"):
+            await intent.verify(
+                credential,
+                {
+                    "amount": "1000",
+                    "currency": "0x1234567890123456789012345678901234567890",
+                    "recipient": "0x4567890123456789012345678901234567890123",
+                },
+            )
+
+        assert await store.get(f"mpp:charge:{tx_hash}") is None
 
     @pytest.mark.asyncio
     async def test_verify_transaction_missing_receipt(self) -> None:
@@ -1198,6 +1412,9 @@ class TestSponsoredTransfer:
     async def test_server_submits_sponsored_transaction(self, httpx_mock: HTTPXMock) -> None:
         """Server should submit sponsored tx via external fee payer service."""
         future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
+        challenge_id = "test-sponsored"
+        realm = "test.example.com"
+        memo = encode_attribution(challenge_id=challenge_id, server_id=realm)
 
         # External fee payer signs and returns co-signed tx
         httpx_mock.add_response(
@@ -1217,14 +1434,12 @@ class TestSponsoredTransfer:
                         {
                             "address": "0x20c0000000000000000000000000000000000000",
                             "topics": [
-                                "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+                                TRANSFER_WITH_MEMO_TOPIC,
                                 "0x000000000000000000000000sender00000000000000000000000000000000",
                                 "0x000000000000000000000000742d35cc6634c0532925a3b844bc9e7595f8fe00",
+                                memo,
                             ],
-                            "data": (
-                                "0x000000000000000000000000000000000000"
-                                "00000000000000000000000000000f4240"
-                            ),
+                            "data": amount_data(1000000),
                         }
                     ],
                 },
@@ -1235,7 +1450,9 @@ class TestSponsoredTransfer:
         intent = ChargeIntent(rpc_url="https://rpc.test")
         credential = make_credential(
             payload={"type": "transaction", "signature": "0x76abcdef"},
+            challenge_id=challenge_id,
             expires=future,
+            realm=realm,
         )
 
         receipt = await intent.verify(

--- a/tests/test_tempo.py
+++ b/tests/test_tempo.py
@@ -1329,6 +1329,48 @@ class TestChargeIntent:
         assert await store.get(f"mpp:charge:{tx_hash}") is None
 
     @pytest.mark.asyncio
+    async def test_verify_transaction_unknown_type_error_releases_reservation(self) -> None:
+        from mpp.store import MemoryStore
+
+        future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
+        store = MemoryStore()
+        intent = ChargeIntent(rpc_url="https://rpc.test", store=store)
+        raw_signature = "0xabcdef1234567890"
+        tx_hash = _raw_transaction_hash(raw_signature)
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(
+            return_value=mock_response(
+                200,
+                {
+                    "jsonrpc": "2.0",
+                    "error": {"message": "unknown transaction type"},
+                    "id": 1,
+                },
+            )
+        )
+        intent._http_client = mock_client
+
+        credential = make_credential(
+            payload={"type": "transaction", "signature": raw_signature},
+            expires=future,
+        )
+
+        with pytest.raises(VerificationError, match="Transaction submission failed"):
+            await intent.verify(
+                credential,
+                {
+                    "amount": "1000",
+                    "currency": "0x1234567890123456789012345678901234567890",
+                    "recipient": "0x4567890123456789012345678901234567890123",
+                },
+            )
+
+        assert await store.get(f"mpp:charge:{tx_hash}") is None
+        methods = [call.kwargs["json"]["method"] for call in mock_client.post.await_args_list]
+        assert methods == ["eth_sendRawTransactionSync"]
+
+    @pytest.mark.asyncio
     async def test_verify_transaction_already_known_error_fetches_receipt(self) -> None:
         from mpp.store import MemoryStore
 

--- a/tests/test_tempo.py
+++ b/tests/test_tempo.py
@@ -1329,6 +1329,69 @@ class TestChargeIntent:
         assert await store.get(f"mpp:charge:{tx_hash}") is None
 
     @pytest.mark.asyncio
+    async def test_verify_transaction_already_known_error_fetches_receipt(self) -> None:
+        from mpp.store import MemoryStore
+
+        future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
+        store = MemoryStore()
+        intent = ChargeIntent(rpc_url="https://rpc.test", store=store)
+
+        asset = "0x1234567890123456789012345678901234567890"
+        destination = "0x4567890123456789012345678901234567890123"
+        raw_signature = "0xabcdef1234567890"
+        tx_hash = _raw_transaction_hash(raw_signature)
+        challenge_id = "challenge-123"
+        realm = "api.example.com"
+        memo = encode_attribution(challenge_id=challenge_id, server_id=realm)
+        receipt_with_logs = {
+            "transactionHash": tx_hash,
+            "status": "0x1",
+            "logs": [
+                {
+                    "address": asset,
+                    "topics": [
+                        TRANSFER_WITH_MEMO_TOPIC,
+                        "0x" + "0" * 24 + "abcd" * 10,
+                        "0x" + "0" * 24 + destination[2:],
+                        memo,
+                    ],
+                    "data": amount_data(1000),
+                }
+            ],
+        }
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(
+            side_effect=[
+                mock_response(
+                    200,
+                    {"jsonrpc": "2.0", "error": {"message": "already known"}, "id": 1},
+                ),
+                mock_response(200, {"jsonrpc": "2.0", "result": receipt_with_logs, "id": 1}),
+            ]
+        )
+        intent._http_client = mock_client
+
+        credential = make_credential(
+            payload={"type": "transaction", "signature": raw_signature},
+            challenge_id=challenge_id,
+            expires=future,
+            realm=realm,
+        )
+        request = {
+            "amount": "1000",
+            "currency": asset,
+            "recipient": destination,
+        }
+
+        receipt = await intent.verify(credential, request)
+
+        assert receipt.reference == tx_hash
+        assert await store.get(f"mpp:charge:{tx_hash}") is not None
+        methods = [call.kwargs["json"]["method"] for call in mock_client.post.await_args_list]
+        assert methods == ["eth_sendRawTransactionSync", "eth_getTransactionReceipt"]
+
+    @pytest.mark.asyncio
     async def test_verify_transaction_missing_receipt(self) -> None:
         future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
         intent = ChargeIntent(rpc_url="https://rpc.test")


### PR DESCRIPTION
## Summary

- Enforce challenge-bound attribution memo checks for Tempo transaction credentials, matching the hash credential path.
- Reserve computed raw transaction hashes before broadcast when replay protection storage is configured.
- On duplicate transaction credentials, fetch and validate the existing receipt instead of rebroadcasting.
- Release reservations for submission errors while keeping receipt/validation failures reserved for retry safety.
- Added a patch changelog entry and regression tests. Confirmed `uv run ruff check .`, `uv run pyright`, and `uv run pytest -q` pass.