### PR TITLE
fix(stripe): bind idempotency key to challenge id, not SPT

### DIFF
--- a/src/mpp/methods/stripe/intents.py
+++ b/src/mpp/methods/stripe/intents.py
@@ -223,7 +223,12 @@ class ChargeIntent:
                 "payment_method_types": list(request.methodDetails.paymentMethodTypes),
                 "shared_payment_granted_token": spt,
             }
-            options = {"idempotency_key": f"mppx_{challenge_id}_{spt}"}
+            # Key idempotency on the challenge alone. The challenge id is HMAC-bound
+            # to the charge parameters (amount/currency/recipient/realm), so it is the
+            # stable identity of the charge. Including the (single-use, regenerated)
+            # SPT would make every retry a fresh key and let Stripe create a second
+            # PaymentIntent for the same logical charge -> double charge.
+            options = {"idempotency_key": f"mppx_{challenge_id}"}
 
             create_async = getattr(payment_intents, "create_async", None)
             if callable(create_async):
@@ -265,7 +270,7 @@ class ChargeIntent:
             headers={
                 "Authorization": f"Basic {auth_value}",
                 "Content-Type": "application/x-www-form-urlencoded",
-                "Idempotency-Key": f"mppx_{challenge_id}_{spt}",
+                "Idempotency-Key": f"mppx_{challenge_id}",
             },
             data=body,
         )

--- a/tests/test_stripe.py
+++ b/tests/test_stripe.py
@@ -653,7 +653,11 @@ class TestChargeIntent:
 
     @pytest.mark.asyncio
     async def test_idempotency_key(self):
-        """Verify idempotency key format matches mppx."""
+        """Idempotency key is bound to the challenge id only, not the SPT.
+
+        The SPT is single-use and regenerated on retry; folding it into the
+        key would defeat idempotency and allow a duplicate charge.
+        """
         captured: list[tuple[tuple, dict]] = []
 
         class CapturingIntents:
@@ -669,7 +673,7 @@ class TestChargeIntent:
         await intent.verify(credential, SAMPLE_REQUEST)
 
         options = captured[0][1]["options"]
-        assert options["idempotency_key"] == "mppx_test-challenge-id_spt_test_xyz"
+        assert options["idempotency_key"] == "mppx_test-challenge-id"
 
     @pytest.mark.asyncio
     async def test_client_request_body_is_first_positional_arg(self):
@@ -757,7 +761,7 @@ class TestChargeIntentRawHttp:
         headers = call_kwargs.kwargs["headers"]
         expected_auth = base64.b64encode(b"sk_test_raw:").decode()
         assert headers["Authorization"] == f"Basic {expected_auth}"
-        assert headers["Idempotency-Key"] == "mppx_test-challenge-id_spt_test_abc"
+        assert headers["Idempotency-Key"] == "mppx_test-challenge-id"
 
         data = call_kwargs.kwargs["data"]
         assert data["amount"] == "150"


### PR DESCRIPTION
# Security advisory: duplicate Stripe charges via SPT in idempotency key

**Severity:** High · **Class:** Financial correctness / idempotency bypass · **Affected:** `mpp.methods.stripe`

## Impact

A buyer can be charged twice for a single payment. Any retry of a 402 flow that
re-mints the Stripe Shared Payment Token (SPT) — the normal case, since SPTs are
short-lived and single-use — produces a *different* idempotency key, so Stripe
happily creates a second `PaymentIntent` for the same logical charge.

## Where it comes from

Both PaymentIntent creation paths derived the idempotency key from the SPT:

```python
options = {"idempotency_key": f"mppx_{challenge_id}_{spt}"}   # SDK path
"Idempotency-Key": f"mppx_{challenge_id}_{spt}"               # raw-HTTP path
```

Idempotency is supposed to collapse retries of *the same charge* into one
settlement. The `challenge_id` already is that identity: it is an HMAC bound to
amount, currency, recipient, realm and intent. The SPT carries no additional
identity — it is an ephemeral credential — so mixing it in only serves to make
otherwise-identical retries look distinct to Stripe.

## Resolution

Key idempotency on `challenge_id` alone:

```python
options = {"idempotency_key": f"mppx_{challenge_id}"}
```

Now a re-tried charge with a freshly minted SPT resolves to the same Stripe
PaymentIntent, and the double-charge window is closed. Both the SDK-client and
raw-HTTP code paths were updated identically so behaviour no longer depends on
which transport is configured.

## Verification

`tests/test_stripe.py` carried two assertions that *encoded the vulnerable
behaviour* (they asserted the SPT was present in the key). Those assertions were
corrected to assert challenge-only keys, and a docstring now records why the SPT
must stay out. Full `test_stripe.py` suite: 50 passed.
