### PR TITLE
fix: harden Claude changelog workflow

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -31,13 +31,14 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           BASE_REF: ${{ github.base_ref }}
         run: |
+          rm -rf .claude/
           CHANGED=$(git diff --name-only "origin/${BASE_REF}...HEAD")
           CODE_CHANGES=$(echo "$CHANGED" | grep -vE '^(\.changelog/|\.github/|\.gitignore|README\.md|AGENTS\.md)' || true)
           if [ -z "$CODE_CHANGES" ]; then
             echo "No code changes requiring changelog, skipping"
             exit 0
           fi
-          ~/.local/bin/changelogs add --ecosystem python --ai "claude -p" --ref "origin/${BASE_REF}"
+          ~/.local/bin/changelogs add --ecosystem python --ai "claude --bare -p" --ref "origin/${BASE_REF}"
       - name: Commit changelog
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Motivation

Prevent PR-controlled Claude Code hooks from executing in the changelog workflow before AI generation starts.

## Summary

- Remove repo-local Claude settings before changelog generation
- Run Claude in bare mode for changelog AI generation

## Key design considerations

- Keeps the existing pull request workflow behavior intact
