### PR TITLE
fix(client): handle multipart and streaming bodies on paid 402 retry

### DIFF
--- a/.changelog/multipart-retry-body.md
+++ b/.changelog/multipart-retry-body.md
@@ -1,0 +1,5 @@
+---
+pympp: patch
+---
+
+Handle multipart (`files=`) and streaming bodies on paid 402 retry. Multipart bodies are buffered and replayed identically; async generator bodies raise `PaymentError` before any I/O.

--- a/src/mpp/client/transport.py
+++ b/src/mpp/client/transport.py
@@ -17,6 +17,7 @@ import httpx
 
 from mpp import Challenge, Credential
 from mpp._parsing import ParseError
+from mpp.errors import PaymentError
 from mpp.events import (
     CHALLENGE_RECEIVED,
     CREDENTIAL_CREATED,
@@ -117,6 +118,25 @@ class PaymentTransport(httpx.AsyncBaseTransport):
 
     async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
         """Handle request, automatically retrying on 402 with credentials."""
+        # Async-generator bodies (content=async_gen()) produce an AsyncByteStream
+        # that is not also a SyncByteStream. They cannot be safely buffered for
+        # replay: the generator may be infinite, already partially consumed, or
+        # tied to a one-shot I/O source. Reject early so callers get a clear
+        # message instead of a silent empty body on the paid retry.
+        if isinstance(request.stream, httpx.AsyncByteStream) and not isinstance(
+            request.stream, httpx.SyncByteStream
+        ):
+            raise PaymentError(
+                "Streaming request bodies (async generators) are not supported "
+                "through the payment retry flow. Use a buffered body "
+                "(bytes, str, files=, or data=) instead."
+            )
+
+        # Buffer the request body before the first dispatch so it can be replayed
+        # on a paid 402 retry. Handles bytes bodies and multipart/files= bodies.
+        # After aread() the stream is replaced with a replayable ByteStream.
+        await request.aread()
+
         response = await self._inner.handle_async_request(request)
 
         if response.status_code != 402:
@@ -240,7 +260,7 @@ class PaymentTransport(httpx.AsyncBaseTransport):
             method=request.method,
             url=request.url,
             headers=headers,
-            stream=request.stream,
+            content=request.content,
             extensions=request.extensions,
         )
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -90,6 +90,166 @@ class TestPaymentTransport:
         method.create_credential.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_paid_retry_replays_request_body(self) -> None:
+        """The paid retry must carry the original bytes request body.
+
+        Regression: the retry previously reused the already-consumed request
+        stream, so a POST body was dropped on the (paying) retry.
+        """
+        challenge = Challenge(
+            id="test-id",
+            method="tempo",
+            intent="charge",
+            request={"amount": "1000"},
+        )
+        www_auth = challenge.to_www_authenticate("example.com")
+
+        inner = MockTransport(
+            [
+                httpx.Response(402, headers={"www-authenticate": www_auth}),
+                httpx.Response(200, content=b'{"data": "ok"}'),
+            ]
+        )
+        transport = PaymentTransport(methods=[MockMethod()], inner=inner)
+
+        body = b'{"prompt": "expensive question"}'
+        request = httpx.Request("POST", "https://example.com", content=body)
+        await transport.handle_async_request(request)
+
+        assert len(inner.requests) == 2
+        retry_request = inner.requests[1]
+        assert retry_request.content == body
+        assert retry_request.headers["content-length"] == str(len(body))
+
+    @pytest.mark.asyncio
+    async def test_paid_retry_replays_multipart_body(self) -> None:
+        """The paid retry must carry the original multipart (files=) body."""
+        challenge = Challenge(
+            id="test-id",
+            method="tempo",
+            intent="charge",
+            request={"amount": "1000"},
+        )
+        www_auth = challenge.to_www_authenticate("example.com")
+
+        inner = MockTransport(
+            [
+                httpx.Response(402, headers={"www-authenticate": www_auth}),
+                httpx.Response(200, content=b'{"data": "ok"}'),
+            ]
+        )
+        transport = PaymentTransport(methods=[MockMethod()], inner=inner)
+
+        file_content = b"hello from file"
+        request = httpx.Request(
+            "POST",
+            "https://example.com",
+            files={"upload": ("report.txt", file_content, "text/plain")},
+        )
+        await transport.handle_async_request(request)
+
+        assert len(inner.requests) == 2
+        initial_body = inner.requests[0].content
+        retry_body = inner.requests[1].content
+        assert retry_body == initial_body
+        assert b"hello from file" in retry_body
+        assert b"report.txt" in retry_body
+
+    @pytest.mark.asyncio
+    async def test_paid_retry_replays_put_body(self) -> None:
+        """The paid retry must carry the original body for PUT requests."""
+        challenge = Challenge(
+            id="test-id",
+            method="tempo",
+            intent="charge",
+            request={"amount": "1000"},
+        )
+        www_auth = challenge.to_www_authenticate("example.com")
+
+        inner = MockTransport(
+            [
+                httpx.Response(402, headers={"www-authenticate": www_auth}),
+                httpx.Response(200, content=b'{"updated": true}'),
+            ]
+        )
+        transport = PaymentTransport(methods=[MockMethod()], inner=inner)
+
+        body = b'{"name": "updated"}'
+        request = httpx.Request("PUT", "https://example.com/item/1", content=body)
+        await transport.handle_async_request(request)
+
+        assert len(inner.requests) == 2
+        retry_request = inner.requests[1]
+        assert retry_request.method == "PUT"
+        assert retry_request.content == body
+        assert retry_request.headers["content-length"] == str(len(body))
+
+    @pytest.mark.asyncio
+    async def test_paid_retry_replays_patch_body(self) -> None:
+        """The paid retry must carry the original body for PATCH requests."""
+        challenge = Challenge(
+            id="test-id",
+            method="tempo",
+            intent="charge",
+            request={"amount": "1000"},
+        )
+        www_auth = challenge.to_www_authenticate("example.com")
+
+        inner = MockTransport(
+            [
+                httpx.Response(402, headers={"www-authenticate": www_auth}),
+                httpx.Response(200, content=b'{"patched": true}'),
+            ]
+        )
+        transport = PaymentTransport(methods=[MockMethod()], inner=inner)
+
+        body = b'{"status": "active"}'
+        request = httpx.Request("PATCH", "https://example.com/item/1", content=body)
+        await transport.handle_async_request(request)
+
+        assert len(inner.requests) == 2
+        retry_request = inner.requests[1]
+        assert retry_request.method == "PATCH"
+        assert retry_request.content == body
+        assert retry_request.headers["content-length"] == str(len(body))
+
+    @pytest.mark.asyncio
+    async def test_paid_retry_raises_for_streaming_body(self) -> None:
+        """Should raise PaymentError upfront for async generator (streaming) bodies.
+
+        Streaming bodies cannot be reliably buffered and replayed: the generator
+        may be infinite, already partially consumed, or tied to a one-shot source.
+        A descriptive error is better than a silent empty body on the paid retry.
+        """
+        from mpp.errors import PaymentError
+
+        challenge = Challenge(
+            id="test-id",
+            method="tempo",
+            intent="charge",
+            request={"amount": "1000"},
+        )
+        www_auth = challenge.to_www_authenticate("example.com")
+
+        inner = MockTransport(
+            [
+                httpx.Response(402, headers={"www-authenticate": www_auth}),
+                httpx.Response(200, content=b'{"data": "ok"}'),
+            ]
+        )
+        transport = PaymentTransport(methods=[MockMethod()], inner=inner)
+
+        async def async_body_gen():
+            yield b"chunk1"
+            yield b"chunk2"
+
+        request = httpx.Request("POST", "https://example.com", content=async_body_gen())
+        with pytest.raises(PaymentError, match="Streaming request bodies"):
+            await transport.handle_async_request(request)
+
+        assert len(inner.requests) == 0
+
+    @pytest.mark.asyncio
     async def test_emits_client_payment_events(self) -> None:
         """Should emit mppx-compatible client payment lifecycle events."""
         events: list[str] = []


### PR DESCRIPTION
## Summary

This PR complements [#156](https://github.com/tempoxyz/pympp/pull/156) (bytes/`content=` body replay) and addresses the two body-type gaps that #156 does **not** cover.

### What #156 fixed
PR #156 by @Tleaoo fixes the core bug: `PaymentTransport` was reusing the already-consumed `request.stream` on 402 retry, so any POST/PUT/PATCH body was silently dropped. The fix is `await request.aread()` before dispatch and `content=request.content` (instead of `stream=request.stream`) on retry.

### What this PR adds on top

**1. Multipart / `files=` bodies (tested)**

`aread()` works for `MultipartStream` because it implements both `SyncByteStream` and `AsyncByteStream`. The full multipart-encoded bytes are buffered before the first dispatch, and the paid retry sends the identical payload.

New tests:
- `test_paid_retry_replays_multipart_body` — `files=` upload, verifies body and filename are present in the retry
- `test_paid_retry_replays_put_body` — PUT with a bytes body
- `test_paid_retry_replays_patch_body` — PATCH with a bytes body

Also includes `test_paid_retry_replays_request_body` (same as #156's test) so this branch is self-contained.

**2. Async generator bodies — explicit `PaymentError`**

`content=async_gen()` in httpx produces an `AsyncIteratorByteStream` which is `AsyncByteStream` but **not** `SyncByteStream`. Unlike `MultipartStream` and `ByteStream`, an async generator:
- may be infinite or tied to a one-shot I/O source
- may already be partially consumed before the transport receives it
- silently buffering it would break the streaming contract and could OOM

`PaymentTransport.handle_async_request` now detects this case before any I/O and raises `PaymentError` with a clear message directing callers to use a buffered body instead.

New test:
- `test_paid_retry_raises_for_streaming_body` — verifies `PaymentError` is raised immediately with no requests sent

### Detection logic

```python
if isinstance(request.stream, httpx.AsyncByteStream) and not isinstance(
    request.stream, httpx.SyncByteStream
):
    raise PaymentError("Streaming request bodies (async generators) are not supported ...")
```

`ByteStream` and `MultipartStream` are both Sync+Async so they pass through. Only `AsyncIteratorByteStream` (async generators) is async-only and is caught.

## Test plan

- [ ] All 28 `tests/test_client.py` tests pass (confirmed locally)
- [ ] No regressions in the rest of the test suite
- [ ] Multipart body is identical byte-for-byte on the initial and retry requests
- [ ] Async generator body raises `PaymentError` before any network I/O
