### PR TITLE
feat: preserve sender-signed fields when cosigning fee-payer envelopes

### DIFF
--- a/.changelog/preserve-key-authorization-rlp.md
+++ b/.changelog/preserve-key-authorization-rlp.md
@@ -1,0 +1,10 @@
+---
+pympp: patch
+---
+
+Preserve all sender-signed fields when decoding and re-signing fee-payer (0x78) envelopes. Two fields that are part of the sender's signing hash were being lost when the fee payer reconstructed the transaction to cosign it, causing valid transactions to be rejected ("Sender address does not match recovered signer") or mis-attributed:
+
+- **`keyAuthorization`**: the decoder rebuilt it from only `chain_id`, `key_type`, `key_id`, and `expiry`, dropping `limits` and the T6 (TIP-1049) `allowed_calls`, `witness`, `is_admin`, and `account` fields. It now round-trips the authorization RLP verbatim (decode and encode), so it works for both legacy and T6 authorizations — including non-secp256k1 root signatures — without requiring a T6-aware `pytempo`.
+- **`tempo_authorization_list`**: was dropped entirely during cosigning; it is now carried through.
+
+Access-key (keychain) and other non-secp256k1 sender signatures, which a fee payer cannot verify offline, are now rejected with a clear error instead of an opaque ECDSA recovery failure, and the envelope decoder fails closed on unexpected field counts.

--- a/.changelog/preserve-key-authorization-rlp.md
+++ b/.changelog/preserve-key-authorization-rlp.md
@@ -8,3 +8,5 @@ Preserve all sender-signed fields when decoding and re-signing fee-payer (0x78) 
 - **`tempo_authorization_list`**: was dropped entirely during cosigning; it is now carried through.
 
 Access-key (keychain) and other non-secp256k1 sender signatures, which a fee payer cannot verify offline, are now rejected with a clear error instead of an opaque ECDSA recovery failure, and the envelope decoder fails closed on unexpected field counts.
+
+Pre-broadcast simulation (`tempo_simulateV1`) is skipped for locally co-signed transactions that carry a `keyAuthorization` or a non-empty `tempo_authorization_list`. These fields are preserved verbatim as opaque RLP for the broadcast transaction but cannot yet be faithfully re-serialized into the simulation JSON (`keyAuthorization` / `aaAuthorizationList`), so the transaction is broadcast without the extra revert check rather than simulated as a different transaction.

--- a/src/mpp/methods/tempo/fee_payer_envelope.py
+++ b/src/mpp/methods/tempo/fee_payer_envelope.py
@@ -11,20 +11,64 @@ Wire format::
         validBefore?, validAfter?, feeToken?,
         senderAddress,           # 20 bytes (replaces feePayerSignature slot)
         authorizationList, keyAuthorization?,
-        signatureEnvelope        # sender's raw 65-byte r||s||v
+        signatureEnvelope        # serialized sender signature; local cosigning
+                                 # currently supports only 65-byte secp256k1
     ])
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
+import attrs
 import rlp
 
 if TYPE_CHECKING:
-    from pytempo import SignedKeyAuthorization, TempoTransaction
+    from pytempo import TempoTransaction
 
 FEE_PAYER_ENVELOPE_TYPE_ID = 0x78
+
+
+@runtime_checkable
+class _HasRlpPayload(Protocol):
+    """Anything exposing ``as_rlp_payload()`` (pytempo's ``SignedKeyAuthorization``
+    or the :class:`_RawSignedKeyAuthorization` wrapper)."""
+
+    def as_rlp_payload(self) -> list: ...
+
+
+@attrs.frozen
+class _RawSignedKeyAuthorization:
+    """Holds a decoded ``keyAuthorization`` field and re-emits it unchanged.
+
+    pytempo includes ``key_authorization.as_rlp_payload()`` in the signing hash
+    and final encoding, so the full payload must round-trip intact regardless of
+    which optional fields it carries (legacy or T6).
+    """
+
+    _rlp: bytes
+
+    def as_rlp_payload(self) -> list:
+        return rlp.decode(self._rlp)
+
+
+def _key_authorization_payload(key_authorization: object) -> list:
+    """Return the RLP-list payload for a transaction's ``keyAuthorization`` field.
+
+    Accepts an object exposing ``as_rlp_payload()``, raw RLP bytes, or a
+    pre-decoded list.
+    """
+    if isinstance(key_authorization, _HasRlpPayload):
+        payload = key_authorization.as_rlp_payload()
+    elif isinstance(key_authorization, (bytes, bytearray)):
+        payload = rlp.decode(bytes(key_authorization))
+    elif isinstance(key_authorization, list):
+        payload = key_authorization
+    else:
+        raise TypeError(f"Unsupported key_authorization type: {type(key_authorization)!r}")
+    if not isinstance(payload, list):
+        raise TypeError("key_authorization payload must be an RLP list")
+    return payload
 
 
 def encode_fee_payer_envelope(signed_tx: TempoTransaction) -> bytes:
@@ -59,7 +103,7 @@ def encode_fee_payer_envelope(signed_tx: TempoTransaction) -> bytes:
     ]
 
     if signed_tx.key_authorization is not None:
-        fields.append(rlp.decode(signed_tx.key_authorization))
+        fields.append(_key_authorization_payload(signed_tx.key_authorization))
         fields.append(sig_bytes)
     else:
         fields.append(sig_bytes)
@@ -69,7 +113,7 @@ def encode_fee_payer_envelope(signed_tx: TempoTransaction) -> bytes:
 
 def decode_fee_payer_envelope(
     data: bytes,
-) -> tuple[list, bytes, bytes, SignedKeyAuthorization | None]:
+) -> tuple[list, bytes, bytes, _RawSignedKeyAuthorization | None]:
     """Decode a 0x78 fee payer envelope.
 
     Args:
@@ -77,7 +121,7 @@ def decode_fee_payer_envelope(
 
     Returns:
         Tuple of (decoded RLP fields, sender_address bytes,
-        sender_signature bytes, SignedKeyAuthorization or None).
+        sender_signature bytes, key authorization passthrough or None).
 
     Raises:
         ValueError: If the data doesn't start with ``0x78`` or is malformed.
@@ -86,7 +130,8 @@ def decode_fee_payer_envelope(
         raise ValueError("Not a fee payer envelope (expected 0x78 prefix)")
 
     decoded = rlp.decode(data[1:])
-    if not isinstance(decoded, list) or len(decoded) < 14:
+    # 14 fields = no key_authorization; 15 = key_authorization present.
+    if not isinstance(decoded, list) or len(decoded) not in (14, 15):
         raise ValueError("Malformed fee payer envelope")
 
     sender_address = decoded[11]
@@ -102,31 +147,18 @@ def decode_fee_payer_envelope(
     return decoded, bytes(sender_address), bytes(sender_signature), key_authorization  # type: ignore[arg-type]
 
 
-def _decode_signed_key_authorization(rlp_fields: list) -> SignedKeyAuthorization:
-    """Reconstruct a SignedKeyAuthorization from decoded RLP fields."""
-    from pytempo import KeyAuthorization, SignatureType, SignedKeyAuthorization
-    from pytempo.models import Signature
+def _decode_signed_key_authorization(rlp_fields: list) -> _RawSignedKeyAuthorization:
+    """Validate and wrap a decoded ``[authorization_payload, signature]`` field.
 
-    auth_fields = rlp_fields[0]
-    sig_bytes = bytes(rlp_fields[1])
+    The signature is preserved as-is (any non-empty serialized signature
+    envelope), not parsed, so it is never assumed to be 65-byte secp256k1.
+    """
+    if not isinstance(rlp_fields, list) or len(rlp_fields) != 2:
+        raise ValueError("Malformed key_authorization field")
+    if not isinstance(rlp_fields[0], list):
+        raise ValueError("Malformed key_authorization payload")
+    sig_bytes = rlp_fields[1]
+    if not isinstance(sig_bytes, bytes) or len(sig_bytes) == 0:
+        raise ValueError("Malformed key_authorization signature")
 
-    chain_id = int.from_bytes(auth_fields[0], "big") if auth_fields[0] else 0
-    key_type = SignatureType(int.from_bytes(auth_fields[1], "big") if auth_fields[1] else 0)
-    key_id = bytes(auth_fields[2])
-
-    expiry = (
-        int.from_bytes(auth_fields[3], "big") if len(auth_fields) > 3 and auth_fields[3] else None
-    )
-
-    authorization = KeyAuthorization(
-        key_id=key_id,
-        chain_id=chain_id,
-        key_type=key_type,
-        expiry=expiry,
-    )
-
-    r = int.from_bytes(sig_bytes[:32], "big")
-    s = int.from_bytes(sig_bytes[32:64], "big")
-    v = sig_bytes[64]
-
-    return SignedKeyAuthorization(authorization=authorization, signature=Signature(r=r, s=s, v=v))
+    return _RawSignedKeyAuthorization(rlp.encode(rlp_fields))

--- a/src/mpp/methods/tempo/intents.py
+++ b/src/mpp/methods/tempo/intents.py
@@ -1033,6 +1033,20 @@ class ChargeIntent:
         except Exception as err:
             raise VerificationError("Failed to deserialize client transaction") from err
 
+        # Cosigning recovers the sender via secp256k1 ECDSA, so only a raw
+        # 65-byte signature is supported; other envelopes (keychain, P256,
+        # WebAuthn) are rejected up front.
+        if len(sender_sig) != 65:
+            if sender_sig and sender_sig[0] in (0x03, 0x04):
+                raise VerificationError(
+                    "Access-key (keychain) signed fee-payer envelopes are not "
+                    "supported by local cosigning"
+                )
+            raise VerificationError(
+                "Only 65-byte secp256k1 sender signatures are supported by local "
+                "fee-payer cosigning"
+            )
+
         def _int(b: bytes) -> int:
             return int.from_bytes(b, "big") if b else 0
 
@@ -1099,14 +1113,19 @@ class ChargeIntent:
             valid_before=_int(decoded[8]) if decoded[8] else None,
             valid_after=_int(decoded[9]) if decoded[9] else None,
             fee_token=decoded[10] if decoded[10] else None,
+            # Part of the sender's signing hash; must be carried through.
+            tempo_authorization_list=tuple(decoded[12]),
             awaiting_fee_payer=True,
-            key_authorization=key_auth,
+            key_authorization=key_auth,  # type: ignore[arg-type]
         )
         sender_hash = tx_for_recovery.get_signing_hash(for_fee_payer=False)
 
         from eth_account import Account
 
-        recovered_address = Account._recover_hash(sender_hash, signature=sender_sig)
+        try:
+            recovered_address = Account._recover_hash(sender_hash, signature=sender_sig)
+        except Exception as err:
+            raise VerificationError("Invalid sender signature") from err
         envelope_address = "0x" + sender_addr_bytes.hex()
 
         if recovered_address.lower() != envelope_address.lower():

--- a/src/mpp/methods/tempo/intents.py
+++ b/src/mpp/methods/tempo/intents.py
@@ -961,8 +961,12 @@ class ChargeIntent:
                 return Receipt.success(reserved_tx_hash)
 
         try:
-            # We pay the gas, so simulate the co-signed tx and bail if it would
-            # revert. Fails closed: any error releases the reservation below.
+            # We pay the gas, so when we can faithfully build a simulate payload,
+            # simulate the co-signed tx and bail if it would revert (any error
+            # releases the reservation below). Auth-bearing txs return
+            # simulate_payload=None because simulating them without their
+            # authorization fields would be a divergent transaction; those are
+            # broadcast without the pre-broadcast revert check.
             if simulate_payload is not None:
                 await self._simulate_before_broadcast(client, simulate_payload, rpc_url)
 
@@ -1024,13 +1028,21 @@ class ChargeIntent:
 
     def _cosign_as_fee_payer(
         self, raw_tx: str, fee_token: str | None = None, request: ChargeRequest | None = None
-    ) -> tuple[str, dict[str, Any]]:
+    ) -> tuple[str, dict[str, Any] | None]:
         """Co-sign a client-signed transaction as fee payer.
 
         Deserializes the client's 0x78 fee payer envelope, optionally validates
         the payment calls against ``request``, sets the fee token, and co-signs.
         Returns ``(raw_0x76_hex, simulate_payload)`` where ``simulate_payload``
         is the ``tempo_simulateV1`` request for the co-signed tx.
+
+        ``simulate_payload`` is ``None`` when the tx carries a
+        ``key_authorization`` or a non-empty ``tempo_authorization_list``: those
+        sender-signed fields are preserved verbatim as opaque RLP for the
+        broadcast tx, but cannot yet be faithfully re-serialized into the
+        ``tempo_simulateV1`` JSON (``keyAuthorization`` / ``aaAuthorizationList``,
+        possibly with P256/WebAuthn signatures). Skipping is preferable to
+        simulating a transaction that differs from the one we broadcast.
         """
         from pytempo import Call, TempoTransaction
         from pytempo.models import Signature, as_address
@@ -1161,6 +1173,14 @@ class ChargeIntent:
             raise VerificationError("Fee payer signing failed") from err
 
         raw_cosigned = "0x" + cosigned.encode().hex()
+
+        # Skip pre-broadcast simulation when the tx carries sender-signed
+        # authorization fields we cannot faithfully serialize into the
+        # tempo_simulateV1 JSON; simulating a divergent tx would be worse than
+        # not simulating at all.
+        if cosigned.key_authorization is not None or cosigned.tempo_authorization_list:
+            return raw_cosigned, None
+
         return raw_cosigned, self._build_simulate_payload(cosigned, recovered_address)
 
     def _build_simulate_payload(self, tx: Any, sender: str) -> dict[str, Any]:
@@ -1169,7 +1189,21 @@ class ChargeIntent:
         Carries the recovered sender as ``from`` (the node needs it to model the
         sender) plus the sponsor fields (``feeToken``, ``feePayerSignature``) so
         the node simulates the same tx we are about to broadcast.
+
+        Must not be called for a tx that carries a ``key_authorization`` or a
+        non-empty ``tempo_authorization_list``: those fields cannot yet be
+        faithfully serialized here, so the resulting payload would describe a
+        different transaction than the one broadcast (``_cosign_as_fee_payer``
+        returns ``None`` for such txs instead of calling this).
         """
+        if getattr(tx, "key_authorization", None) is not None or getattr(
+            tx, "tempo_authorization_list", ()
+        ):
+            raise VerificationError(
+                "Cannot build a faithful tempo_simulateV1 payload for an "
+                "authorization-bearing transaction"
+            )
+
         sig = tx.fee_payer_signature
         parity = sig.v if sig.v in (0, 1) else sig.v - 27
 

--- a/tests/test_fee_payer_envelope.py
+++ b/tests/test_fee_payer_envelope.py
@@ -391,8 +391,11 @@ class TestKeyAuthorizationRoundtrip:
         tempo(fee_payer=fee_payer, rpc_url="https://rpc.test", intents={"charge": intent})
 
         # Succeeds only if the sender hash matched -> the full payload round-tripped.
-        result = intent._cosign_as_fee_payer(envelope_hex, CURRENCY)
+        result, simulate_payload = intent._cosign_as_fee_payer(envelope_hex, CURRENCY)
         assert result.startswith("0x76")
+        # keyAuthorization cannot be faithfully serialized into the simulate JSON,
+        # so pre-broadcast simulation is skipped rather than run on a divergent tx.
+        assert simulate_payload is None
 
         # keyAuthorization sits at index 13 in the 0x76 encoding (before sender sig).
         decoded = rlp.decode(bytes.fromhex(result[2:])[1:])
@@ -472,11 +475,31 @@ class TestTempoAuthorizationListRoundtrip:
         tempo(fee_payer=fee_payer, rpc_url="https://rpc.test", intents={"charge": intent})
 
         # Succeeds only if the auth list was preserved into the recovery hash.
-        result = intent._cosign_as_fee_payer(envelope_hex, CURRENCY)
+        result, simulate_payload = intent._cosign_as_fee_payer(envelope_hex, CURRENCY)
         assert result.startswith("0x76")
+        # aaAuthorizationList cannot be faithfully serialized into the simulate
+        # JSON, so pre-broadcast simulation is skipped for this tx.
+        assert simulate_payload is None
 
         decoded = rlp.decode(bytes.fromhex(result[2:])[1:])
         assert decoded[12] == [b"\x77" * 20, b"\x88" * 32]
+
+    def test_cosign_plain_tx_still_builds_simulate_payload(self) -> None:
+        """A tx without authorization fields keeps the pre-broadcast simulation."""
+        from mpp.methods.tempo import TempoAccount, tempo
+        from mpp.methods.tempo.intents import ChargeIntent
+
+        signed = _make_signed_tx(valid_before=int(time.time()) + 300)
+        envelope_hex = "0x" + encode_fee_payer_envelope(signed).hex()
+
+        fee_payer = TempoAccount.from_key("0x" + "ab" * 32)
+        intent = ChargeIntent(rpc_url="https://rpc.test")
+        tempo(fee_payer=fee_payer, rpc_url="https://rpc.test", intents={"charge": intent})
+
+        result, simulate_payload = intent._cosign_as_fee_payer(envelope_hex, CURRENCY)
+        assert result.startswith("0x76")
+        assert simulate_payload is not None
+        assert "blockStateCalls" in simulate_payload
 
 
 class TestKeychainSignatureRejected:

--- a/tests/test_fee_payer_envelope.py
+++ b/tests/test_fee_payer_envelope.py
@@ -321,3 +321,184 @@ class TestEncoderDecoderIntegration:
         assert ("0x" + decoded[10].hex()).lower() == CURRENCY.lower()
         assert sender_addr == bytes(signed.sender_address)  # type: ignore[arg-type]
         assert key_auth is None
+
+
+# Full T6 (TIP-1049) keyAuthorization payload:
+#   [chain_id, key_type, key_id, expiry, limits, allowed_calls, witness, is_admin, account]
+# Values are hand-encoded byte strings; only byte-exact round-tripping matters here.
+_T6_KEY_AUTH_PAYLOAD = [
+    [
+        (42431).to_bytes(2, "big"),  # chain_id
+        b"\x00",  # key_type
+        bytes.fromhex("11" * 20),  # key_id
+        (9999999999).to_bytes(5, "big"),  # expiry
+        [],  # limits
+        [[bytes.fromhex("22" * 20), b"\xa9\x05\x9c\xbb"]],  # allowed_calls (TIP-1011)
+        b"",  # witness (TIP-1053)
+        b"\x01",  # is_admin (TIP-1049)
+        bytes.fromhex("33" * 20),  # account (TIP-1049)
+    ],
+    bytes.fromhex("44" * 65),  # 65-byte root signature over the authorization
+]
+
+
+def _sign_tx_with_key_auth(key_auth_payload: list) -> TempoTransaction:
+    """Sign a fee-payer-awaiting tx whose sender signature commits to ``key_auth_payload``."""
+
+    class _Stub:
+        def as_rlp_payload(self) -> list:
+            return key_auth_payload
+
+    selector = "a9059cbb"
+    to_padded = RECIPIENT[2:].lower().zfill(64)
+    amount_padded = hex(1000000)[2:].zfill(64)
+    transfer_data = f"0x{selector}{to_padded}{amount_padded}"
+
+    tx = TempoTransaction.create(
+        chain_id=42431,
+        gas_limit=100000,
+        max_fee_per_gas=1,
+        max_priority_fee_per_gas=1,
+        nonce=0,
+        nonce_key=(1 << 256) - 1,
+        awaiting_fee_payer=True,
+        valid_before=int(time.time()) + 300,
+        calls=(Call.create(to=CURRENCY, value=0, data=transfer_data),),
+        key_authorization=_Stub(),  # type: ignore[arg-type]
+    )
+    return tx.sign(TEST_PRIVATE_KEY)
+
+
+class TestKeyAuthorizationRoundtrip:
+    """The decoded keyAuthorization must preserve every signed field (TIP-1049 T6)."""
+
+    def test_cosign_preserves_full_t6_key_authorization(self) -> None:
+        """encode -> decode -> cosign must keep the full T6 payload byte-exact.
+
+        The sender signs a hash that includes ``key_authorization.as_rlp_payload()``.
+        If decoding drops any signed field (``limits``/``allowed_calls``/``witness``/
+        ``is_admin``/``account``), the recomputed sender hash changes and cosign
+        fails with "Sender address does not match recovered signer".
+        """
+        from mpp.methods.tempo import TempoAccount, tempo
+        from mpp.methods.tempo.intents import ChargeIntent
+
+        signed = _sign_tx_with_key_auth(_T6_KEY_AUTH_PAYLOAD)
+        envelope_hex = "0x" + encode_fee_payer_envelope(signed).hex()
+
+        fee_payer = TempoAccount.from_key("0x" + "ab" * 32)
+        intent = ChargeIntent(rpc_url="https://rpc.test")
+        tempo(fee_payer=fee_payer, rpc_url="https://rpc.test", intents={"charge": intent})
+
+        # Succeeds only if the sender hash matched -> the full payload round-tripped.
+        result = intent._cosign_as_fee_payer(envelope_hex, CURRENCY)
+        assert result.startswith("0x76")
+
+        # keyAuthorization sits at index 13 in the 0x76 encoding (before sender sig).
+        decoded = rlp.decode(bytes.fromhex(result[2:])[1:])
+        assert len(decoded) == 15
+        assert decoded[13] == _T6_KEY_AUTH_PAYLOAD
+
+    def test_decode_preserves_payload(self) -> None:
+        """The decode wrapper re-encodes the original keyAuthorization verbatim."""
+        signed = _sign_tx_with_key_auth(_T6_KEY_AUTH_PAYLOAD)
+        encoded = encode_fee_payer_envelope(signed)
+        _, _, _, key_auth = decode_fee_payer_envelope(encoded)
+
+        assert key_auth is not None
+        assert key_auth.as_rlp_payload() == _T6_KEY_AUTH_PAYLOAD
+
+    def test_encode_accepts_object_key_authorization(self) -> None:
+        """encode must read ``as_rlp_payload()``, not rlp.decode() an object."""
+        signed = _sign_tx_with_key_auth(_T6_KEY_AUTH_PAYLOAD)
+        encoded = encode_fee_payer_envelope(signed)
+
+        decoded = rlp.decode(encoded[1:])
+        assert len(decoded) == 15
+        assert decoded[13] == _T6_KEY_AUTH_PAYLOAD
+
+    def test_decode_preserves_non_secp256k1_key_auth_signature(self) -> None:
+        """The root's authorization signature may be a P256/WebAuthn envelope
+        (not a 65-byte secp256k1 sig); it must still round-trip verbatim."""
+        p256_payload = [
+            list(_T6_KEY_AUTH_PAYLOAD[0]),
+            b"\x01" + b"\x55" * 129,  # P256 envelope: 0x01 || 129 bytes
+        ]
+        signed = _sign_tx_with_key_auth(p256_payload)
+        encoded = encode_fee_payer_envelope(signed)
+        _, _, _, key_auth = decode_fee_payer_envelope(encoded)
+
+        assert key_auth is not None
+        assert key_auth.as_rlp_payload() == p256_payload
+
+    def test_decode_rejects_malformed_key_authorization(self) -> None:
+        """A keyAuthorization with an empty signature is rejected."""
+        from mpp.methods.tempo.fee_payer_envelope import _decode_signed_key_authorization
+
+        with pytest.raises(ValueError, match="Malformed key_authorization signature"):
+            _decode_signed_key_authorization([[b"\x00"], b""])
+
+
+class TestTempoAuthorizationListRoundtrip:
+    """tempo_authorization_list is part of the signing hash and must survive cosign."""
+
+    def test_cosign_preserves_authorization_list(self) -> None:
+        from mpp.methods.tempo import TempoAccount, tempo
+        from mpp.methods.tempo.intents import ChargeIntent
+
+        auth_list = (b"\x77" * 20, b"\x88" * 32)
+
+        selector = "a9059cbb"
+        to_padded = RECIPIENT[2:].lower().zfill(64)
+        amount_padded = hex(1000000)[2:].zfill(64)
+        transfer_data = f"0x{selector}{to_padded}{amount_padded}"
+        tx = TempoTransaction.create(
+            chain_id=42431,
+            gas_limit=100000,
+            max_fee_per_gas=1,
+            max_priority_fee_per_gas=1,
+            nonce=0,
+            nonce_key=(1 << 256) - 1,
+            awaiting_fee_payer=True,
+            valid_before=int(time.time()) + 300,
+            calls=(Call.create(to=CURRENCY, value=0, data=transfer_data),),
+            tempo_authorization_list=auth_list,
+        )
+        signed = tx.sign(TEST_PRIVATE_KEY)
+        envelope_hex = "0x" + encode_fee_payer_envelope(signed).hex()
+
+        fee_payer = TempoAccount.from_key("0x" + "ab" * 32)
+        intent = ChargeIntent(rpc_url="https://rpc.test")
+        tempo(fee_payer=fee_payer, rpc_url="https://rpc.test", intents={"charge": intent})
+
+        # Succeeds only if the auth list was preserved into the recovery hash.
+        result = intent._cosign_as_fee_payer(envelope_hex, CURRENCY)
+        assert result.startswith("0x76")
+
+        decoded = rlp.decode(bytes.fromhex(result[2:])[1:])
+        assert decoded[12] == [b"\x77" * 20, b"\x88" * 32]
+
+
+class TestKeychainSignatureRejected:
+    """Access-key (keychain) signed envelopes must fail cleanly, not opaquely."""
+
+    def test_cosign_rejects_keychain_signature(self) -> None:
+        from mpp.methods.tempo import TempoAccount, tempo
+        from mpp.methods.tempo.intents import ChargeIntent
+        from mpp.server.intent import VerificationError
+
+        signed = _make_signed_tx(valid_before=int(time.time()) + 300)
+        encoded = encode_fee_payer_envelope(signed)
+
+        # Replace the 65-byte sender signature (last field) with an 86-byte
+        # keychain signature: 0x04 || root_account (20) || inner (65).
+        decoded_fields = rlp.decode(encoded[1:])
+        decoded_fields[-1] = b"\x04" + b"\x11" * 20 + b"\x22" * 65
+        tampered = "0x" + (bytes([0x78]) + bytes(rlp.encode(decoded_fields))).hex()
+
+        fee_payer = TempoAccount.from_key("0x" + "ab" * 32)
+        intent = ChargeIntent(rpc_url="https://rpc.test")
+        tempo(fee_payer=fee_payer, rpc_url="https://rpc.test", intents={"charge": intent})
+
+        with pytest.raises(VerificationError, match="keychain.*not supported"):
+            intent._cosign_as_fee_payer(tampered, CURRENCY)

--- a/tests/test_tempo.py
+++ b/tests/test_tempo.py
@@ -1734,6 +1734,7 @@ class TestCosignAsFeePayer:
         max_priority_fee_per_gas: int = 1,
         valid_before: int | None = None,
         with_memo: str | None = None,
+        tempo_authorization_list: tuple[bytes, ...] = (),
     ) -> str:
         """Build a client-signed fee-payer-awaiting transaction."""
         from pytempo import Call, TempoTransaction
@@ -1762,6 +1763,7 @@ class TestCosignAsFeePayer:
             valid_before=valid_before,
             calls=calls,
             access_list=access_list,
+            tempo_authorization_list=tempo_authorization_list,
         )
 
         signed = tx.sign(TEST_PRIVATE_KEY)
@@ -2104,6 +2106,7 @@ class TestCosignAsFeePayer:
 
         raw_tx = self._build_client_tx(currency=currency)
         _result, payload = intent._cosign_as_fee_payer(raw_tx, currency)
+        assert payload is not None
         tx_request = payload["blockStateCalls"][0]["calls"][0]
 
         sender = TempoAccount.from_key(TEST_PRIVATE_KEY).address
@@ -2169,6 +2172,7 @@ class TestCosignAsFeePayer:
         currency = "0x20c0000000000000000000000000000000000000"
         raw_tx = self._build_client_tx(currency=currency)
         _result, payload = intent._cosign_as_fee_payer(raw_tx, currency)
+        assert payload is not None
         return payload
 
     # A reverting simulation must block the broadcast so the sponsor never pays
@@ -2273,6 +2277,82 @@ class TestCosignAsFeePayer:
         methods = [json.loads(r.read().decode())["method"] for r in requests]
         assert methods == ["tempo_simulateV1"]
         assert "eth_sendRawTransactionSync" not in methods
+
+    # A locally co-signed sponsored charge whose tx carries an authorization
+    # field cannot be faithfully simulated, so verify() must skip
+    # tempo_simulateV1 and broadcast directly (rather than simulate a divergent
+    # tx). It still succeeds end-to-end against a matching receipt.
+    @pytest.mark.asyncio
+    async def test_verify_local_fee_payer_auth_bearing_skips_simulation(
+        self, httpx_mock: HTTPXMock
+    ) -> None:
+        future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
+        currency = "0x20c0000000000000000000000000000000000000"
+        recipient = "0x742d35Cc6634c0532925a3b844bC9e7595F8fE00"
+        amount = 1000000
+        challenge_id = "challenge-auth-bearing"
+        realm = "api.example.com"
+        memo = encode_attribution(challenge_id=challenge_id, server_id=realm)
+
+        intent = self._make_intent()
+        # tempo_authorization_list makes the cosigned tx auth-bearing, so the
+        # simulate payload cannot be built and is skipped.
+        raw_tx = self._build_client_tx(
+            currency=currency,
+            recipient=recipient,
+            amount=amount,
+            with_memo=memo,
+            tempo_authorization_list=(b"\x77" * 20, b"\x88" * 32),
+        )
+        credential = make_credential(
+            payload={"type": "transaction", "signature": raw_tx},
+            challenge_id=challenge_id,
+            expires=future,
+            realm=realm,
+        )
+
+        from_topic = "0x" + "0" * 24 + "abcd" * 10
+        to_topic = "0x" + "0" * 24 + recipient[2:]
+        httpx_mock.add_response(
+            url="https://rpc.test",
+            json={
+                "jsonrpc": "2.0",
+                "result": {
+                    "transactionHash": "0xtxhash123",
+                    "status": "0x1",
+                    "logs": [
+                        {
+                            "address": currency,
+                            "topics": [TRANSFER_WITH_MEMO_TOPIC, from_topic, to_topic, memo],
+                            "data": "0x" + hex(amount)[2:].zfill(64),
+                        }
+                    ],
+                },
+                "id": 1,
+            },
+        )
+
+        receipt = await intent.verify(
+            credential,
+            {
+                "amount": str(amount),
+                "currency": currency,
+                "recipient": recipient,
+                "methodDetails": {"feePayer": True},
+            },
+        )
+
+        assert receipt.status == "success"
+        assert receipt.reference == "0xtxhash123"
+
+        # Simulation was skipped; only the broadcast was attempted, and the
+        # broadcast tx is the auth-bearing co-signed 0x76 (auth list preserved).
+        bodies = [json.loads(r.read().decode()) for r in httpx_mock.get_requests()]
+        assert [b["method"] for b in bodies] == ["eth_sendRawTransactionSync"]
+        broadcast_raw = bodies[0]["params"][0]
+        assert broadcast_raw.startswith("0x76")
+        decoded = rlp.decode(bytes.fromhex(broadcast_raw[2:])[1:])
+        assert decoded[12] == [b"\x77" * 20, b"\x88" * 32]
 
     # An already-reserved charge fetches the existing receipt without simulating.
     @pytest.mark.asyncio


### PR DESCRIPTION
Fee-payer cosigning rebuilt the transaction lossily, dropping `keyAuthorization` fields (`limits` + T6 `allowed_calls`/`witness`/`is_admin`/`account`) and `tempo_authorization_list`. Since these are part of the sender's signing hash, recovery failed ("Sender address does not match recovered signer"). Now the envelope round-trips these fields verbatim, and unsupported sender signature types are rejected with a clear error. 

Closes OSS-389