### PR TITLE
ci: add conformance gate

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -1,0 +1,37 @@
+name: Conformance
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - edited
+      - labeled
+      - unlabeled
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  conformance-policy:
+    uses: tempoxyz/mpp-tools/.github/workflows/sdk-conformance-policy.yml@main
+    with:
+      protocol-paths: |
+        src/**
+        pyproject.toml
+        uv.lock
+
+  conformance:
+    needs: conformance-policy
+    uses: tempoxyz/mpp-tools/.github/workflows/sdk-conformance.yml@main
+    with:
+      adapter: python
+      conformance-ref: ${{ needs.conformance-policy.outputs.conformance_ref }}


### PR DESCRIPTION
## Summary

- Add the reusable mpp-tools SDK conformance workflow for the Python adapter.
- Add the mpp-tools conformance policy gate for protocol-sensitive Python SDK paths.
- Confirmed local Python vector and flow conformance pass against this SDK checkout.

<img width="821" height="98" alt="Screenshot 2026-06-02 at 12 12 28" src="https://github.com/user-attachments/assets/de04a004-ff0b-4628-9254-b98ff1488911" />