### PR TITLE
feat: add hint field to PaymentError problem details

### DIFF
--- a/.changelog/error-hints.md
+++ b/.changelog/error-hints.md
@@ -1,0 +1,5 @@
+---
+pympp: minor
+---
+
+Add `hint` field to `PaymentError` problem details. `PaymentRequiredError`, `MalformedCredentialError`, and `PaymentMethodUnsupportedError` now include a default hint pointing users to wallet documentation.

--- a/src/mpp/errors.py
+++ b/src/mpp/errors.py
@@ -12,6 +12,22 @@ from typing import Any
 _BASE_URI = "https://paymentauth.org/problems"
 
 
+class Hints:
+    """Default hint messages for payment errors."""
+
+    payment_required = (
+        "Use a supported wallet to pay for this resource using one of the supported "
+        "payment methods returned in the WWW-Authenticate header. "
+        "See https://mpp.dev/tools/wallet.md"
+    )
+    malformed_credential = (
+        "Use a supported wallet to construct valid credentials for one of the supported "
+        "payment methods returned in the WWW-Authenticate header. "
+        "See https://mpp.dev/tools/wallet.md"
+    )
+    method_unsupported = payment_required
+
+
 def _to_slug(name: str) -> str:
     """CamelCaseError → kebab-case slug (e.g. InvalidPayloadError → invalid-payload)."""
     name = name.removesuffix("Error")
@@ -29,6 +45,7 @@ class PaymentError(Exception):
 
     status: int = 402
     title: str = "Payment Error"
+    hint: str | None = None
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)
@@ -49,11 +66,15 @@ class PaymentError(Exception):
         }
         if challenge_id is not None:
             details["challengeId"] = challenge_id
+        if self.hint is not None:
+            details["hint"] = self.hint
         return details
 
 
 class PaymentRequiredError(PaymentError):
     """No credential was provided but payment is required."""
+
+    hint = Hints.payment_required
 
     def __init__(self, realm: str | None = None, description: str | None = None) -> None:
         parts = ["Payment is required"]
@@ -66,6 +87,8 @@ class PaymentRequiredError(PaymentError):
 
 class MalformedCredentialError(PaymentError):
     """Credential is malformed (invalid base64url, bad JSON structure)."""
+
+    hint = Hints.malformed_credential
 
     def __init__(self, reason: str | None = None) -> None:
         msg = f"Credential is malformed: {reason}." if reason else "Credential is malformed."
@@ -135,6 +158,7 @@ class PaymentMethodUnsupportedError(PaymentError):
     status = 400
     type = f"{_BASE_URI}/method-unsupported"
     title = "Method Unsupported"
+    hint = Hints.method_unsupported
 
     def __init__(self, method: str | None = None) -> None:
         msg = (

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -50,6 +50,19 @@ class TestToProblemDetails:
         with_cid = err.to_problem_details(challenge_id="ch-1")
         assert set(with_cid.keys()) == {"type", "title", "status", "detail", "challengeId"}
 
+    def test_hint_included_when_present(self) -> None:
+        """to_problem_details() should include hint when the error class defines one."""
+        err = PaymentRequiredError()
+        details = err.to_problem_details()
+        assert "hint" in details
+        assert "wallet" in details["hint"].lower()
+
+    def test_hint_excluded_when_none(self) -> None:
+        """to_problem_details() should not include hint when not set."""
+        err = PaymentError("test")
+        details = err.to_problem_details()
+        assert "hint" not in details
+
 
 class TestAutoSlug:
     @pytest.mark.parametrize(
@@ -177,6 +190,49 @@ class TestSubclassInstantiation:
     def test_payment_action_required_no_reason(self) -> None:
         err = PaymentActionRequiredError()
         assert "requires action" in str(err)
+
+
+class TestHintDefaults:
+    def test_payment_required_has_wallet_hint(self) -> None:
+        err = PaymentRequiredError()
+        details = err.to_problem_details()
+        assert details["hint"] == (
+            "Use a supported wallet to pay for this resource using one of the supported "
+            "payment methods returned in the WWW-Authenticate header. "
+            "See https://mpp.dev/tools/wallet.md"
+        )
+
+    def test_malformed_credential_has_hint(self) -> None:
+        err = MalformedCredentialError()
+        details = err.to_problem_details()
+        assert details["hint"] == (
+            "Use a supported wallet to construct valid credentials for one of the supported "
+            "payment methods returned in the WWW-Authenticate header. "
+            "See https://mpp.dev/tools/wallet.md"
+        )
+
+    def test_method_unsupported_has_wallet_hint(self) -> None:
+        err = PaymentMethodUnsupportedError()
+        details = err.to_problem_details()
+        assert details["hint"] == (
+            "Use a supported wallet to pay for this resource using one of the supported "
+            "payment methods returned in the WWW-Authenticate header. "
+            "See https://mpp.dev/tools/wallet.md"
+        )
+
+    def test_other_errors_have_no_hint(self) -> None:
+        for cls in (
+            InvalidChallengeError,
+            VerificationFailedError,
+            PaymentExpiredError,
+            InvalidPayloadError,
+            BadRequestError,
+            PaymentInsufficientError,
+            PaymentActionRequiredError,
+        ):
+            err = cls()
+            details = err.to_problem_details()
+            assert "hint" not in details, f"{cls.__name__} should not have a hint"
 
 
 class TestSubclassProblemDetails:


### PR DESCRIPTION
Same as https://github.com/wevm/mppx/pull/600 but for our python SDK. Adds an optional `hint` to the problem details response body for `PaymentRequiredError`, `MalformedCredentialError`, and `PaymentMethodUnsupportedError`. I expect this to help an agent without prior context on MPP to better unblock themself.