### PR TITLE
Fix MCP payment error detection for current SDK

### DIFF
--- a/.changelog/safe-bees-bow.md
+++ b/.changelog/safe-bees-bow.md
@@ -1,0 +1,5 @@
+---
+pympp: patch
+---
+
+Fixed MCP payment error detection to support the current MCP SDK's `McpError` shape, where error code and data are nested under an `error` attribute rather than directly on the exception. Added helper functions `_error_code` and `_error_data` to extract these fields from both error shapes.

--- a/src/mpp/extensions/mcp/client.py
+++ b/src/mpp/extensions/mcp/client.py
@@ -62,16 +62,31 @@ class Method(Protocol):
         ...
 
 
+def _error_code(error: Exception) -> int | None:
+    code = getattr(error, "code", None)
+    if code is not None:
+        return code
+    nested = getattr(error, "error", None)
+    return getattr(nested, "code", None)
+
+
+def _error_data(error: Exception) -> Any:
+    data = getattr(error, "data", None)
+    if data is not None:
+        return data
+    nested = getattr(error, "error", None)
+    return getattr(nested, "data", None)
+
+
 def _is_payment_required_error(error: Exception) -> bool:
     """Check whether an MCP error is a -32042 payment required error.
 
     Distinguishes payment errors from other uses of -32042 (such as
     URL elicitation) by checking for a ``challenges`` array in ``error.data``.
     """
-    code = getattr(error, "code", None)
-    if code != CODE_PAYMENT_REQUIRED:
+    if _error_code(error) != CODE_PAYMENT_REQUIRED:
         return False
-    data = getattr(error, "data", None)
+    data = _error_data(error)
     if not isinstance(data, dict):
         return False
     challenges = data.get("challenges")
@@ -108,7 +123,7 @@ def _parse_challenge(raw_challenge: Any) -> MCPChallenge | None:
 
 def _extract_challenges(error: Exception) -> list[MCPChallenge]:
     """Extract valid payment challenges from a payment required error."""
-    data = getattr(error, "data", None)
+    data = _error_data(error)
     if not isinstance(data, dict):
         return []
 

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -43,6 +43,23 @@ class FakeMcpError(Exception):
 
 
 @dataclass
+class FakeMcpErrorData:
+    """Mimics current mcp.types.ErrorData."""
+
+    code: int
+    message: str = ""
+    data: Any = None
+
+
+class FakeCurrentMcpError(Exception):
+    """Mimics current mcp.shared.exceptions.McpError with nested ErrorData."""
+
+    def __init__(self, error: FakeMcpErrorData):
+        super().__init__(error.message)
+        self.error = error
+
+
+@dataclass
 class FakeMethod:
     """Fake payment method for testing."""
 
@@ -115,6 +132,29 @@ class TestIsPaymentRequiredError:
     def test_correct_error(self) -> None:
         err = FakeMcpError(-32042, data={"challenges": [_make_challenge_dict()]})
         assert _is_payment_required_error(err) is True
+
+    def test_current_sdk_nested_error_data(self) -> None:
+        err = FakeCurrentMcpError(
+            FakeMcpErrorData(
+                -32042,
+                data={"challenges": [_make_challenge_dict()]},
+            )
+        )
+        assert _is_payment_required_error(err) is True
+
+    def test_real_current_mcp_sdk_error_data(self) -> None:
+        exceptions = pytest.importorskip("mcp.shared.exceptions")
+        types = pytest.importorskip("mcp.types")
+        err = exceptions.McpError(
+            types.ErrorData(
+                code=-32042,
+                message="Payment Required",
+                data={"challenges": [_make_challenge_dict()]},
+            )
+        )
+
+        assert _is_payment_required_error(err) is True
+        assert _extract_challenges(err) == [_make_challenge()]
 
     def test_wrong_code(self) -> None:
         err = FakeMcpError(-32000, data={"challenges": [_make_challenge_dict()]})
@@ -246,6 +286,56 @@ class TestMcpClientPaidTool:
             # Verify retry included credential in meta
             retry_call_kwargs = session.call_tool.call_args_list[1]
             retry_meta = retry_call_kwargs.kwargs.get("meta") or retry_call_kwargs[1].get("meta")
+            assert META_CREDENTIAL in retry_meta
+        finally:
+            for mod_name, orig in original_modules.items():
+                if orig is None:
+                    sys.modules.pop(mod_name, None)
+                else:
+                    sys.modules[mod_name] = orig
+
+    @pytest.mark.asyncio
+    async def test_payment_flow_with_current_sdk_error_shape(self) -> None:
+        """Current mcp SDK stores ErrorData on McpError.error."""
+        session = AsyncMock()
+
+        import sys
+        from unittest.mock import MagicMock
+
+        mcp_mock = MagicMock()
+        mcp_mock.shared.exceptions.McpError = FakeCurrentMcpError
+        original_modules = {}
+        for mod_name in ["mcp", "mcp.shared", "mcp.shared.exceptions"]:
+            original_modules[mod_name] = sys.modules.get(mod_name)
+        sys.modules["mcp"] = mcp_mock
+        sys.modules["mcp.shared"] = mcp_mock.shared
+        sys.modules["mcp.shared.exceptions"] = mcp_mock.shared.exceptions
+
+        try:
+            payment_error = FakeCurrentMcpError(
+                FakeMcpErrorData(
+                    -32042,
+                    message="Payment Required",
+                    data={
+                        "httpStatus": 402,
+                        "challenges": [_make_challenge_dict()],
+                    },
+                )
+            )
+            retry_result = FakeCallToolResult(
+                content=[{"type": "text", "text": "premium result"}],
+                meta=_make_receipt_meta(),
+            )
+            session.call_tool = AsyncMock(side_effect=[payment_error, retry_result])
+
+            client = McpClient(session, methods=[FakeMethod()])
+            result = await client.call_tool("premium_tool", {"query": "test"})
+
+            assert result.content[0]["text"] == "premium result"
+            assert result.receipt is not None
+            assert result.receipt.reference == "0xtxhash"
+
+            retry_meta = session.call_tool.call_args_list[1].kwargs.get("meta", {})
             assert META_CREDENTIAL in retry_meta
         finally:
             for mod_name, orig in original_modules.items():

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -133,15 +133,6 @@ class TestIsPaymentRequiredError:
         err = FakeMcpError(-32042, data={"challenges": [_make_challenge_dict()]})
         assert _is_payment_required_error(err) is True
 
-    def test_current_sdk_nested_error_data(self) -> None:
-        err = FakeCurrentMcpError(
-            FakeMcpErrorData(
-                -32042,
-                data={"challenges": [_make_challenge_dict()]},
-            )
-        )
-        assert _is_payment_required_error(err) is True
-
     def test_real_current_mcp_sdk_error_data(self) -> None:
         exceptions = pytest.importorskip("mcp.shared.exceptions")
         types = pytest.importorskip("mcp.types")


### PR DESCRIPTION
## Summary

Fix MCP payment-required detection for current `mcp` SDK exceptions by reading `ErrorData` from `McpError.error` when top-level `code` and `data` attributes are absent.

The existing top-level shape is still supported, so this remains compatible with older/fake error objects used by the current tests.

## Root cause

`McpClient` checked `McpError.code` and `McpError.data`, but current `mcp.shared.exceptions.McpError` stores the `ErrorData` object at `McpError.error`. That made a real `-32042` payment-required tool error propagate instead of triggering the credential retry flow.

The bug was missed because existing MCP client tests mocked an older top-level `code`/`data` shape.

## Validation

- `/Users/parv/Documents/Codex/2026-07-02/wr/work/venv-pympp/bin/python -m pytest tests/test_mcp_client.py -q`
- `/Users/parv/Documents/Codex/2026-07-02/wr/work/venv-pympp/bin/python -m pytest tests/test_mcp.py tests/test_mcp_client.py -q`
- `/Users/parv/Documents/Codex/2026-07-02/wr/work/venv-pympp/bin/python -m ruff check src/mpp/extensions/mcp/client.py tests/test_mcp_client.py`
- Local Hermes-style HTTP + MCP smoke test passes with the patched checkout.