### PR TITLE
fix: reject padded Tempo calldata

### DIFF
--- a/.changelog/merry-snails-jump.md
+++ b/.changelog/merry-snails-jump.md
@@ -1,0 +1,5 @@
+---
+pympp: patch
+---
+
+Fixed rejection of ABI-encoded calldata with trailing padding bytes in Tempo transfer, approve, and swap calls. Added exact-length validation constants and updated `_match_single_transfer_calldata`, `_match_transfer_calldata`, and `_validate_call_scope` to reject any calldata that does not match the expected byte length precisely.

--- a/src/mpp/methods/tempo/intents.py
+++ b/src/mpp/methods/tempo/intents.py
@@ -35,6 +35,10 @@ TRANSFER_SELECTOR = "a9059cbb"
 TRANSFER_WITH_MEMO_SELECTOR = "95777d59"
 APPROVE_SELECTOR = "095ea7b3"
 SWAP_EXACT_AMOUNT_OUT_SELECTOR = "b30d91d5"
+TRANSFER_CALLDATA_HEX_LENGTH = 8 + (2 * 64)
+TRANSFER_WITH_MEMO_CALLDATA_HEX_LENGTH = 8 + (3 * 64)
+APPROVE_CALLDATA_HEX_LENGTH = 8 + (2 * 64)
+SWAP_EXACT_AMOUNT_OUT_CALLDATA_HEX_LENGTH = 8 + (4 * 64)
 
 TRANSFER_TOPIC = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
 TRANSFER_WITH_MEMO_TOPIC = "0x57bc7354aa85aed339e000bccffabbc529466af35f0772c8f8ee1145927de7f0"
@@ -136,18 +140,20 @@ def _match_single_transfer_calldata(
     memo: bytes | None,
 ) -> bool:
     """Check if ABI-encoded calldata matches a single expected transfer."""
-    if len(call_data_hex) < 136:
-        return False
-
     selector = call_data_hex[:8].lower()
 
     if memo is not None:
         if selector != TRANSFER_WITH_MEMO_SELECTOR:
             return False
-    elif selector == TRANSFER_WITH_MEMO_SELECTOR:
-        if len(call_data_hex) < 200:
+        if len(call_data_hex) != TRANSFER_WITH_MEMO_CALLDATA_HEX_LENGTH:
             return False
-    elif selector != TRANSFER_SELECTOR:
+    elif selector == TRANSFER_WITH_MEMO_SELECTOR:
+        if len(call_data_hex) != TRANSFER_WITH_MEMO_CALLDATA_HEX_LENGTH:
+            return False
+    elif selector == TRANSFER_SELECTOR:
+        if len(call_data_hex) != TRANSFER_CALLDATA_HEX_LENGTH:
+            return False
+    else:
         return False
 
     decoded_to = "0x" + call_data_hex[32:72]
@@ -159,8 +165,6 @@ def _match_single_transfer_calldata(
         return False
 
     if memo is not None:
-        if len(call_data_hex) < 200:
-            return False
         decoded_memo = bytes.fromhex(call_data_hex[136:200])
         if decoded_memo != memo:
             return False
@@ -186,19 +190,21 @@ def _rpc_error_msg(result: dict) -> str:
 
 def _match_transfer_calldata(call_data_hex: str, request: ChargeRequest) -> bool:
     """Check if ABI-encoded calldata matches the expected transfer parameters."""
-    if len(call_data_hex) < 136:
-        return False
-
     selector = call_data_hex[:8].lower()
     expected_memo = request.methodDetails.memo
 
     if expected_memo:
         if selector != TRANSFER_WITH_MEMO_SELECTOR:
             return False
-    elif selector == TRANSFER_WITH_MEMO_SELECTOR:
-        if len(call_data_hex) < 200:
+        if len(call_data_hex) != TRANSFER_WITH_MEMO_CALLDATA_HEX_LENGTH:
             return False
-    elif selector != TRANSFER_SELECTOR:
+    elif selector == TRANSFER_WITH_MEMO_SELECTOR:
+        if len(call_data_hex) != TRANSFER_WITH_MEMO_CALLDATA_HEX_LENGTH:
+            return False
+    elif selector == TRANSFER_SELECTOR:
+        if len(call_data_hex) != TRANSFER_CALLDATA_HEX_LENGTH:
+            return False
+    else:
         return False
 
     decoded_to = "0x" + call_data_hex[32:72]
@@ -210,8 +216,6 @@ def _match_transfer_calldata(call_data_hex: str, request: ChargeRequest) -> bool
         return False
 
     if expected_memo:
-        if len(call_data_hex) < 200:
-            return False
         decoded_memo = "0x" + call_data_hex[136:200]
         memo_clean = expected_memo.lower()
         if not memo_clean.startswith("0x"):
@@ -259,6 +263,10 @@ def _validate_call_scope(calls: list[tuple[str, int, str]]) -> int:
     if has_swap_prefix:
         approve_to, _, approve_data = calls[0]
         swap_to, _, swap_data = calls[1]
+        if len(approve_data) != APPROVE_CALLDATA_HEX_LENGTH:
+            raise VerificationError("Invalid transaction: malformed approve call data")
+        if len(swap_data) != SWAP_EXACT_AMOUNT_OUT_CALLDATA_HEX_LENGTH:
+            raise VerificationError("Invalid transaction: malformed swap call data")
         approve_spender = _decode_call_address_arg(approve_data, 0)
         swap_token_in = _decode_call_address_arg(swap_data, 0)
 

--- a/tests/test_tempo.py
+++ b/tests/test_tempo.py
@@ -1308,6 +1308,7 @@ class TestCosignAsFeePayer:
         recipient: str,
         amount: int,
         memo: str | None = None,
+        padding: str = "",
     ) -> str:
         selector = TRANSFER_WITH_MEMO_SELECTOR if memo is not None else TRANSFER_SELECTOR
         to_padded = recipient[2:].lower().zfill(64)
@@ -1315,6 +1316,7 @@ class TestCosignAsFeePayer:
         data = f"0x{selector}{to_padded}{amount_padded}"
         if memo is not None:
             data += memo[2:] if memo.startswith("0x") else memo
+        data += padding
         return data
 
     def _encode_approve_data(self, spender: str, amount: int) -> str:
@@ -1483,6 +1485,27 @@ class TestCosignAsFeePayer:
 
         result = intent._cosign_as_fee_payer(raw_tx, request.currency, request=request)
         assert result.startswith("0x76")
+
+    def test_cosign_rejects_padded_transfer_calldata(self) -> None:
+        """Should reject padded calldata before fee payer signing."""
+        from pytempo import Call
+
+        intent = self._make_intent()
+        currency = "0x20c0000000000000000000000000000000000000"
+        recipient = "0x742d35Cc6634c0532925a3b844bC9e7595F8fE00"
+        raw_tx = self._build_client_tx(
+            calls=(
+                Call.create(
+                    to=currency,
+                    value=0,
+                    data=self._encode_transfer_data(recipient, 1000000, padding="01" * 5500),
+                ),
+            )
+        )
+        request = ChargeRequest(amount="1000000", currency=currency, recipient=recipient)
+
+        with pytest.raises(VerificationError, match="no matching payment call"):
+            intent._cosign_as_fee_payer(raw_tx, request.currency, request=request)
 
     def test_cosign_rejects_extra_trailing_call(self) -> None:
         """Should reject sponsored transactions with extra trailing calls."""
@@ -1718,6 +1741,7 @@ class TestValidateTransactionPayload:
         recipient: str,
         amount: int,
         memo: str | None = None,
+        padding: str = "",
     ) -> str:
         selector = TRANSFER_WITH_MEMO_SELECTOR if memo is not None else TRANSFER_SELECTOR
         to_padded = recipient[2:].lower().zfill(64)
@@ -1725,6 +1749,7 @@ class TestValidateTransactionPayload:
         data = f"0x{selector}{to_padded}{amount_padded}"
         if memo is not None:
             data += memo[2:] if memo.startswith("0x") else memo
+        data += padding
         return data
 
     def _build_0x78_envelope(
@@ -1733,13 +1758,14 @@ class TestValidateTransactionPayload:
         recipient: str = "0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
         amount: int = 1000000,
         memo: str | None = None,
+        padding: str = "",
     ) -> str:
         """Build a 0x78 fee payer envelope."""
         from pytempo import Call, TempoTransaction
 
         from mpp.methods.tempo.fee_payer_envelope import encode_fee_payer_envelope
 
-        transfer_data = self._encode_transfer_data(recipient, amount, memo)
+        transfer_data = self._encode_transfer_data(recipient, amount, memo, padding)
 
         tx = TempoTransaction.create(
             chain_id=42431,
@@ -1762,13 +1788,14 @@ class TestValidateTransactionPayload:
         recipient: str = "0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
         amount: int = 1000000,
         memo: str | None = None,
+        padding: str = "",
     ) -> str:
         """Build a standard 0x76 transaction."""
         import attrs
         from pytempo import Call, TempoTransaction
         from pytempo.models import Signature
 
-        transfer_data = self._encode_transfer_data(recipient, amount, memo)
+        transfer_data = self._encode_transfer_data(recipient, amount, memo, padding)
 
         tx = TempoTransaction.create(
             chain_id=42431,
@@ -1808,6 +1835,32 @@ class TestValidateTransactionPayload:
         sig = self._build_0x78_envelope(memo=memo)
 
         intent._validate_transaction_payload(sig, request)
+
+    def test_rejects_0x78_with_padded_transfer_calldata(self) -> None:
+        """Should reject ABI calldata with trailing bytes."""
+        intent = ChargeIntent(rpc_url="https://rpc.test")
+        request = ChargeRequest(
+            amount="1000000",
+            currency="0x20c0000000000000000000000000000000000000",
+            recipient="0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
+        )
+        sig = self._build_0x78_envelope(padding="01" * 5500)
+
+        with pytest.raises(VerificationError, match="no matching payment call"):
+            intent._validate_transaction_payload(sig, request)
+
+    def test_rejects_0x76_with_padded_transfer_calldata(self) -> None:
+        """Should reject padded calldata for standard Tempo transactions too."""
+        intent = ChargeIntent(rpc_url="https://rpc.test")
+        request = ChargeRequest(
+            amount="1000000",
+            currency="0x20c0000000000000000000000000000000000000",
+            recipient="0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
+        )
+        sig = self._build_0x76_tx(padding="01" * 5500)
+
+        with pytest.raises(VerificationError, match="no matching payment call"):
+            intent._validate_transaction_payload(sig, request)
 
     def test_rejects_0x78_with_wrong_amount(self) -> None:
         """Should reject a 0x78 envelope with mismatched amount."""
@@ -2388,6 +2441,17 @@ class TestMatchTransferCalldataWithMemo:
         )
         assert _match_transfer_calldata(calldata, request) is True
 
+    def test_memo_rejects_trailing_padding(self) -> None:
+        """transferWithMemo calldata must be exactly selector + 3 ABI words."""
+        request = self._make_request(memo=self.MEMO)
+        calldata = (
+            self._build_calldata(
+                TRANSFER_WITH_MEMO_SELECTOR, self.RECIPIENT, self.AMOUNT, self.MEMO
+            )
+            + "01"
+        )
+        assert _match_transfer_calldata(calldata, request) is False
+
     def test_memo_wrong_memo_value(self) -> None:
         """Wrong memo value should be rejected."""
         request = self._make_request(memo=self.MEMO)
@@ -2424,6 +2488,12 @@ class TestMatchTransferCalldataWithMemo:
         )
         assert _match_transfer_calldata(calldata_plain, request) is True
         assert _match_transfer_calldata(calldata_memo, request) is True
+
+    def test_no_memo_rejects_plain_transfer_trailing_padding(self) -> None:
+        """Plain transfer calldata must be exactly selector + 2 ABI words."""
+        request = self._make_request(memo=None)
+        calldata = self._build_calldata(TRANSFER_SELECTOR, self.RECIPIENT, self.AMOUNT) + "01"
+        assert _match_transfer_calldata(calldata, request) is False
 
     def test_no_memo_rejects_short_transfer_with_memo_calldata(self) -> None:
         """When no memo, truncated transferWithMemo calldata should still be rejected."""
@@ -3122,6 +3192,26 @@ class TestMatchSingleTransferCalldata:
             is True
         )
 
+    def test_memo_rejects_trailing_padding(self) -> None:
+        calldata = (
+            self._build_calldata(
+                TRANSFER_WITH_MEMO_SELECTOR,
+                self.RECIPIENT,
+                self.AMOUNT,
+                "ab" * 32,
+            )
+            + "01"
+        )
+        assert (
+            _match_single_transfer_calldata(
+                calldata,
+                self.RECIPIENT,
+                self.AMOUNT,
+                self.MEMO,
+            )
+            is False
+        )
+
     def test_no_memo_accepts_transfer_with_memo_selector(self) -> None:
         """When no memo expected, transferWithMemo calldata should be accepted."""
         calldata = self._build_calldata(
@@ -3140,6 +3230,10 @@ class TestMatchSingleTransferCalldata:
     def test_no_memo_accepts_plain_transfer(self) -> None:
         calldata = self._build_calldata(TRANSFER_SELECTOR, self.RECIPIENT, self.AMOUNT)
         assert _match_single_transfer_calldata(calldata, self.RECIPIENT, self.AMOUNT, None) is True
+
+    def test_no_memo_rejects_plain_transfer_trailing_padding(self) -> None:
+        calldata = self._build_calldata(TRANSFER_SELECTOR, self.RECIPIENT, self.AMOUNT) + "01"
+        assert _match_single_transfer_calldata(calldata, self.RECIPIENT, self.AMOUNT, None) is False
 
 
 class TestSplitLogMemoStrictness:


### PR DESCRIPTION
## Motivation

Fee-payer sponsorship validates transfer calldata before co-signing. ABI decoding can ignore trailing bytes, so padded calls must be rejected by exact calldata length before the server signs.

## Summary

- Require exact calldata lengths for Tempo transfer and transferWithMemo calls.
- Require exact approve and swap prefix lengths in fee-payer call validation.
- Add padded calldata regression coverage for fee-payer and transaction payload validation.

## Key design considerations

- Keep validation centralized in the existing normalized call matching path.
- Preserve support for client attribution memos by accepting exact-length transferWithMemo calls when no server memo is required.