### PR TITLE
feat: simulate sponsored txs before broadcast

### DIFF
--- a/.changelog/sponsor-pre-broadcast-simulation.md
+++ b/.changelog/sponsor-pre-broadcast-simulation.md
@@ -1,0 +1,5 @@
+---
+pympp: minor
+---
+
+Sponsored (fee-payer) charges now dry-run the co-signed transaction via `tempo_simulateV1` before broadcasting. If the transaction would revert on-chain, the sponsor rejects it instead of paying gas for a failing transaction. The check fails closed: if the simulation RPC is unavailable, the charge is rejected.

--- a/src/mpp/methods/tempo/intents.py
+++ b/src/mpp/methods/tempo/intents.py
@@ -820,17 +820,13 @@ class ChargeIntent:
 
         rpc_url = self._get_rpc_url()
 
-        # We pay the gas, so simulate the co-signed tx first and bail if it
-        # would revert. Fails closed: no simulation, no broadcast.
-        if simulate_payload is not None:
-            await self._simulate_before_broadcast(client, simulate_payload, rpc_url)
-
         reserved_tx_hash: str | None = None
         store_key: str | None = None
         if self._store is not None:
             reserved_tx_hash = _raw_transaction_hash(raw_tx)
             store_key = f"mpp:charge:{reserved_tx_hash.lower()}"
             if not await self._store.put_if_absent(store_key, reserved_tx_hash):
+                # Already reserved: return the existing receipt without re-broadcasting.
                 receipt_data = await self._fetch_transaction_receipt(client, reserved_tx_hash)
                 self._verify_receipt_transfers(
                     receipt_data,
@@ -841,6 +837,11 @@ class ChargeIntent:
                 return Receipt.success(reserved_tx_hash)
 
         try:
+            # We pay the gas, so simulate the co-signed tx and bail if it would
+            # revert. Fails closed: any error releases the reservation below.
+            if simulate_payload is not None:
+                await self._simulate_before_broadcast(client, simulate_payload, rpc_url)
+
             response = await client.post(
                 rpc_url,
                 json={

--- a/src/mpp/methods/tempo/intents.py
+++ b/src/mpp/methods/tempo/intents.py
@@ -781,9 +781,14 @@ class ChargeIntent:
 
         raw_tx = payload.signature
 
+        # Simulation payload for the locally co-signed tx, if we sponsor it.
+        simulate_payload: dict[str, Any] | None = None
+
         if request.methodDetails.feePayer:
             if self.fee_payer is not None:
-                raw_tx = self._cosign_as_fee_payer(raw_tx, request.currency, request=request)
+                raw_tx, simulate_payload = self._cosign_as_fee_payer(
+                    raw_tx, request.currency, request=request
+                )
             else:
                 fee_payer_url = request.methodDetails.feePayerUrl
                 if not fee_payer_url:
@@ -814,6 +819,12 @@ class ChargeIntent:
                     raise VerificationError("Fee payer returned no signed transaction")
 
         rpc_url = self._get_rpc_url()
+
+        # We pay the gas, so simulate the co-signed tx first and bail if it
+        # would revert. Fails closed: no simulation, no broadcast.
+        if simulate_payload is not None:
+            await self._simulate_before_broadcast(client, simulate_payload, rpc_url)
+
         reserved_tx_hash: str | None = None
         store_key: str | None = None
         if self._store is not None:
@@ -888,12 +899,13 @@ class ChargeIntent:
 
     def _cosign_as_fee_payer(
         self, raw_tx: str, fee_token: str | None = None, request: ChargeRequest | None = None
-    ) -> str:
+    ) -> tuple[str, dict[str, Any]]:
         """Co-sign a client-signed transaction as fee payer.
 
         Deserializes the client's 0x78 fee payer envelope, optionally validates
         the payment calls against ``request``, sets the fee token, and co-signs.
-        Returns the fully co-signed 0x76 transaction hex.
+        Returns ``(raw_0x76_hex, simulate_payload)`` where ``simulate_payload``
+        is the ``tempo_simulateV1`` request for the co-signed tx.
         """
         from pytempo import Call, TempoTransaction
         from pytempo.models import Signature, as_address
@@ -1004,7 +1016,99 @@ class ChargeIntent:
         except Exception as err:
             raise VerificationError("Fee payer signing failed") from err
 
-        return "0x" + cosigned.encode().hex()
+        raw_cosigned = "0x" + cosigned.encode().hex()
+        return raw_cosigned, self._build_simulate_payload(cosigned, recovered_address)
+
+    def _build_simulate_payload(self, tx: Any, sender: str) -> dict[str, Any]:
+        """Build a ``tempo_simulateV1`` payload for the co-signed 0x76 tx.
+
+        Carries the recovered sender as ``from`` (the node needs it to model the
+        sender) plus the sponsor fields (``feeToken``, ``feePayerSignature``) so
+        the node simulates the same tx we are about to broadcast.
+        """
+        sig = tx.fee_payer_signature
+        parity = sig.v if sig.v in (0, 1) else sig.v - 27
+        tx_request: dict[str, Any] = {
+            "from": sender,
+            "type": "0x76",
+            "chainId": hex(tx.chain_id),
+            "nonce": hex(tx.nonce),
+            "nonceKey": hex(tx.nonce_key),
+            "gas": hex(tx.gas_limit),
+            "maxFeePerGas": hex(tx.max_fee_per_gas),
+            "maxPriorityFeePerGas": hex(tx.max_priority_fee_per_gas),
+            "feeToken": "0x" + bytes(tx.fee_token).hex(),
+            "feePayerSignature": {
+                # Fixed 32-byte r/s so leading zeros are not dropped.
+                "r": f"0x{sig.r:064x}",
+                "s": f"0x{sig.s:064x}",
+                "yParity": hex(parity),
+            },
+            "calls": [
+                {
+                    "to": "0x" + bytes(c.to).hex(),
+                    "value": hex(c.value),
+                    "input": "0x" + c.data.hex(),
+                }
+                for c in tx.calls
+            ],
+        }
+        if tx.valid_before is not None:
+            tx_request["validBefore"] = hex(tx.valid_before)
+        if tx.valid_after is not None:
+            tx_request["validAfter"] = hex(tx.valid_after)
+
+        return {
+            "blockStateCalls": [{"calls": [tx_request]}],
+            # We only care about execution outcome, not mempool admission.
+            "validation": False,
+            "traceTransfers": False,
+            "returnFullTransactions": False,
+        }
+
+    async def _simulate_before_broadcast(
+        self, client: Any, simulate_payload: dict[str, Any], rpc_url: str
+    ) -> None:
+        """Simulate the co-signed tx and raise if it would revert.
+
+        Fails closed: any RPC/transport error is treated as a failed check.
+        """
+        try:
+            response = await client.post(
+                rpc_url,
+                json={
+                    "jsonrpc": "2.0",
+                    "method": "tempo_simulateV1",
+                    "params": [simulate_payload],
+                    "id": 1,
+                },
+            )
+            response.raise_for_status()
+            result = response.json()
+        except Exception as err:
+            raise VerificationError("Pre-broadcast simulation failed") from err
+
+        if "error" in result:
+            raise VerificationError(f"Pre-broadcast simulation failed: {_rpc_error_msg(result)}")
+
+        rpc_result = result.get("result")
+        blocks = rpc_result.get("blocks") if isinstance(rpc_result, dict) else None
+        block0 = blocks[0] if isinstance(blocks, list) and blocks else None
+        calls = block0.get("calls") if isinstance(block0, dict) else None
+        call = None
+        if isinstance(calls, list) and calls and isinstance(calls[0], dict):
+            call = calls[0]
+        if call is None:
+            raise VerificationError("Pre-broadcast simulation returned no call results")
+
+        status = call.get("status")
+        if status in ("0x1", 1, True):
+            return
+
+        detail = (call.get("error") or {}).get("message") or "no revert reason returned"
+        raise VerificationError(
+            f"Sponsored transaction would revert in pre-broadcast simulation: {detail}"
+        )
 
     def _validate_calls(self, calls: tuple, request: ChargeRequest) -> None:
         """Validate that calls match all expected transfers."""

--- a/src/mpp/methods/tempo/intents.py
+++ b/src/mpp/methods/tempo/intents.py
@@ -1028,6 +1028,14 @@ class ChargeIntent:
         """
         sig = tx.fee_payer_signature
         parity = sig.v if sig.v in (0, 1) else sig.v - 27
+
+        # The node rebuilds the batch as ``calls[]`` followed by the top-level
+        # call appended last; an absent top-level ``to`` is read as a CREATE and
+        # rejected. So we put the final call top-level and the rest in ``calls``
+        # to preserve order.
+        last_call = tx.calls[-1]
+        leading_calls = tx.calls[:-1]
+
         tx_request: dict[str, Any] = {
             "from": sender,
             "type": "0x76",
@@ -1044,15 +1052,20 @@ class ChargeIntent:
                 "s": f"0x{sig.s:064x}",
                 "yParity": hex(parity),
             },
-            "calls": [
+            # Top-level payment call so the node does not read this as a CREATE.
+            "to": "0x" + bytes(last_call.to).hex(),
+            "value": hex(last_call.value),
+            "data": "0x" + last_call.data.hex(),
+        }
+        if leading_calls:
+            tx_request["calls"] = [
                 {
                     "to": "0x" + bytes(c.to).hex(),
                     "value": hex(c.value),
-                    "input": "0x" + c.data.hex(),
+                    "data": "0x" + c.data.hex(),
                 }
-                for c in tx.calls
-            ],
-        }
+                for c in leading_calls
+            ]
         if tx.valid_before is not None:
             tx_request["validBefore"] = hex(tx.valid_before)
         if tx.valid_after is not None:
@@ -1079,7 +1092,7 @@ class ChargeIntent:
                 json={
                     "jsonrpc": "2.0",
                     "method": "tempo_simulateV1",
-                    "params": [simulate_payload],
+                    "params": [simulate_payload, "latest"],
                     "id": 1,
                 },
             )

--- a/tests/test_fee_payer_envelope.py
+++ b/tests/test_fee_payer_envelope.py
@@ -205,7 +205,7 @@ class TestEncoderDecoderIntegration:
         intent = ChargeIntent(rpc_url="https://rpc.test")
         tempo(fee_payer=fee_payer, rpc_url="https://rpc.test", intents={"charge": intent})
 
-        result = intent._cosign_as_fee_payer(envelope_hex, CURRENCY)
+        result, _ = intent._cosign_as_fee_payer(envelope_hex, CURRENCY)
         assert result.startswith("0x76")
 
         # The co-signed tx should be valid RLP with 0x76 prefix

--- a/tests/test_tempo.py
+++ b/tests/test_tempo.py
@@ -1,5 +1,6 @@
 """Tests for Tempo payment method."""
 
+import json
 import os
 import re
 from datetime import UTC, datetime, timedelta
@@ -2222,6 +2223,56 @@ class TestCosignAsFeePayer:
 
         with pytest.raises(VerificationError, match="Pre-broadcast simulation failed"):
             await intent._simulate_before_broadcast(mock_client, payload, "https://rpc.test")
+
+    # End-to-end: a reverting simulation for a locally co-signed sponsored charge
+    # must abort `verify` before the tx is broadcast, so the sponsor never pays
+    # gas. We register only the simulate response; if the code wrongly attempted
+    # eth_sendRawTransactionSync, no response would match and the test would fail.
+    @pytest.mark.asyncio
+    async def test_verify_local_fee_payer_revert_does_not_broadcast(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
+        currency = "0x20c0000000000000000000000000000000000000"
+        recipient = "0x742d35Cc6634c0532925a3b844bC9e7595F8fE00"
+
+        intent = self._make_intent()
+        raw_tx = self._build_client_tx(currency=currency, recipient=recipient, amount=1000000)
+        credential = make_credential(
+            payload={"type": "transaction", "signature": raw_tx},
+            expires=future,
+        )
+
+        # tempo_simulateV1 reports the co-signed tx would revert.
+        httpx_mock.add_response(
+            url="https://rpc.test",
+            json={
+                "jsonrpc": "2.0",
+                "result": {
+                    "blocks": [
+                        {"calls": [{"status": "0x0", "error": {"message": "execution reverted"}}]}
+                    ]
+                },
+                "id": 1,
+            },
+        )
+
+        with pytest.raises(VerificationError, match="would revert"):
+            await intent.verify(
+                credential,
+                {
+                    "amount": "1000000",
+                    "currency": currency,
+                    "recipient": recipient,
+                    "methodDetails": {"feePayer": True},
+                },
+            )
+
+        # Exactly one RPC call (the simulation); no broadcast was attempted.
+        requests = httpx_mock.get_requests()
+        methods = [json.loads(r.read().decode())["method"] for r in requests]
+        assert methods == ["tempo_simulateV1"]
+        assert "eth_sendRawTransactionSync" not in methods
 
 
 class TestValidateTransactionPayload:

--- a/tests/test_tempo.py
+++ b/tests/test_tempo.py
@@ -2117,8 +2117,52 @@ class TestCosignAsFeePayer:
         assert sig["yParity"] in ("0x0", "0x1")
         assert tx_request["nonceKey"].startswith("0x")
         assert tx_request["validBefore"].startswith("0x")
-        assert len(tx_request["calls"]) == 1
-        assert tx_request["calls"][0]["to"].lower() == currency.lower()
+        # Top-level payment call (with `data`, not `input`) so it isn't a CREATE.
+        assert tx_request["to"].lower() == currency.lower()
+        assert tx_request["data"].startswith("0x")
+        assert tx_request["value"].startswith("0x")
+        # A single-call charge needs no nested batch.
+        assert "calls" not in tx_request
+
+    # The node appends the top-level call after `calls[]`, so the final call
+    # goes top-level and the leading calls in `calls`, preserving order.
+    def test_build_simulate_payload_multi_call_preserves_order(self) -> None:
+        from types import SimpleNamespace
+
+        intent = self._make_intent()
+
+        def _call(byte: int) -> SimpleNamespace:
+            return SimpleNamespace(
+                to=bytes([byte]) * 20,
+                value=0,
+                data=bytes([byte]) * 4,
+            )
+
+        calls = (_call(0xA1), _call(0xB2), _call(0xC3))
+        tx = SimpleNamespace(
+            fee_payer_signature=SimpleNamespace(r=1, s=2, v=27),
+            chain_id=42431,
+            nonce=0,
+            nonce_key=(1 << 256) - 1,
+            gas_limit=100000,
+            max_fee_per_gas=1,
+            max_priority_fee_per_gas=1,
+            fee_token=bytes(20),
+            calls=calls,
+            valid_before=None,
+            valid_after=None,
+        )
+
+        payload = intent._build_simulate_payload(tx, "0x" + "11" * 20)
+        tx_request = payload["blockStateCalls"][0]["calls"][0]
+
+        assert tx_request["to"] == "0x" + "c3" * 20
+        assert tx_request["data"] == "0x" + "c3" * 4
+        assert [c["to"] for c in tx_request["calls"]] == [
+            "0x" + "a1" * 20,
+            "0x" + "b2" * 20,
+        ]
+        assert all("data" in c and "input" not in c for c in tx_request["calls"])
 
     def _cosign_payload(self, intent: ChargeIntent) -> dict:
         currency = "0x20c0000000000000000000000000000000000000"
@@ -2146,7 +2190,9 @@ class TestCosignAsFeePayer:
 
         with pytest.raises(VerificationError, match="would revert"):
             await intent._simulate_before_broadcast(mock_client, payload, "https://rpc.test")
-        assert mock_client.post.await_args.kwargs["json"]["method"] == "tempo_simulateV1"
+        sent = mock_client.post.await_args.kwargs["json"]
+        assert sent["method"] == "tempo_simulateV1"
+        assert sent["params"][1] == "latest"
 
     # A successful simulation must let the broadcast proceed.
     @pytest.mark.asyncio

--- a/tests/test_tempo.py
+++ b/tests/test_tempo.py
@@ -2274,6 +2274,126 @@ class TestCosignAsFeePayer:
         assert methods == ["tempo_simulateV1"]
         assert "eth_sendRawTransactionSync" not in methods
 
+    # An already-reserved charge fetches the existing receipt without simulating.
+    @pytest.mark.asyncio
+    async def test_verify_duplicate_skips_simulation_and_fetches_receipt(self) -> None:
+        from mpp.store import MemoryStore
+
+        future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
+        currency = "0x20c0000000000000000000000000000000000000"
+        recipient = "0x742d35Cc6634c0532925a3b844bC9e7595F8fE00"
+        challenge_id = "challenge-dup"
+        realm = "api.example.com"
+        memo = encode_attribution(challenge_id=challenge_id, server_id=realm)
+
+        intent = self._make_intent()
+        store = MemoryStore()
+        intent._store = store
+
+        # Reserve the co-signed tx hash that verify() will compute.
+        raw_tx = self._build_client_tx(currency=currency, recipient=recipient, amount=1000000)
+        cosigned_raw, _ = intent._cosign_as_fee_payer(raw_tx, currency)
+        tx_hash = _raw_transaction_hash(cosigned_raw)
+        await store.put_if_absent(f"mpp:charge:{tx_hash.lower()}", tx_hash)
+
+        receipt_with_logs = {
+            "transactionHash": tx_hash,
+            "status": "0x1",
+            "logs": [
+                {
+                    "address": currency,
+                    "topics": [
+                        TRANSFER_WITH_MEMO_TOPIC,
+                        "0x" + "0" * 24 + "abcd" * 10,
+                        "0x" + "0" * 24 + recipient[2:],
+                        memo,
+                    ],
+                    "data": amount_data(1000000),
+                }
+            ],
+        }
+
+        def _post(*_args: object, **kwargs: object) -> httpx.Response:
+            method = cast(dict, kwargs["json"])["method"]
+            if method == "tempo_simulateV1":
+                return mock_response(200, {"jsonrpc": "2.0", "error": {"message": "node busy"}})
+            if method == "eth_getTransactionReceipt":
+                return mock_response(200, {"jsonrpc": "2.0", "result": receipt_with_logs, "id": 1})
+            raise AssertionError(f"unexpected RPC method: {method}")
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(side_effect=_post)
+        intent._http_client = mock_client
+
+        credential = make_credential(
+            payload={"type": "transaction", "signature": raw_tx},
+            challenge_id=challenge_id,
+            expires=future,
+            realm=realm,
+        )
+
+        receipt = await intent.verify(
+            credential,
+            {
+                "amount": "1000000",
+                "currency": currency,
+                "recipient": recipient,
+                "methodDetails": {"feePayer": True},
+            },
+        )
+
+        assert receipt.status == "success"
+        assert receipt.reference == tx_hash
+        methods = [call.kwargs["json"]["method"] for call in mock_client.post.await_args_list]
+        assert methods == ["eth_getTransactionReceipt"]
+        assert "tempo_simulateV1" not in methods
+
+    # A simulation failure releases the reservation and does not broadcast.
+    @pytest.mark.asyncio
+    async def test_verify_simulation_failure_releases_reservation(self) -> None:
+        from mpp.store import MemoryStore
+
+        future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
+        currency = "0x20c0000000000000000000000000000000000000"
+        recipient = "0x742d35Cc6634c0532925a3b844bC9e7595F8fE00"
+
+        intent = self._make_intent()
+        store = MemoryStore()
+        intent._store = store
+
+        raw_tx = self._build_client_tx(currency=currency, recipient=recipient, amount=1000000)
+        cosigned_raw, _ = intent._cosign_as_fee_payer(raw_tx, currency)
+        tx_hash = _raw_transaction_hash(cosigned_raw)
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(
+            return_value=mock_response(
+                200, {"jsonrpc": "2.0", "error": {"message": "node busy"}, "id": 1}
+            )
+        )
+        intent._http_client = mock_client
+
+        credential = make_credential(
+            payload={"type": "transaction", "signature": raw_tx},
+            expires=future,
+        )
+
+        with pytest.raises(VerificationError, match="Pre-broadcast simulation failed"):
+            await intent.verify(
+                credential,
+                {
+                    "amount": "1000000",
+                    "currency": currency,
+                    "recipient": recipient,
+                    "methodDetails": {"feePayer": True},
+                },
+            )
+
+        assert await store.get(f"mpp:charge:{tx_hash.lower()}") is None
+        methods = [call.kwargs["json"]["method"] for call in mock_client.post.await_args_list]
+        assert methods == ["tempo_simulateV1"]
+        assert "eth_sendRawTransactionSync" not in methods
+
 
 class TestValidateTransactionPayload:
     """Tests for _validate_transaction_payload with both 0x76 and 0x78."""

--- a/tests/test_tempo.py
+++ b/tests/test_tempo.py
@@ -1,6 +1,7 @@
 """Tests for Tempo payment method."""
 
 import os
+import re
 from datetime import UTC, datetime, timedelta
 from typing import cast
 from unittest.mock import AsyncMock, patch
@@ -1773,7 +1774,9 @@ class TestCosignAsFeePayer:
         intent = self._make_intent()
 
         raw_tx = self._build_client_tx()
-        result = intent._cosign_as_fee_payer(raw_tx, "0x20c0000000000000000000000000000000000000")
+        result, _ = intent._cosign_as_fee_payer(
+            raw_tx, "0x20c0000000000000000000000000000000000000"
+        )
 
         assert result.startswith("0x76")
         assert len(result) > len(raw_tx)
@@ -1863,7 +1866,7 @@ class TestCosignAsFeePayer:
             recipient="0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
         )
 
-        result = intent._cosign_as_fee_payer(raw_tx, request.currency, request=request)
+        result, _ = intent._cosign_as_fee_payer(raw_tx, request.currency, request=request)
         assert result.startswith("0x76")
 
     def test_cosign_rejects_extra_trailing_call(self) -> None:
@@ -2088,8 +2091,91 @@ class TestCosignAsFeePayer:
             recipient="0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
         )
 
-        result = intent._cosign_as_fee_payer(raw_tx, request.currency, request=request)
+        result, _ = intent._cosign_as_fee_payer(raw_tx, request.currency, request=request)
         assert result.startswith("0x76")
+
+    # The simulate payload must target the co-signed tx: the recovered sender as
+    # `from`, the sponsor fields the node needs (feeToken, feePayerSignature), the
+    # payment calls, the expiring nonceKey, the validity window, and validation off.
+    def test_cosign_returns_simulate_payload_with_sponsor_abi(self) -> None:
+        intent = self._make_intent()
+        currency = "0x20c0000000000000000000000000000000000000"
+
+        raw_tx = self._build_client_tx(currency=currency)
+        _result, payload = intent._cosign_as_fee_payer(raw_tx, currency)
+        tx_request = payload["blockStateCalls"][0]["calls"][0]
+
+        sender = TempoAccount.from_key(TEST_PRIVATE_KEY).address
+        assert payload["validation"] is False
+        assert tx_request["type"] == "0x76"
+        assert tx_request["from"].lower() == sender.lower()
+        assert tx_request["feeToken"].lower() == currency.lower()
+        sig = tx_request["feePayerSignature"]
+        assert set(sig) == {"r", "s", "yParity"}
+        assert re.fullmatch(r"0x[0-9a-f]{64}", sig["r"])
+        assert re.fullmatch(r"0x[0-9a-f]{64}", sig["s"])
+        assert sig["yParity"] in ("0x0", "0x1")
+        assert tx_request["nonceKey"].startswith("0x")
+        assert tx_request["validBefore"].startswith("0x")
+        assert len(tx_request["calls"]) == 1
+        assert tx_request["calls"][0]["to"].lower() == currency.lower()
+
+    def _cosign_payload(self, intent: ChargeIntent) -> dict:
+        currency = "0x20c0000000000000000000000000000000000000"
+        raw_tx = self._build_client_tx(currency=currency)
+        _result, payload = intent._cosign_as_fee_payer(raw_tx, currency)
+        return payload
+
+    # A reverting simulation must block the broadcast so the sponsor never pays
+    # gas for a failing transaction.
+    @pytest.mark.asyncio
+    async def test_simulate_before_broadcast_rejects_revert(self) -> None:
+        intent = self._make_intent()
+        payload = self._cosign_payload(intent)
+        revert = {
+            "jsonrpc": "2.0",
+            "result": {
+                "blocks": [
+                    {"calls": [{"status": "0x0", "error": {"message": "execution reverted"}}]}
+                ]
+            },
+            "id": 1,
+        }
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response(200, revert))
+
+        with pytest.raises(VerificationError, match="would revert"):
+            await intent._simulate_before_broadcast(mock_client, payload, "https://rpc.test")
+        assert mock_client.post.await_args.kwargs["json"]["method"] == "tempo_simulateV1"
+
+    # A successful simulation must let the broadcast proceed.
+    @pytest.mark.asyncio
+    async def test_simulate_before_broadcast_accepts_success(self) -> None:
+        intent = self._make_intent()
+        payload = self._cosign_payload(intent)
+        success = {
+            "jsonrpc": "2.0",
+            "result": {"blocks": [{"calls": [{"status": "0x1"}]}]},
+            "id": 1,
+        }
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response(200, success))
+
+        assert (
+            await intent._simulate_before_broadcast(mock_client, payload, "https://rpc.test")
+            is None
+        )
+
+    # If the simulation RPC itself errors, fail closed.
+    @pytest.mark.asyncio
+    async def test_simulate_before_broadcast_fails_closed_on_rpc_error(self) -> None:
+        intent = self._make_intent()
+        payload = self._cosign_payload(intent)
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(side_effect=RuntimeError("node unavailable"))
+
+        with pytest.raises(VerificationError, match="Pre-broadcast simulation failed"):
+            await intent._simulate_before_broadcast(mock_client, payload, "https://rpc.test")
 
 
 class TestValidateTransactionPayload:

--- a/tests/test_tempo_integration.py
+++ b/tests/test_tempo_integration.py
@@ -364,6 +364,18 @@ class TestChargeIntegration:
             expires=expires,
         )
 
+        # Spy on the simulate payload to catch request-shape regressions that
+        # mocked-RPC unit tests cannot.
+        captured: list[dict] = []
+        original_build = intent._build_simulate_payload
+
+        def _spy(tx, sender):
+            payload = original_build(tx, sender)
+            captured.append(payload)
+            return payload
+
+        intent._build_simulate_payload = _spy  # type: ignore[method-assign]
+
         credential = await client_method.create_credential(challenge)
         receipt = await intent.verify(credential, request_dict)
 
@@ -371,6 +383,13 @@ class TestChargeIntegration:
         assert receipt.method == "tempo"
         assert receipt.reference.startswith("0x")
         assert len(receipt.reference) >= 66
+
+        # Simulation must carry a top-level `to` (not a CREATE) or the node rejects it.
+        assert captured, "pre-broadcast simulation payload was never built"
+        tx_request = captured[0]["blockStateCalls"][0]["calls"][0]
+        assert tx_request.get("to"), "simulate payload missing top-level `to` (CREATE)"
+        assert tx_request["to"].lower() == currency.lower()
+        assert tx_request["data"].startswith("0x")
 
     async def test_verify_with_server_memo(
         self, rpc_url, funded_payer, funded_recipient, currency, charge_intent, chain_id


### PR DESCRIPTION
Adds pre-broadcast simulation for locally co-signed sponsored Tempo charges. Before broadcasting, the server simulates the co-signed tx via `tempo_simulateV1` and refuses to broadcast (fail-closed, including on RPC error) if it would revert, so the sponsor never pays gas for a failing transaction. 

Part of OSS-314