### PR TITLE
feat: validate hash credential source

### DIFF
--- a/.changelog/hash-credential-source-validation.md
+++ b/.changelog/hash-credential-source-validation.md
@@ -1,0 +1,5 @@
+---
+pympp: minor
+---
+
+Validate the credential `source` on the Tempo hash-credential verification path. The server now parses the `did:pkh:eip155` source before reserving the transaction hash, requires TIP-20 transfers to originate from the declared source address (falling back to the receipt sender when no source is provided), and rejects malformed or chain-mismatched sources with a uniform error. Adds a `validate_sender` callback (with `SenderValidation` / `ValidateSender`) to `ChargeIntent` to authorize smart-account / relayer flows where the on-chain transfer sender differs from the declared source.

--- a/src/mpp/methods/tempo/__init__.py
+++ b/src/mpp/methods/tempo/__init__.py
@@ -43,7 +43,13 @@ _EXTRA_INSTALL_HINT = 'Install the "tempo" extra to use this module: pip install
 _LAZY_EXPORTS = {
     "mpp.methods.tempo.account": ("TempoAccount",),
     "mpp.methods.tempo.client": ("TempoMethod", "TransactionError", "tempo"),
-    "mpp.methods.tempo.intents": ("ChargeIntent", "Transfer", "get_transfers"),
+    "mpp.methods.tempo.intents": (
+        "ChargeIntent",
+        "Transfer",
+        "SenderValidation",
+        "ValidateSender",
+        "get_transfers",
+    ),
     "mpp.methods.tempo.schemas": ("Split",),
 }
 

--- a/src/mpp/methods/tempo/__init__.pyi
+++ b/src/mpp/methods/tempo/__init__.pyi
@@ -10,7 +10,9 @@ from mpp.methods.tempo.client import TempoMethod as _TempoMethod
 from mpp.methods.tempo.client import TransactionError as _TransactionError
 from mpp.methods.tempo.client import tempo as _tempo
 from mpp.methods.tempo.intents import ChargeIntent as _ChargeIntent
+from mpp.methods.tempo.intents import SenderValidation as _SenderValidation
 from mpp.methods.tempo.intents import Transfer as _Transfer
+from mpp.methods.tempo.intents import ValidateSender as _ValidateSender
 from mpp.methods.tempo.intents import get_transfers as _get_transfers
 from mpp.methods.tempo.schemas import Split as _Split
 
@@ -26,6 +28,8 @@ TempoMethod = _TempoMethod
 TransactionError = _TransactionError
 tempo = _tempo
 ChargeIntent = _ChargeIntent
+SenderValidation = _SenderValidation
 Transfer = _Transfer
+ValidateSender = _ValidateSender
 get_transfers = _get_transfers
 Split = _Split

--- a/src/mpp/methods/tempo/intents.py
+++ b/src/mpp/methods/tempo/intents.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import re
 import time
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, Literal
@@ -186,6 +187,45 @@ def _match_single_transfer_calldata(
 class MatchedTransferLog:
     kind: Literal["memo", "transfer"]
     memo: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class SenderValidation:
+    """Arguments passed to a ``validate_sender`` callback on a sender mismatch."""
+
+    expected_sender: str
+    """The expected sender (source address, or receipt sender if no source)."""
+    sender: str
+    """The actual ``from`` address on the transfer log."""
+    source: str | None
+    """The raw credential source DID, if provided."""
+
+
+# Authorizes a transfer whose sender differs from the expected sender;
+# return ``True`` to accept.
+ValidateSender = Callable[[SenderValidation], bool]
+
+
+_PKH_SOURCE_RE = re.compile(r"did:pkh:eip155:(0|[1-9][0-9]*):(.+)")
+_PKH_ADDRESS_RE = re.compile(r"0x[a-fA-F0-9]{40}")
+
+
+def _parse_pkh_source(source: str) -> tuple[str, int] | None:
+    """Parse a ``did:pkh:eip155:<chainId>:<address>`` DID.
+
+    Returns ``(address, chain_id)`` or ``None`` if malformed.
+    """
+    match = _PKH_SOURCE_RE.fullmatch(source)
+    if match is None:
+        return None
+    address = match.group(2)
+    if _PKH_ADDRESS_RE.fullmatch(address) is None:
+        return None
+    try:
+        chain_id = int(match.group(1))
+    except ValueError:
+        return None
+    return address, chain_id
 
 
 def _rpc_error_msg(result: dict) -> str:
@@ -377,6 +417,7 @@ class ChargeIntent:
         http_client: httpx.AsyncClient | None = None,
         timeout: float = DEFAULT_TIMEOUT,
         store: Store | None = None,
+        validate_sender: ValidateSender | None = None,
     ) -> None:
         """Initialize the charge intent.
 
@@ -391,6 +432,9 @@ class ChargeIntent:
             store: Optional key-value store for tx hash replay protection.
                 When provided, each verified hash is recorded and subsequent
                 attempts to reuse it are rejected.
+            validate_sender: Optional callback invoked when a hash-credential
+                transfer's sender differs from the expected sender; return
+                ``True`` to accept (e.g. smart-account / relayer flows).
         """
         if rpc_url is None and chain_id is not None:
             rpc_url = rpc_url_for_chain(chain_id)
@@ -400,6 +444,7 @@ class ChargeIntent:
         self._owns_client = http_client is None
         self._timeout = timeout
         self._store = store
+        self._validate_sender = validate_sender
 
     @property
     def fee_payer(self) -> TempoAccount | None:
@@ -481,6 +526,7 @@ class ChargeIntent:
                 req,
                 challenge_id=credential.challenge.id,
                 realm=credential.challenge.realm,
+                source=credential.source,
             )
         else:
             return await self._verify_transaction(
@@ -490,14 +536,59 @@ class ChargeIntent:
                 realm=credential.challenge.realm,
             )
 
+    def _parse_hash_credential_source(
+        self, source: str | None, expected_chain_id: int
+    ) -> str | None:
+        """Parse a hash credential source.
+
+        Returns ``None`` if absent, the address for a ``did:pkh:eip155`` DID
+        matching ``expected_chain_id``, else raises ``VerificationError``.
+        """
+        if source is None:
+            return None
+        parsed = _parse_pkh_source(source)
+        if parsed is None or parsed[1] != expected_chain_id:
+            raise VerificationError("Hash credential source is invalid.")
+        return parsed[0]
+
+    def _sender_authorized(
+        self,
+        from_address: str,
+        expected_sender: str | None,
+        source: str | None,
+        validate_sender: ValidateSender | None,
+    ) -> bool:
+        """Whether ``from_address`` is an acceptable transfer sender.
+
+        Matches when no expected sender is set or it equals ``from_address``.
+        On a mismatch, an optional ``validate_sender`` callback may authorize it.
+        """
+        if not expected_sender or from_address.lower() == expected_sender.lower():
+            return True
+        if validate_sender is None:
+            return False
+        return bool(
+            validate_sender(
+                SenderValidation(
+                    expected_sender=expected_sender,
+                    sender=from_address,
+                    source=source,
+                )
+            )
+        )
+
     async def _verify_hash(
         self,
         payload: HashCredentialPayload,
         request: ChargeRequest,
         challenge_id: str,
         realm: str,
+        source: str | None = None,
     ) -> Receipt:
         """Verify a credential with a transaction hash."""
+        # Validate the source before reserving the hash.
+        source_address = self._parse_hash_credential_source(source, request.methodDetails.chainId)
+
         client = await self._get_client()
 
         store_key: str | None = None
@@ -513,6 +604,9 @@ class ChargeIntent:
                 request,
                 challenge_id=challenge_id,
                 realm=realm,
+                source=source,
+                source_address=source_address,
+                validate_sender=self._validate_sender,
             )
         except Exception:
             if self._store is not None and store_key is not None:
@@ -572,11 +666,22 @@ class ChargeIntent:
         request: ChargeRequest,
         challenge_id: str,
         realm: str,
+        source: str | None = None,
+        source_address: str | None = None,
+        validate_sender: ValidateSender | None = None,
     ) -> list[MatchedTransferLog]:
         if receipt_data.get("status") != "0x1":
             raise VerificationError("Transaction reverted")
 
-        matched_logs = self._verify_transfer_logs(receipt_data, request)
+        # Use the source address if present, otherwise the receipt sender.
+        expected_sender = source_address or receipt_data.get("from")
+        matched_logs = self._verify_transfer_logs(
+            receipt_data,
+            request,
+            expected_sender=expected_sender,
+            source=source,
+            validate_sender=validate_sender,
+        )
         if not matched_logs:
             raise VerificationError(
                 "Transaction must contain a Transfer log matching request parameters"
@@ -603,6 +708,8 @@ class ChargeIntent:
         amount: int,
         memo: bytes | None,
         expected_sender: str | None = None,
+        source: str | None = None,
+        validate_sender: ValidateSender | None = None,
     ) -> list[MatchedTransferLog]:
         """Check if receipt contains matching Transfer/TransferWithMemo logs.
 
@@ -625,8 +732,6 @@ class ChargeIntent:
 
             if to_address.lower() != recipient.lower():
                 continue
-            if expected_sender and from_address.lower() != expected_sender.lower():
-                continue
 
             if event_topic == TRANSFER_WITH_MEMO_TOPIC:
                 if len(topics) < 4:
@@ -642,6 +747,10 @@ class ChargeIntent:
                     expected_memo_hex = "0x" + memo.hex()
                     if log_memo.lower() != expected_memo_hex.lower():
                         continue
+                if not self._sender_authorized(
+                    from_address, expected_sender, source, validate_sender
+                ):
+                    continue
                 memo_matches.append(MatchedTransferLog(kind="memo", memo=log_memo))
             elif event_topic == TRANSFER_TOPIC:
                 if memo is not None:
@@ -649,7 +758,9 @@ class ChargeIntent:
                 data = log.get("data", "0x")
                 if len(data) >= 66:
                     log_amount = int(data, 16)
-                    if log_amount == amount:
+                    if log_amount == amount and self._sender_authorized(
+                        from_address, expected_sender, source, validate_sender
+                    ):
                         transfer_matches.append(MatchedTransferLog(kind="transfer"))
 
         return memo_matches + transfer_matches
@@ -659,6 +770,8 @@ class ChargeIntent:
         receipt: dict[str, Any],
         request: ChargeRequest,
         expected_sender: str | None = None,
+        source: str | None = None,
+        validate_sender: ValidateSender | None = None,
     ) -> list[MatchedTransferLog]:
         """Check if receipt contains matching Transfer or TransferWithMemo logs.
 
@@ -680,6 +793,8 @@ class ChargeIntent:
                 t.amount,
                 t.memo,
                 expected_sender,
+                source,
+                validate_sender,
             )
 
         # Multi-transfer: order-insensitive matching
@@ -713,8 +828,6 @@ class ChargeIntent:
 
                 if to_addr.lower() != transfer.recipient.lower():
                     continue
-                if expected_sender and from_addr.lower() != expected_sender.lower():
-                    continue
 
                 if transfer.memo is not None:
                     if event_topic != TRANSFER_WITH_MEMO_TOPIC:
@@ -727,7 +840,13 @@ class ChargeIntent:
                     log_amount = int(data[2:66], 16)
                     memo_topic = topics[3]
                     expected_hex = "0x" + transfer.memo.hex()
-                    if log_amount == transfer.amount and memo_topic.lower() == expected_hex.lower():
+                    if (
+                        log_amount == transfer.amount
+                        and memo_topic.lower() == expected_hex.lower()
+                        and self._sender_authorized(
+                            from_addr, expected_sender, source, validate_sender
+                        )
+                    ):
                         used_logs.add(log_idx)
                         all_matches.append(MatchedTransferLog(kind="memo", memo=memo_topic))
                         found = True
@@ -740,7 +859,9 @@ class ChargeIntent:
                         if len(data) < 66:
                             continue
                         log_amount = int(data[2:66], 16)
-                        if log_amount == transfer.amount:
+                        if log_amount == transfer.amount and self._sender_authorized(
+                            from_addr, expected_sender, source, validate_sender
+                        ):
                             used_logs.add(log_idx)
                             all_matches.append(MatchedTransferLog(kind="memo", memo=topics[3]))
                             found = True
@@ -749,7 +870,9 @@ class ChargeIntent:
                         if len(data) < 66:
                             continue
                         log_amount = int(data, 16)
-                        if log_amount == transfer.amount:
+                        if log_amount == transfer.amount and self._sender_authorized(
+                            from_addr, expected_sender, source, validate_sender
+                        ):
                             used_logs.add(log_idx)
                             all_matches.append(MatchedTransferLog(kind="transfer"))
                             found = True

--- a/src/mpp/methods/tempo/intents.py
+++ b/src/mpp/methods/tempo/intents.py
@@ -194,7 +194,7 @@ class SenderValidation:
     """Arguments passed to a ``validate_sender`` callback on a sender mismatch."""
 
     expected_sender: str
-    """The expected sender (source address, or receipt sender if no source)."""
+    """The expected sender: the address declared in the credential source."""
     sender: str
     """The actual ``from`` address on the transfer log."""
     source: str | None
@@ -673,8 +673,9 @@ class ChargeIntent:
         if receipt_data.get("status") != "0x1":
             raise VerificationError("Transaction reverted")
 
-        # Use the source address if present, otherwise the receipt sender.
-        expected_sender = source_address or receipt_data.get("from")
+        # Bind the transfer sender only when a credential source is present;
+        # no source means no sender filtering.
+        expected_sender = source_address
         matched_logs = self._verify_transfer_logs(
             receipt_data,
             request,

--- a/tests/test_tempo.py
+++ b/tests/test_tempo.py
@@ -3685,3 +3685,271 @@ class TestGetTransfersInvalidMemo:
         ]
         with pytest.raises(VerificationError, match="exactly 32 bytes"):
             get_transfers(1_000_000, "0x01", None, splits)
+
+
+class TestHashCredentialSourceValidation:
+    """Hash credential source validation (did:pkh) and validate_sender hook."""
+
+    CURRENCY = "0x20c0000000000000000000000000000000000000"
+    RECIPIENT = "0x742d35Cc6634c0532925a3b844bC9e7595F8fE00"
+    CHAIN_ID = 4217
+    SOURCE_ADDR = "0x00000000000000000000000000000000000000aa"
+    RELAYER = "0x00000000000000000000000000000000000000bb"
+
+    def _topic(self, address: str) -> str:
+        return "0x" + address.lower().removeprefix("0x").zfill(64)
+
+    def _memo_log(self, frm: str, memo: str, amount: int = 1000) -> dict:
+        return {
+            "address": self.CURRENCY,
+            "topics": [
+                TRANSFER_WITH_MEMO_TOPIC,
+                self._topic(frm),
+                self._topic(self.RECIPIENT),
+                memo,
+            ],
+            "data": amount_data(amount),
+        }
+
+    def _did(self, chain_id: int, address: str) -> str:
+        return f"did:pkh:eip155:{chain_id}:{address}"
+
+    def _intent(self, receipt: dict, *, validate_sender=None, store=None) -> ChargeIntent:
+        intent = ChargeIntent(
+            rpc_url="https://rpc.test", validate_sender=validate_sender, store=store
+        )
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(
+            return_value=mock_response(200, {"jsonrpc": "2.0", "result": receipt, "id": 1})
+        )
+        intent._http_client = mock_client
+        return intent
+
+    async def _verify(self, intent: ChargeIntent, source: str | None, memo_value=None):
+        future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
+        request: dict = {
+            "amount": "1000",
+            "currency": self.CURRENCY,
+            "recipient": self.RECIPIENT,
+        }
+        if memo_value is not None:
+            request["methodDetails"] = {"memo": memo_value}
+        credential = make_credential(
+            payload={"type": "hash", "hash": "0xabc123"},
+            challenge_id="challenge-123",
+            realm="api.example.com",
+            expires=future,
+            source=source,
+        )
+        return await intent.verify(credential, request)
+
+    @property
+    def _bound_memo(self) -> str:
+        return encode_attribution(challenge_id="challenge-123", server_id="api.example.com")
+
+    # ---- parse unit tests ----
+
+    def test_parse_absent_is_none(self) -> None:
+        intent = ChargeIntent(rpc_url="https://rpc.test")
+        assert intent._parse_hash_credential_source(None, self.CHAIN_ID) is None
+
+    def test_parse_valid_returns_address(self) -> None:
+        intent = ChargeIntent(rpc_url="https://rpc.test")
+        source = self._did(self.CHAIN_ID, self.SOURCE_ADDR)
+        assert intent._parse_hash_credential_source(source, self.CHAIN_ID) == self.SOURCE_ADDR
+
+    def test_parse_chain_mismatch_raises(self) -> None:
+        intent = ChargeIntent(rpc_url="https://rpc.test")
+        with pytest.raises(VerificationError, match="Hash credential source is invalid"):
+            intent._parse_hash_credential_source(self._did(1, self.SOURCE_ADDR), self.CHAIN_ID)
+
+    def test_parse_malformed_variants_raise(self) -> None:
+        intent = ChargeIntent(rpc_url="https://rpc.test")
+        cases = [
+            "not-a-valid-did",
+            f"did:pkh:solana:{self.CHAIN_ID}:{self.SOURCE_ADDR}",
+            f"did:pkh:eip155:04217:{self.SOURCE_ADDR}",
+            f"did:pkh:eip155:not-a-number:{self.SOURCE_ADDR}",
+            f"did:pkh:eip155:{self.CHAIN_ID}:extra:{self.SOURCE_ADDR}",
+            f"did:pkh:eip155:{self.CHAIN_ID}:not-an-address",
+        ]
+        for source in cases:
+            with pytest.raises(VerificationError, match="Hash credential source is invalid"):
+                intent._parse_hash_credential_source(source, self.CHAIN_ID)
+
+    def test_parse_rejects_non_ascii_chain_digits(self) -> None:
+        intent = ChargeIntent(rpc_url="https://rpc.test")
+        source = f"did:pkh:eip155:4\uff1217:{self.SOURCE_ADDR}"  # full-width digits
+        with pytest.raises(VerificationError, match="Hash credential source is invalid"):
+            intent._parse_hash_credential_source(source, self.CHAIN_ID)
+
+    # ---- end-to-end verify tests ----
+
+    @pytest.mark.asyncio
+    async def test_hash_accepts_source_matching_transfer_sender(self) -> None:
+        receipt = {
+            "status": "0x1",
+            "from": self.SOURCE_ADDR,
+            "logs": [self._memo_log(self.SOURCE_ADDR, self._bound_memo)],
+        }
+        intent = self._intent(receipt)
+        result = await self._verify(intent, source=self._did(self.CHAIN_ID, self.SOURCE_ADDR))
+        assert result.reference == "0xabc123"
+
+    @pytest.mark.asyncio
+    async def test_hash_accepts_source_when_receipt_sender_differs(self) -> None:
+        # Relayer submitted the tx (receipt.from = RELAYER) but the transfer is
+        # from the declared source.
+        receipt = {
+            "status": "0x1",
+            "from": self.RELAYER,
+            "logs": [self._memo_log(self.SOURCE_ADDR, self._bound_memo)],
+        }
+        intent = self._intent(receipt)
+        result = await self._verify(intent, source=self._did(self.CHAIN_ID, self.SOURCE_ADDR))
+        assert result.reference == "0xabc123"
+
+    @pytest.mark.asyncio
+    async def test_hash_rejects_source_differing_from_transfer_sender(self) -> None:
+        receipt = {
+            "status": "0x1",
+            "from": self.RELAYER,
+            "logs": [self._memo_log(self.RELAYER, self._bound_memo)],
+        }
+        intent = self._intent(receipt)
+        with pytest.raises(VerificationError, match="must contain a Transfer log"):
+            await self._verify(intent, source=self._did(self.CHAIN_ID, self.SOURCE_ADDR))
+
+    @pytest.mark.asyncio
+    async def test_hash_validate_sender_override_allows_mismatch(self) -> None:
+        seen: dict = {}
+
+        def validate_sender(v) -> bool:
+            seen["v"] = v
+            return True
+
+        receipt = {
+            "status": "0x1",
+            "from": self.RELAYER,
+            "logs": [self._memo_log(self.RELAYER, self._bound_memo)],
+        }
+        intent = self._intent(receipt, validate_sender=validate_sender)
+        source = self._did(self.CHAIN_ID, self.SOURCE_ADDR)
+        result = await self._verify(intent, source=source)
+
+        assert result.reference == "0xabc123"
+        assert seen["v"].expected_sender.lower() == self.SOURCE_ADDR.lower()
+        assert seen["v"].sender.lower() == self.RELAYER.lower()
+        assert seen["v"].source == source
+
+    @pytest.mark.asyncio
+    async def test_hash_validate_sender_returning_false_rejects(self) -> None:
+        receipt = {
+            "status": "0x1",
+            "from": self.RELAYER,
+            "logs": [self._memo_log(self.RELAYER, self._bound_memo)],
+        }
+        intent = self._intent(receipt, validate_sender=lambda v: False)
+        with pytest.raises(VerificationError, match="must contain a Transfer log"):
+            await self._verify(intent, source=self._did(self.CHAIN_ID, self.SOURCE_ADDR))
+
+    @pytest.mark.asyncio
+    async def test_hash_validate_sender_not_called_when_sender_matches(self) -> None:
+        def boom(v) -> bool:
+            raise AssertionError("validate_sender must not be called")
+
+        receipt = {
+            "status": "0x1",
+            "from": self.SOURCE_ADDR,
+            "logs": [self._memo_log(self.SOURCE_ADDR, self._bound_memo)],
+        }
+        intent = self._intent(receipt, validate_sender=boom)
+        result = await self._verify(intent, source=self._did(self.CHAIN_ID, self.SOURCE_ADDR))
+        assert result.reference == "0xabc123"
+
+    @pytest.mark.asyncio
+    async def test_hash_validate_sender_not_called_for_non_candidate_logs(self) -> None:
+        def boom(v) -> bool:
+            raise AssertionError("validate_sender must not be called")
+
+        explicit_memo = "0x" + "ab" * 32
+        other_memo = "0x" + "cd" * 32
+        # First log has a wrong sender and a non-matching memo (non-candidate);
+        # second log matches fully, so the callback is never reached.
+        receipt = {
+            "status": "0x1",
+            "from": self.SOURCE_ADDR,
+            "logs": [
+                self._memo_log(self.RELAYER, other_memo),
+                self._memo_log(self.SOURCE_ADDR, explicit_memo),
+            ],
+        }
+        intent = self._intent(receipt, validate_sender=boom)
+        result = await self._verify(
+            intent, source=self._did(self.CHAIN_ID, self.SOURCE_ADDR), memo_value=explicit_memo
+        )
+        assert result.reference == "0xabc123"
+
+    @pytest.mark.asyncio
+    async def test_hash_rejects_source_from_different_chain(self) -> None:
+        receipt = {
+            "status": "0x1",
+            "from": self.SOURCE_ADDR,
+            "logs": [self._memo_log(self.SOURCE_ADDR, self._bound_memo)],
+        }
+        intent = self._intent(receipt)
+        with pytest.raises(VerificationError, match="Hash credential source is invalid"):
+            await self._verify(intent, source=self._did(1, self.SOURCE_ADDR))
+
+    @pytest.mark.asyncio
+    async def test_hash_malformed_source_does_not_consume_hash(self) -> None:
+        from mpp.store import MemoryStore
+
+        store = MemoryStore()
+        receipt = {
+            "status": "0x1",
+            "from": self.SOURCE_ADDR,
+            "logs": [self._memo_log(self.SOURCE_ADDR, self._bound_memo)],
+        }
+        intent = self._intent(receipt, store=store)
+
+        # Malformed source is rejected before the hash is reserved.
+        with pytest.raises(VerificationError, match="Hash credential source is invalid"):
+            await self._verify(intent, source="not-a-valid-did")
+        assert await store.get("mpp:charge:0xabc123") is None
+
+        # A valid retry then succeeds.
+        result = await self._verify(intent, source=self._did(self.CHAIN_ID, self.SOURCE_ADDR))
+        assert result.reference == "0xabc123"
+
+    def test_public_types_are_exported(self) -> None:
+        from mpp.methods.tempo import SenderValidation, ValidateSender  # noqa: F401
+
+        validation = SenderValidation(
+            expected_sender=self.SOURCE_ADDR, sender=self.RELAYER, source=None
+        )
+        assert validation.expected_sender == self.SOURCE_ADDR
+
+    @pytest.mark.asyncio
+    async def test_broadcast_path_does_not_use_validate_sender(self) -> None:
+        # The validate_sender callback applies to hash credentials only; on the
+        # broadcast path a sender mismatch is rejected without consulting it.
+        future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
+        receipt = {
+            "transactionHash": "0xtxhash123",
+            "status": "0x1",
+            "from": self.SOURCE_ADDR,
+            "logs": [self._memo_log(self.RELAYER, self._bound_memo)],
+        }
+        intent = self._intent(receipt, validate_sender=lambda v: True)
+        credential = make_credential(
+            payload={"type": "transaction", "signature": "0xabcdef1234567890"},
+            challenge_id="challenge-123",
+            realm="api.example.com",
+            expires=future,
+        )
+        with pytest.raises(VerificationError, match="must contain a Transfer log"):
+            await intent.verify(
+                credential,
+                {"amount": "1000", "currency": self.CURRENCY, "recipient": self.RECIPIENT},
+            )

--- a/tests/test_tempo.py
+++ b/tests/test_tempo.py
@@ -3931,9 +3931,13 @@ class TestHashCredentialSourceValidation:
         assert validation.expected_sender == self.SOURCE_ADDR
 
     @pytest.mark.asyncio
-    async def test_broadcast_path_does_not_use_validate_sender(self) -> None:
-        # The validate_sender callback applies to hash credentials only; on the
-        # broadcast path a sender mismatch is rejected without consulting it.
+    async def test_broadcast_path_does_not_bind_sender(self) -> None:
+        # No source is threaded through the broadcast path, so a transfer whose
+        # `from` differs from the receipt sender still passes and the
+        # validate_sender callback is never consulted.
+        def boom(v) -> bool:
+            raise AssertionError("validate_sender must not be called on the broadcast path")
+
         future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
         receipt = {
             "transactionHash": "0xtxhash123",
@@ -3941,15 +3945,31 @@ class TestHashCredentialSourceValidation:
             "from": self.SOURCE_ADDR,
             "logs": [self._memo_log(self.RELAYER, self._bound_memo)],
         }
-        intent = self._intent(receipt, validate_sender=lambda v: True)
+        intent = self._intent(receipt, validate_sender=boom)
         credential = make_credential(
             payload={"type": "transaction", "signature": "0xabcdef1234567890"},
             challenge_id="challenge-123",
             realm="api.example.com",
             expires=future,
         )
-        with pytest.raises(VerificationError, match="must contain a Transfer log"):
-            await intent.verify(
-                credential,
-                {"amount": "1000", "currency": self.CURRENCY, "recipient": self.RECIPIENT},
-            )
+        result = await intent.verify(
+            credential,
+            {"amount": "1000", "currency": self.CURRENCY, "recipient": self.RECIPIENT},
+        )
+        assert result.reference == "0xtxhash123"
+
+    @pytest.mark.asyncio
+    async def test_hash_without_source_does_not_bind_sender(self) -> None:
+        # Hash credential with no source: the transfer sender differs from the
+        # receipt sender but there is nothing to bind against, so it passes.
+        def boom(v) -> bool:
+            raise AssertionError("validate_sender must not be called without a source")
+
+        receipt = {
+            "status": "0x1",
+            "from": self.SOURCE_ADDR,
+            "logs": [self._memo_log(self.RELAYER, self._bound_memo)],
+        }
+        intent = self._intent(receipt, validate_sender=boom)
+        result = await self._verify(intent, source=None)
+        assert result.reference == "0xabc123"


### PR DESCRIPTION
Adds server-side validation of the credential `source` on the Tempo hash-credential verification path. The verifier now parses the `did:pkh:eip155` source before reserving the transaction hash, requires TIP-20 transfers to originate from the declared source address (falling back to the receipt sender when no source is provided), and rejects malformed or chain-mismatched sources with a uniform error.

Adds new public API (`validate_sender` on `ChargeIntent`, plus `SenderValidation` and `ValidateSender`) to authorize smart-account / relayer flows where the on-chain transfer sender differs from the declared source, matching the minor changelog bump.

Part of OSS-323