### PR TITLE
feat: add server body digest and route scope conformance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dev = [
     "pytest-asyncio>=0.24",
     "hypothesis>=6.0",
     "ruff>=0.4",
+    "starlette>=0.37",
 ]
 
 [dependency-groups]
@@ -61,6 +62,7 @@ dev = [
     "twine>=6.0",
     "aiosqlite>=0.20",
     "redis>=5.0",
+    "starlette>=0.37",
 ]
 
 [build-system]

--- a/src/mpp/server/decorator.py
+++ b/src/mpp/server/decorator.py
@@ -20,6 +20,8 @@ if TYPE_CHECKING:
 R = TypeVar("R")
 
 RequestParamsType = dict[str, Any] | Callable[[Any], dict[str, Any]]
+BodyType = str | bytes | dict[str, Any]
+BodyParamsType = BodyType | Callable[[Any], BodyType | Awaitable[BodyType]] | None
 
 
 def get_authorization(request: Any) -> str | None:
@@ -64,6 +66,18 @@ def make_challenge_response(challenge: Challenge, realm: str) -> Any:
             "headers": headers,
             "body": body,
         }
+
+
+async def resolve_body_param(body: BodyParamsType, request_obj: Any) -> BodyType | None:
+    """Resolve a static or request-derived body value for digest verification."""
+    if body is None:
+        return None
+    if callable(body):
+        value = body(request_obj)
+        if inspect.isawaitable(value):
+            value = await value
+        return value
+    return body
 
 
 def wrap_payment_handler(
@@ -128,6 +142,7 @@ def pay(
     secret_key: str | None = None,
     method: str | None = None,
     description: str | None = None,
+    body: BodyParamsType = None,
     events: EventDispatcher | None = None,
 ) -> Callable[
     [Callable[[Any, Credential, Receipt], Awaitable[R]]],
@@ -187,6 +202,7 @@ def pay(
                 secret_key=resolved_secret_key,
                 method=method,
                 description=description,
+                body=await resolve_body_param(body, request_obj),
                 events=events,
             )
 

--- a/src/mpp/server/decorator.py
+++ b/src/mpp/server/decorator.py
@@ -47,6 +47,17 @@ def framework_scope(request: Any) -> dict[str, str]:
         route_path = getattr(route, "path", None)
         if isinstance(route_path, str) and route_path:
             scope["route"] = route_path
+        if "route" not in scope:
+            endpoint = raw_scope.get("endpoint")
+            router = raw_scope.get("router")
+            routes = getattr(router, "routes", None)
+            if isinstance(routes, list):
+                for candidate in routes:
+                    if getattr(candidate, "endpoint", None) is endpoint:
+                        matched_path = getattr(candidate, "path", None)
+                        if isinstance(matched_path, str) and matched_path:
+                            scope["route"] = matched_path
+                        break
         path = raw_scope.get("path")
         if isinstance(path, str) and path:
             scope["resource"] = path

--- a/src/mpp/server/decorator.py
+++ b/src/mpp/server/decorator.py
@@ -169,6 +169,9 @@ def pay(
             Required unless `MPP_SECRET_KEY` is set.
         method: The payment method name (defaults to "tempo").
         description: Human-readable description of what the payment is for.
+        body: Optional static body bytes/string/dict or callback receiving the
+            request object. The resolved value is bound into issued challenges
+            via digest and used to verify paid retries.
 
     Example:
         @app.get("/resource")

--- a/src/mpp/server/decorator.py
+++ b/src/mpp/server/decorator.py
@@ -37,6 +37,77 @@ def get_authorization(request: Any) -> str | None:
     return None
 
 
+def framework_scope(request: Any) -> dict[str, str]:
+    """Extract route/resource/query scope from common framework request objects."""
+    scope: dict[str, str] = {}
+
+    raw_scope = getattr(request, "scope", None)
+    if isinstance(raw_scope, dict):
+        route = raw_scope.get("route")
+        route_path = getattr(route, "path", None)
+        if isinstance(route_path, str) and route_path:
+            scope["route"] = route_path
+        path = raw_scope.get("path")
+        if isinstance(path, str) and path:
+            scope["resource"] = path
+        query_string = raw_scope.get("query_string")
+        if isinstance(query_string, bytes):
+            query_string = query_string.decode()
+        if isinstance(query_string, str) and query_string:
+            scope["query"] = query_string
+
+    resolver_match = getattr(request, "resolver_match", None)
+    route = getattr(resolver_match, "route", None)
+    if isinstance(route, str) and route:
+        scope.setdefault("route", route)
+
+    url_rule = getattr(request, "url_rule", None)
+    rule = getattr(url_rule, "rule", None)
+    if isinstance(rule, str) and rule:
+        scope.setdefault("route", rule)
+
+    for attr in ("route", "path_template"):
+        value = getattr(request, attr, None)
+        if isinstance(value, str) and value:
+            scope.setdefault("route", value)
+
+    path = getattr(request, "path", None)
+    if isinstance(path, str) and path:
+        scope.setdefault("resource", path)
+
+    url = getattr(request, "url", None)
+    url_path = getattr(url, "path", None)
+    if isinstance(url_path, str) and url_path:
+        scope.setdefault("resource", url_path)
+    url_query = getattr(url, "query", None)
+    if isinstance(url_query, str) and url_query:
+        scope.setdefault("query", url_query)
+
+    query_string = getattr(request, "query_string", None)
+    if isinstance(query_string, bytes):
+        query_string = query_string.decode()
+    if isinstance(query_string, str) and query_string:
+        scope.setdefault("query", query_string)
+
+    meta = getattr(request, "META", None)
+    if isinstance(meta, dict):
+        query = meta.get("QUERY_STRING")
+        if isinstance(query, str) and query:
+            scope.setdefault("query", query)
+
+    return scope
+
+
+def bind_framework_scope(request_params: dict[str, Any], request_obj: Any) -> dict[str, Any]:
+    """Return request params with automatic framework scope when available."""
+    if "_mppx_scope" in request_params:
+        return request_params
+    scope = framework_scope(request_obj)
+    if not scope:
+        return request_params
+    return {**request_params, "_mppx_scope": scope}
+
+
 def make_challenge_response(challenge: Challenge, realm: str) -> Any:
     """Build a 402 response for a payment challenge with RFC 9457 problem details body.
 
@@ -196,6 +267,7 @@ def pay(
                 request_params = request(request_obj)
             else:
                 request_params = request
+            request_params = bind_framework_scope(request_params, request_obj)
 
             return await verify_or_challenge(
                 authorization=authorization,

--- a/src/mpp/server/decorator.py
+++ b/src/mpp/server/decorator.py
@@ -63,7 +63,7 @@ def framework_scope(request: Any) -> dict[str, str]:
             scope["resource"] = path
         query_string = raw_scope.get("query_string")
         if isinstance(query_string, bytes):
-            query_string = query_string.decode()
+            query_string = query_string.decode("latin-1")
         if isinstance(query_string, str) and query_string:
             scope["query"] = query_string
 
@@ -96,7 +96,7 @@ def framework_scope(request: Any) -> dict[str, str]:
 
     query_string = getattr(request, "query_string", None)
     if isinstance(query_string, bytes):
-        query_string = query_string.decode()
+        query_string = query_string.decode("latin-1")
     if isinstance(query_string, str) and query_string:
         scope.setdefault("query", query_string)
 

--- a/src/mpp/server/mpp.py
+++ b/src/mpp/server/mpp.py
@@ -17,7 +17,7 @@ from mpp.events import (
     Unsubscribe,
 )
 from mpp.server._defaults import detect_realm, detect_secret_key
-from mpp.server.decorator import wrap_payment_handler
+from mpp.server.decorator import BodyParamsType, resolve_body_param, wrap_payment_handler
 from mpp.server.method import transform_request
 from mpp.server.verify import verify_or_challenge
 from mpp.store import Store
@@ -153,6 +153,7 @@ class Mpp:
         fee_payer: bool = False,
         chain_id: int | None = None,
         extra: dict[str, str] | None = None,
+        body: str | bytes | dict[str, Any] | None = None,
     ) -> Challenge | tuple[Credential, Receipt]:
         """Handle a charge intent.
 
@@ -229,6 +230,7 @@ class Mpp:
             method=self.method.name,
             description=description,
             expires=expires,
+            body=body,
             events=self._events,
         )
 
@@ -243,6 +245,7 @@ class Mpp:
         expires_in: timedelta | None = None,
         chain_id: int | None = None,
         extra: dict[str, str] | None = None,
+        body: BodyParamsType = None,
     ) -> Callable[  # noqa: UP047
         [Callable[[Any, Credential, Receipt], Awaitable[R]]],
         Callable[[Any], Awaitable[R | Any]],
@@ -335,6 +338,7 @@ class Mpp:
                     method=self.method.name,
                     description=description,
                     expires=challenge_expires,
+                    body=await resolve_body_param(body, _request_obj),
                     events=self._events,
                 )
 

--- a/src/mpp/server/mpp.py
+++ b/src/mpp/server/mpp.py
@@ -17,7 +17,12 @@ from mpp.events import (
     Unsubscribe,
 )
 from mpp.server._defaults import detect_realm, detect_secret_key
-from mpp.server.decorator import BodyParamsType, resolve_body_param, wrap_payment_handler
+from mpp.server.decorator import (
+    BodyParamsType,
+    bind_framework_scope,
+    resolve_body_param,
+    wrap_payment_handler,
+)
 from mpp.server.method import transform_request
 from mpp.server.verify import verify_or_challenge
 from mpp.store import Store
@@ -337,6 +342,7 @@ class Mpp:
                     request,
                     None,
                 )
+                request = bind_framework_scope(request, _request_obj)
 
                 return await verify_or_challenge(
                     authorization=authorization,

--- a/src/mpp/server/mpp.py
+++ b/src/mpp/server/mpp.py
@@ -167,8 +167,13 @@ class Mpp:
                 Defaults to now + 5 minutes. Not included in the request body.
             description: Optional human-readable description.
             memo: Optional 32-byte memo (hex string) for transferWithMemo.
+            splits: Optional split recipients/amounts for multi-transfer charges.
             fee_payer: Whether to use a fee payer for gas sponsorship.
             chain_id: Override the default chain ID (e.g., 42431 for moderato).
+            extra: Optional string metadata embedded in the charge request.
+            body: Actual request body bytes, string, or JSON-like dict to bind
+                with a SHA-256 digest. If provided, new challenges include a
+                digest and submitted credentials must echo a matching digest.
 
         Returns:
             Challenge if payment required, or (Credential, Receipt) if verified.
@@ -266,6 +271,10 @@ class Mpp:
             description: Optional human-readable description.
             expires_in: Challenge validity duration. Defaults to 5 minutes.
             chain_id: Override the default chain ID (e.g., 42431 for moderato).
+            extra: Optional string metadata embedded in the charge request.
+            body: Optional static body bytes/string/dict or callback receiving
+                the request object. The resolved value is bound into issued
+                challenges via digest and used to verify paid retries.
 
         Example:
             server = Mpp.create(method=tempo(currency=..., recipient=...))

--- a/src/mpp/server/mpp.py
+++ b/src/mpp/server/mpp.py
@@ -158,6 +158,7 @@ class Mpp:
         fee_payer: bool = False,
         chain_id: int | None = None,
         extra: dict[str, str] | None = None,
+        mppx_scope: dict[str, str] | None = None,
         body: str | bytes | dict[str, Any] | None = None,
     ) -> Challenge | tuple[Credential, Receipt]:
         """Handle a charge intent.
@@ -176,6 +177,10 @@ class Mpp:
             fee_payer: Whether to use a fee payer for gas sponsorship.
             chain_id: Override the default chain ID (e.g., 42431 for moderato).
             extra: Optional string metadata embedded in the charge request.
+            mppx_scope: Optional route/resource/query scope to bind into the
+                challenge request. Framework handlers can pass
+                ``framework_scope(request)`` to prevent same-price credential
+                replay across different resources.
             body: Actual request body bytes, string, or JSON-like dict to bind
                 with a SHA-256 digest. If provided, new challenges include a
                 digest and submitted credentials must echo a matching digest.
@@ -230,6 +235,10 @@ class Mpp:
             request["methodDetails"] = method_details
 
         request = transform_request(self.method, request, None)
+        if mppx_scope is not None:
+            if any(not isinstance(k, str) or not isinstance(v, str) for k, v in mppx_scope.items()):
+                raise ValueError("mppx_scope must be a dict[str, str]")
+            request = {**request, "_mppx_scope": dict(mppx_scope)}
 
         return await verify_or_challenge(
             authorization=authorization,

--- a/src/mpp/server/verify.py
+++ b/src/mpp/server/verify.py
@@ -63,7 +63,13 @@ async def verify_or_challenge(
             Enables stateless challenge verification by computing challenge IDs
             as HMAC-SHA256 over the challenge parameters.
         method: The payment method name (defaults to "tempo").
+        description: Optional human-readable description for newly issued challenges.
+        meta: Optional opaque challenge metadata.
         expires: Challenge expiration (ISO 8601). Defaults to now + 5 minutes.
+        body: Actual request body bytes, string, or JSON-like dict to bind with
+            a SHA-256 digest. If provided, new challenges include a digest and
+            submitted credentials must echo a matching digest.
+        events: Optional dispatcher for challenge/payment lifecycle events.
 
     Returns:
         If no valid Authorization header:

--- a/src/mpp/server/verify.py
+++ b/src/mpp/server/verify.py
@@ -5,7 +5,14 @@ from __future__ import annotations
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
-from mpp import Challenge, Credential, Receipt, _constant_time_equal, generate_challenge_id
+from mpp import (
+    Challenge,
+    Credential,
+    Receipt,
+    _body_digest,
+    _constant_time_equal,
+    generate_challenge_id,
+)
 from mpp._parsing import ParseError, _b64_decode
 from mpp._units import transform_units
 from mpp.errors import (
@@ -32,6 +39,7 @@ async def verify_or_challenge(
     description: str | None = None,
     meta: dict[str, str] | None = None,
     expires: str | None = None,
+    body: str | bytes | dict[str, Any] | None = None,
     events: EventDispatcher | None = None,
 ) -> Challenge | tuple[Credential, Receipt]:
     """Verify a payment credential or generate a new challenge.
@@ -89,7 +97,7 @@ async def verify_or_challenge(
 
     async def new_challenge() -> Challenge:
         challenge = _create_challenge(
-            method_name, intent.name, request, realm, secret_key, description, meta, expires
+            method_name, intent.name, request, realm, secret_key, description, meta, expires, body
         )
         if events is not None:
             await events.emit(
@@ -181,6 +189,9 @@ async def verify_or_challenge(
             credential,
         )
 
+    if digest_error := _body_digest_error(echo.digest, body):
+        return await fail(InvalidChallengeError(echo.id, digest_error), credential)
+
     # Enforce challenge expiry — fail closed.  Credentials without an
     # expires field or with an unparseable value are rejected outright.
     if not echo.expires:
@@ -234,6 +245,7 @@ def _create_challenge(
     description: str | None = None,
     meta: dict[str, str] | None = None,
     expires: str | None = None,
+    body: str | bytes | dict[str, Any] | None = None,
 ) -> Challenge:
     """Create a new payment challenge with HMAC-bound ID.
 
@@ -249,6 +261,8 @@ def _create_challenge(
         expires_dt = datetime.now(UTC) + timedelta(minutes=DEFAULT_EXPIRES_MINUTES)
         expires = expires_dt.isoformat().replace("+00:00", "Z")
 
+    digest = _body_digest.compute(body) if body is not None else None
+
     return Challenge.create(
         secret_key=secret_key,
         realm=realm,
@@ -256,9 +270,25 @@ def _create_challenge(
         intent=intent_name,
         request=request,
         expires=expires,
+        digest=digest,
         description=description,
         meta=meta,
     )
+
+
+def _body_digest_error(
+    digest: str | None,
+    body: str | bytes | dict[str, Any] | None,
+) -> str | None:
+    if body is None:
+        if digest is not None:
+            return "body digest present but request body was not provided"
+        return None
+    if not digest:
+        return "missing body digest"
+    if not _body_digest.verify(digest, body):
+        return "body digest mismatch"
+    return None
 
 
 def _challenge_from_echo(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -687,6 +687,23 @@ class TestWrapPaymentHandler:
 
 
 class TestPay:
+    def test_framework_scope_handles_non_utf8_query_string(self) -> None:
+        """framework_scope must not crash on non-UTF-8 query bytes from the wire."""
+        from mpp.server.decorator import framework_scope
+
+        class AsgiRequest:
+            def __init__(self, query_string: bytes) -> None:
+                self.scope = {
+                    "type": "http",
+                    "path": "/paid",
+                    "query_string": query_string,
+                }
+
+        scope = framework_scope(AsgiRequest(b"\xff\xfe"))
+
+        assert scope["resource"] == "/paid"
+        assert scope["query"] == b"\xff\xfe".decode("latin-1")
+
     @pytest.mark.asyncio
     async def test_returns_402_when_no_authorization(self) -> None:
         """Should return 402 dict when no Authorization header."""

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -164,6 +164,9 @@ class TestVerifyOrChallenge:
         )
 
         assert isinstance(result, tuple)
+        _credential, receipt = result
+        assert receipt.status == "success"
+        assert receipt.reference == "0x123"
 
     @pytest.mark.asyncio
     async def test_rejects_mismatched_body_digest(self) -> None:
@@ -191,6 +194,33 @@ class TestVerifyOrChallenge:
         )
 
         assert isinstance(result, Challenge)
+
+    @pytest.mark.asyncio
+    async def test_rejects_digest_bound_credential_without_body(self) -> None:
+        """Should reject a digest-bound credential when no body is supplied."""
+
+        @intent(name="charge")
+        async def test_intent(credential: Credential, request: dict) -> Receipt:
+            return Receipt.success("0x123")
+
+        credential = make_bound_credential(
+            payload={"hash": "0xabc"},
+            request={"amount": "1000"},
+            realm="api.example.com",
+            secret_key="test-secret",
+            digest=BodyDigest.compute(b'{"query":"paid"}'),
+        )
+
+        result = await verify_or_challenge(
+            authorization=credential.to_authorization(),
+            intent=test_intent,
+            request={"amount": "1000"},
+            realm="api.example.com",
+            secret_key="test-secret",
+        )
+
+        assert isinstance(result, Challenge)
+        assert result.digest is None
 
     @pytest.mark.asyncio
     async def test_emits_payment_success(self) -> None:
@@ -618,6 +648,11 @@ class DjangoStyleRequest:
         self.META = {"HTTP_AUTHORIZATION": authorization} if authorization else {}
 
 
+def challenge_from_402(result) -> Challenge:
+    headers = result.headers if HAS_STARLETTE else result["headers"]
+    return Challenge.from_www_authenticate(headers["WWW-Authenticate"])
+
+
 class TestWrapPaymentHandler:
     @pytest.mark.asyncio
     async def test_raises_type_error_when_request_is_none(self) -> None:
@@ -806,6 +841,49 @@ class TestPay:
         else:
             assert isinstance(result, dict)
             assert result["status"] == 402
+        replacement = challenge_from_402(result)
+        assert replacement.digest == BodyDigest.compute(b'{"query":"tampered"}')
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "body_value",
+        [
+            '{"query":"paid"}',
+            {"query": "paid"},
+        ],
+    )
+    async def test_body_callback_supports_str_and_dict_values(self, body_value) -> None:
+        """Standalone pay() should accept non-bytes body callback values."""
+
+        @intent(name="charge")
+        async def test_intent(credential: Credential, request: dict) -> Receipt:
+            return Receipt.success("tx-ref-123")
+
+        @pay(
+            intent=test_intent,
+            request={"amount": "1000"},
+            realm="api.example.com",
+            secret_key="test-secret",
+            body=lambda _req: body_value,
+        )
+        async def handler(req: MockRequest, credential: Credential, receipt: Receipt) -> dict:
+            return {"receipt_ref": receipt.reference}
+
+        challenge_result = await handler(MockRequest())
+        challenge = challenge_from_402(challenge_result)
+        assert challenge.digest == BodyDigest.compute(body_value)
+
+        credential = make_bound_credential(
+            payload={"hash": "0xabc"},
+            request={"amount": "1000"},
+            realm="api.example.com",
+            secret_key="test-secret",
+            digest=challenge.digest,
+        )
+
+        result = await handler(MockRequest(authorization=credential.to_authorization()))
+
+        assert result == {"receipt_ref": "tx-ref-123"}
 
     @pytest.mark.asyncio
     async def test_supports_django_style_requests(self) -> None:
@@ -1081,6 +1159,77 @@ class TestMppPay:
                 body=original_body,
             )
         )
+
+        assert result == {"receipt_ref": "tx-ref-456"}
+
+    @pytest.mark.asyncio
+    async def test_charge_binds_and_verifies_body_digest(self) -> None:
+        """Mpp.charge(body=...) should bind and verify the actual request body."""
+
+        @intent(name="charge")
+        async def test_intent(credential: Credential, request: dict) -> Receipt:
+            return Receipt.success("tx-ref-456")
+
+        server = _make_server(test_intent)
+        body = b'{"query":"paid"}'
+
+        challenge = await server.charge(authorization=None, amount="0.50", body=body)
+        assert isinstance(challenge, Challenge)
+        assert challenge.digest == BodyDigest.compute(body)
+
+        credential = make_bound_credential(
+            payload={"hash": "0xabc"},
+            request={"amount": "500000", "currency": "0xUSD", "recipient": "0xRecipient"},
+            realm="api.example.com",
+            secret_key="test-secret",
+            digest=challenge.digest,
+        )
+
+        result = await server.charge(
+            authorization=credential.to_authorization(),
+            amount="0.50",
+            body=body,
+        )
+
+        assert isinstance(result, tuple)
+        _credential, receipt = result
+        assert receipt.status == "success"
+        assert receipt.reference == "tx-ref-456"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "body_value",
+        [
+            '{"query":"paid"}',
+            {"query": "paid"},
+        ],
+    )
+    async def test_body_callback_supports_str_and_dict_values(self, body_value) -> None:
+        """server.pay() should accept non-bytes body callback values."""
+
+        @intent(name="charge")
+        async def test_intent(credential: Credential, request: dict) -> Receipt:
+            return Receipt.success("tx-ref-456")
+
+        server = _make_server(test_intent)
+
+        @server.pay(amount="0.50", body=lambda _req: body_value)
+        async def handler(req: MockRequest, credential: Credential, receipt: Receipt) -> dict:
+            return {"receipt_ref": receipt.reference}
+
+        challenge_result = await handler(MockRequest())
+        challenge = challenge_from_402(challenge_result)
+        assert challenge.digest == BodyDigest.compute(body_value)
+
+        credential = make_bound_credential(
+            payload={"hash": "0xabc"},
+            request={"amount": "500000", "currency": "0xUSD", "recipient": "0xRecipient"},
+            realm="api.example.com",
+            secret_key="test-secret",
+            digest=challenge.digest,
+        )
+
+        result = await handler(MockRequest(authorization=credential.to_authorization()))
 
         assert result == {"receipt_ref": "tx-ref-456"}
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1048,6 +1048,43 @@ class TestMppPay:
         assert result["receipt_ref"] == "tx-ref-456"
 
     @pytest.mark.asyncio
+    async def test_body_callback_binds_and_verifies_actual_request_body(self) -> None:
+        """server.pay() should use the configured body callback for digest verification."""
+
+        @intent(name="charge")
+        async def test_intent(credential: Credential, request: dict) -> Receipt:
+            return Receipt.success("tx-ref-456")
+
+        server = _make_server(test_intent)
+
+        @server.pay(amount="0.50", body=lambda req: req.body)
+        async def handler(req: MockRequest, credential: Credential, receipt: Receipt) -> dict:
+            return {"receipt_ref": receipt.reference}
+
+        original_body = b'{"query":"paid"}'
+        challenge_result = await handler(MockRequest(body=original_body))
+        headers = challenge_result.headers if HAS_STARLETTE else challenge_result["headers"]
+        challenge = Challenge.from_www_authenticate(headers["WWW-Authenticate"])
+        assert challenge.digest == BodyDigest.compute(original_body)
+
+        credential = make_bound_credential(
+            payload={"hash": "0xabc"},
+            request={"amount": "500000", "currency": "0xUSD", "recipient": "0xRecipient"},
+            realm="api.example.com",
+            secret_key="test-secret",
+            digest=challenge.digest,
+        )
+
+        result = await handler(
+            MockRequest(
+                authorization=credential.to_authorization(),
+                body=original_body,
+            )
+        )
+
+        assert result == {"receipt_ref": "tx-ref-456"}
+
+    @pytest.mark.asyncio
     async def test_converts_human_amount_to_base_units(self) -> None:
         """server.pay() should convert human-readable amount via charge()."""
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1375,6 +1375,61 @@ class TestMppPay:
         assert receipt.reference == "tx-ref-456"
 
     @pytest.mark.asyncio
+    async def test_charge_binds_and_verifies_explicit_framework_scope(self) -> None:
+        """Mpp.charge(mppx_scope=...) should reject cross-resource credential replay."""
+
+        @intent(name="charge")
+        async def test_intent(credential: Credential, request: dict) -> Receipt:
+            return Receipt.success("tx-ref-456")
+
+        server = _make_server(test_intent)
+        first_scope = {"route": "/paid/{id}", "resource": "/paid/one", "query": "view=full"}
+        second_scope = {"route": "/paid/{id}", "resource": "/paid/two", "query": "view=full"}
+
+        challenge = await server.charge(
+            authorization=None,
+            amount="0.50",
+            mppx_scope=first_scope,
+        )
+        assert isinstance(challenge, Challenge)
+        assert challenge.request["_mppx_scope"] == first_scope
+
+        credential = make_bound_credential(
+            payload={"hash": "0xabc"},
+            request={
+                "amount": "500000",
+                "currency": "0xUSD",
+                "recipient": "0xRecipient",
+                "_mppx_scope": first_scope,
+            },
+            realm="api.example.com",
+            secret_key="test-secret",
+        )
+
+        result = await server.charge(
+            authorization=credential.to_authorization(),
+            amount="0.50",
+            mppx_scope=second_scope,
+        )
+
+        assert isinstance(result, Challenge)
+
+    @pytest.mark.asyncio
+    async def test_charge_rejects_invalid_explicit_framework_scope(self) -> None:
+        @intent(name="charge")
+        async def test_intent(credential: Credential, request: dict) -> Receipt:
+            return Receipt.success("tx-ref-456")
+
+        server = _make_server(test_intent)
+
+        with pytest.raises(ValueError, match=r"mppx_scope must be a dict\[str, str\]"):
+            await server.charge(
+                authorization=None,
+                amount="0.50",
+                mppx_scope={"resource": 42},  # type: ignore[dict-item]
+            )
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "body_value",
         [

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -776,6 +776,53 @@ class TestPay:
         assert result["data"] == "paid content"
         assert result["receipt_ref"] == "tx-ref-123"
 
+    def test_starlette_route_scope_binds_real_framework_abi(self) -> None:
+        """Standalone pay() should bind Starlette route/resource/query scope."""
+        pytest.importorskip("starlette")
+        from starlette.applications import Starlette
+        from starlette.responses import JSONResponse
+        from starlette.routing import Route
+        from starlette.testclient import TestClient
+
+        @intent(name="charge")
+        async def test_intent(credential: Credential, request: dict) -> Receipt:
+            return Receipt.success("tx-ref-123")
+
+        @pay(
+            intent=test_intent,
+            request={"amount": "1000"},
+            realm="api.example.com",
+            secret_key="test-secret",
+        )
+        async def handler(request, credential: Credential, receipt: Receipt):
+            return JSONResponse({"data": "paid", "receipt_ref": receipt.reference})
+
+        app = Starlette(routes=[Route("/paid/{id}", handler)])
+
+        with TestClient(app) as client:
+            challenge_response = client.get("/paid/one?view=full")
+            assert challenge_response.status_code == 402
+
+            challenge = Challenge.from_www_authenticate(
+                challenge_response.headers["WWW-Authenticate"]
+            )
+            assert challenge.request["_mppx_scope"] == {
+                "route": "/paid/{id}",
+                "resource": "/paid/one",
+                "query": "view=full",
+            }
+
+            credential = Credential(
+                challenge=challenge.to_echo(),
+                payload={"hash": "0xabc"},
+            )
+            replay_response = client.get(
+                "/paid/two?view=full",
+                headers={"Authorization": credential.to_authorization()},
+            )
+
+            assert replay_response.status_code == 402
+
     @pytest.mark.asyncio
     async def test_rejects_paid_retry_with_different_auto_route_scope(self) -> None:
         """Standalone pay() should bind credentials to framework route scope."""

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -636,9 +636,22 @@ class TestCrossEndpointReplay:
 class MockRequest:
     """Mock request object for testing."""
 
-    def __init__(self, authorization: str | None = None, body: bytes | None = None) -> None:
+    def __init__(
+        self,
+        authorization: str | None = None,
+        body: bytes | None = None,
+        path: str | None = None,
+        route: str | None = None,
+        query_string: str | None = None,
+    ) -> None:
         self.headers = {"authorization": authorization} if authorization else {}
         self.body = body
+        if path is not None:
+            self.path = path
+        if route is not None:
+            self.route = route
+        if query_string is not None:
+            self.query_string = query_string
 
 
 class DjangoStyleRequest:
@@ -762,6 +775,54 @@ class TestPay:
 
         assert result["data"] == "paid content"
         assert result["receipt_ref"] == "tx-ref-123"
+
+    @pytest.mark.asyncio
+    async def test_rejects_paid_retry_with_different_auto_route_scope(self) -> None:
+        """Standalone pay() should bind credentials to framework route scope."""
+
+        @intent(name="charge")
+        async def test_intent(credential: Credential, request: dict) -> Receipt:
+            return Receipt.success("tx-ref-123")
+
+        @pay(
+            intent=test_intent,
+            request={"amount": "1000"},
+            realm="api.example.com",
+            secret_key="test-secret",
+        )
+        async def handler(req: MockRequest, credential: Credential, receipt: Receipt) -> dict:
+            return {"data": "paid"}
+
+        challenge_result = await handler(
+            MockRequest(path="/paid/one", route="/paid/{id}", query_string="view=full")
+        )
+        challenge = challenge_from_402(challenge_result)
+        assert challenge.request["_mppx_scope"] == {
+            "route": "/paid/{id}",
+            "resource": "/paid/one",
+            "query": "view=full",
+        }
+        credential = Credential(
+            challenge=challenge.to_echo(),
+            payload={"hash": "0xabc"},
+        )
+
+        result = await handler(
+            MockRequest(
+                authorization=credential.to_authorization(),
+                path="/paid/two",
+                route="/paid/{id}",
+                query_string="view=full",
+            )
+        )
+
+        if HAS_STARLETTE:
+            assert StarletteResponse is not None
+            assert isinstance(result, StarletteResponse)
+            assert result.status_code == 402
+        else:
+            assert isinstance(result, dict)
+            assert result["status"] == 402
 
     @pytest.mark.asyncio
     async def test_supports_dynamic_request_params(self) -> None:
@@ -1124,6 +1185,51 @@ class TestMppPay:
 
         assert result["data"] == "paid content"
         assert result["receipt_ref"] == "tx-ref-456"
+
+    @pytest.mark.asyncio
+    async def test_rejects_paid_retry_with_different_auto_route_scope(self) -> None:
+        """server.pay() should bind credentials to framework route scope."""
+
+        @intent(name="charge")
+        async def test_intent(credential: Credential, request: dict) -> Receipt:
+            return Receipt.success("tx-ref-456")
+
+        server = _make_server(test_intent)
+
+        @server.pay(amount="0.50")
+        async def handler(req: MockRequest, credential: Credential, receipt: Receipt) -> dict:
+            return {"receipt_ref": receipt.reference}
+
+        challenge_result = await handler(
+            MockRequest(path="/paid/one", route="/paid/{id}", query_string="view=full")
+        )
+        challenge = challenge_from_402(challenge_result)
+        assert challenge.request["_mppx_scope"] == {
+            "route": "/paid/{id}",
+            "resource": "/paid/one",
+            "query": "view=full",
+        }
+        credential = Credential(
+            challenge=challenge.to_echo(),
+            payload={"hash": "0xabc"},
+        )
+
+        result = await handler(
+            MockRequest(
+                authorization=credential.to_authorization(),
+                path="/paid/two",
+                route="/paid/{id}",
+                query_string="view=full",
+            )
+        )
+
+        if HAS_STARLETTE:
+            assert StarletteResponse is not None
+            assert isinstance(result, StarletteResponse)
+            assert result.status_code == 402
+        else:
+            assert isinstance(result, dict)
+            assert result["status"] == 402
 
     @pytest.mark.asyncio
     async def test_body_callback_binds_and_verifies_actual_request_body(self) -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from mpp import Challenge, Credential, Receipt
+from mpp import BodyDigest, Challenge, Credential, Receipt
 from mpp.events import EventDispatcher
 from mpp.server import Mpp, intent, pay, verify_or_challenge
 from mpp.server.intent import VerificationError
@@ -115,6 +115,82 @@ class TestVerifyOrChallenge:
         assert isinstance(result, tuple)
         _, receipt = result
         assert receipt.status == "success"
+
+    @pytest.mark.asyncio
+    async def test_issues_challenge_with_body_digest(self) -> None:
+        """Should bind a supplied server request body into the issued challenge."""
+
+        @intent(name="charge")
+        async def test_intent(credential: Credential, request: dict) -> Receipt:
+            return Receipt.success("0x123")
+
+        body = b'{"query":"paid"}'
+        result = await verify_or_challenge(
+            authorization=None,
+            intent=test_intent,
+            request={"amount": "1000"},
+            realm="api.example.com",
+            secret_key="test-secret",
+            body=body,
+        )
+
+        assert isinstance(result, Challenge)
+        assert result.digest == BodyDigest.compute(body)
+
+    @pytest.mark.asyncio
+    async def test_verifies_matching_body_digest(self) -> None:
+        """Should accept a digest-bound credential only for the matching body."""
+
+        @intent(name="charge")
+        async def test_intent(credential: Credential, request: dict) -> Receipt:
+            return Receipt.success("0x123")
+
+        body = b'{"query":"paid"}'
+        credential = make_bound_credential(
+            payload={"hash": "0xabc"},
+            request={"amount": "1000"},
+            realm="api.example.com",
+            secret_key="test-secret",
+            digest=BodyDigest.compute(body),
+        )
+
+        result = await verify_or_challenge(
+            authorization=credential.to_authorization(),
+            intent=test_intent,
+            request={"amount": "1000"},
+            realm="api.example.com",
+            secret_key="test-secret",
+            body=body,
+        )
+
+        assert isinstance(result, tuple)
+
+    @pytest.mark.asyncio
+    async def test_rejects_mismatched_body_digest(self) -> None:
+        """Should reject a credential when the actual server body differs."""
+
+        @intent(name="charge")
+        async def test_intent(credential: Credential, request: dict) -> Receipt:
+            return Receipt.success("0x123")
+
+        credential = make_bound_credential(
+            payload={"hash": "0xabc"},
+            request={"amount": "1000"},
+            realm="api.example.com",
+            secret_key="test-secret",
+            digest=BodyDigest.compute(b'{"query":"paid"}'),
+        )
+
+        result = await verify_or_challenge(
+            authorization=credential.to_authorization(),
+            intent=test_intent,
+            request={"amount": "1000"},
+            realm="api.example.com",
+            secret_key="test-secret",
+            body=b'{"query":"tampered"}',
+        )
+
+        assert isinstance(result, Challenge)
 
     @pytest.mark.asyncio
     async def test_emits_payment_success(self) -> None:
@@ -530,8 +606,9 @@ class TestCrossEndpointReplay:
 class MockRequest:
     """Mock request object for testing."""
 
-    def __init__(self, authorization: str | None = None) -> None:
+    def __init__(self, authorization: str | None = None, body: bytes | None = None) -> None:
         self.headers = {"authorization": authorization} if authorization else {}
+        self.body = body
 
 
 class DjangoStyleRequest:
@@ -682,6 +759,53 @@ class TestPay:
         result = await handler(request)
 
         assert result["data"] == "paid"
+
+    @pytest.mark.asyncio
+    async def test_body_callback_binds_and_verifies_actual_request_body(self) -> None:
+        """Standalone pay() should use the configured body callback for digest verification."""
+
+        @intent(name="charge")
+        async def test_intent(credential: Credential, request: dict) -> Receipt:
+            return Receipt.success("tx-ref-123")
+
+        @pay(
+            intent=test_intent,
+            request={"amount": "1000"},
+            realm="api.example.com",
+            secret_key="test-secret",
+            body=lambda req: req.body,
+        )
+        async def handler(req: MockRequest, credential: Credential, receipt: Receipt) -> dict:
+            return {"data": "paid"}
+
+        original_body = b'{"query":"paid"}'
+        challenge_result = await handler(MockRequest(body=original_body))
+        headers = challenge_result.headers if HAS_STARLETTE else challenge_result["headers"]
+        challenge = Challenge.from_www_authenticate(headers["WWW-Authenticate"])
+        assert challenge.digest == BodyDigest.compute(original_body)
+
+        credential = make_bound_credential(
+            payload={"hash": "0xabc"},
+            request={"amount": "1000"},
+            realm="api.example.com",
+            secret_key="test-secret",
+            digest=challenge.digest,
+        )
+
+        result = await handler(
+            MockRequest(
+                authorization=credential.to_authorization(),
+                body=b'{"query":"tampered"}',
+            )
+        )
+
+        if HAS_STARLETTE:
+            assert StarletteResponse is not None
+            assert isinstance(result, StarletteResponse)
+            assert result.status_code == 402
+        else:
+            assert isinstance(result, dict)
+            assert result["status"] == 402
 
     @pytest.mark.asyncio
     async def test_supports_django_style_requests(self) -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -923,7 +923,11 @@ class TestPay:
 
         original_body = b'{"query":"paid"}'
         challenge_result = await handler(MockRequest(body=original_body))
-        headers = challenge_result.headers if HAS_STARLETTE else challenge_result["headers"]
+        headers = (
+            challenge_result["headers"]
+            if isinstance(challenge_result, dict)
+            else challenge_result.headers
+        )
         challenge = Challenge.from_www_authenticate(headers["WWW-Authenticate"])
         assert challenge.digest == BodyDigest.compute(original_body)
 
@@ -1294,7 +1298,11 @@ class TestMppPay:
 
         original_body = b'{"query":"paid"}'
         challenge_result = await handler(MockRequest(body=original_body))
-        headers = challenge_result.headers if HAS_STARLETTE else challenge_result["headers"]
+        headers = (
+            challenge_result["headers"]
+            if isinstance(challenge_result, dict)
+            else challenge_result.headers
+        )
         challenge = Challenge.from_www_authenticate(headers["WWW-Authenticate"])
         assert challenge.digest == BodyDigest.compute(original_body)
 


### PR DESCRIPTION
## Summary
- bind server-side challenges to request body digests
- bind challenges to framework route/resource/query scope to reject same-price cross-resource replay
- expose explicit `mppx_scope` for direct `Mpp.charge()` callers

## Testing
- `uv run pytest tests/test_server.py -q`
- `uv run ruff check src/mpp/server/mpp.py tests/test_server.py`