### PR TITLE
fix(client): replay request body on paid 402 retry

### DIFF
--- a/src/mpp/client/transport.py
+++ b/src/mpp/client/transport.py
@@ -117,6 +117,13 @@ class PaymentTransport(httpx.AsyncBaseTransport):
 
     async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
         """Handle request, automatically retrying on 402 with credentials."""
+        # Buffer the request body up front. Request bodies (e.g. a POST payload)
+        # are streamed and one-shot: the inner transport consumes the stream when
+        # it sends the initial request, so a paid retry that reused the original
+        # stream would transmit an empty/garbled body. Reading here replaces the
+        # stream with a replayable ByteStream, so the retry carries the real body.
+        await request.aread()
+
         response = await self._inner.handle_async_request(request)
 
         if response.status_code != 402:
@@ -240,7 +247,7 @@ class PaymentTransport(httpx.AsyncBaseTransport):
             method=request.method,
             url=request.url,
             headers=headers,
-            stream=request.stream,
+            content=request.content,
             extensions=request.extensions,
         )
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -90,6 +90,38 @@ class TestPaymentTransport:
         method.create_credential.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_paid_retry_replays_request_body(self) -> None:
+        """The paid retry must carry the original request body.
+
+        Regression: the retry previously reused the already-consumed request
+        stream, so a POST body was dropped on the (paying) retry.
+        """
+        challenge = Challenge(
+            id="test-id",
+            method="tempo",
+            intent="charge",
+            request={"amount": "1000"},
+        )
+        www_auth = challenge.to_www_authenticate("example.com")
+
+        inner = MockTransport(
+            [
+                httpx.Response(402, headers={"www-authenticate": www_auth}),
+                httpx.Response(200, content=b'{"data": "ok"}'),
+            ]
+        )
+        transport = PaymentTransport(methods=[MockMethod()], inner=inner)
+
+        body = b'{"prompt": "expensive question"}'
+        request = httpx.Request("POST", "https://example.com", content=body)
+        await transport.handle_async_request(request)
+
+        assert len(inner.requests) == 2
+        retry_request = inner.requests[1]
+        assert retry_request.content == body
+        assert retry_request.headers["content-length"] == str(len(body))
+
+    @pytest.mark.asyncio
     async def test_emits_client_payment_events(self) -> None:
         """Should emit mppx-compatible client payment lifecycle events."""
         events: list[str] = []


### PR DESCRIPTION
## Bug: POST/PUT body is dropped on the paid (402) retry

### Environment
- Component: `mpp.client.PaymentTransport`
- Affects: any request that carries a body (POST/PUT/PATCH) through the payment flow

### Steps to reproduce
1. Configure a `Client` with a payment method.
2. `await client.post(url, content=b'{"prompt": "..."}')` against an endpoint
   that answers `402 Payment Required`.
3. The transport creates a credential and retries with the `Authorization` header.

### Expected
The retried request reaches the server with the **same body** as the original —
that's the whole point of the flow: the *paid* request is the one that must
carry the payload.

### Actual
The retry was built reusing the original request's stream:

```python
retry_request = httpx.Request(..., stream=request.stream, ...)
```

Request bodies are streamed and **one-shot**. The inner transport already
consumed `request.stream` when it sent the initial request, so the retry went
out with an empty or malformed body. GET requests have no body, which is why the
existing GET-only tests never caught it.

### Fix
Buffer the body before the first dispatch and replay it on the retry:

```python
await request.aread()          # replaces stream with a replayable ByteStream
...
retry_request = httpx.Request(..., content=request.content, ...)
```

`aread()` reads the stream once and swaps in a replayable `ByteStream`, so both
the initial send and the retry transmit identical bytes and a correct
`Content-Length`.

### Test
Added `test_paid_retry_replays_request_body` — POSTs a body, forces a 402, and
asserts the retried request's `content` and `content-length` match the original.
`tests/test_client.py`: 24 passed.