### PR TITLE
fix(client): mcp challenge metadata conversion

### DIFF
--- a/.changelog/mcp-challenge-core-metadata.md
+++ b/.changelog/mcp-challenge-core-metadata.md
@@ -1,0 +1,5 @@
+---
+pympp: patch
+---
+
+Preserved MCP challenge metadata when converting MCP challenges to core payment challenges.

--- a/src/mpp/extensions/mcp/types.py
+++ b/src/mpp/extensions/mcp/types.py
@@ -83,14 +83,24 @@ class MCPChallenge:
         )
 
     def to_core(self) -> Challenge:
-        """Convert to core Challenge type (loses realm, expires, description)."""
+        """Convert to core Challenge type, preserving MCP challenge metadata."""
+        import base64
+        import json
+
         from mpp import Challenge
+
+        request_json = json.dumps(self.request, separators=(",", ":"), sort_keys=True)
+        request_b64 = base64.urlsafe_b64encode(request_json.encode()).decode().rstrip("=")
 
         return Challenge(
             id=self.id,
             method=self.method,
             intent=self.intent,
             request=self.request,
+            realm=self.realm,
+            request_b64=request_b64,
+            expires=self.expires,
+            description=self.description,
             digest=self.digest,
             opaque=self.opaque,
         )

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -139,6 +139,10 @@ class TestMCPChallenge:
         assert core.method == "tempo"
         assert core.intent == "charge"
         assert core.request == {"amount": "1000"}
+        assert core.realm == "api.example.com"
+        assert core.expires == "2025-01-15T12:05:00Z"
+        assert core.description == "API call fee"
+        assert core.to_echo().request
 
     def test_to_core_preserves_digest_opaque(self) -> None:
         mcp_challenge = MCPChallenge(


### PR DESCRIPTION
## Summary
- preserve MCP `realm`, `expires`, `description`, and encoded request metadata when converting `MCPChallenge` to core `Challenge`
- add regression assertions for the conversion
- add one patch changelog fragment

## Validation
- `uv run ruff format --check src/mpp/extensions/mcp/types.py tests/test_mcp.py`
- `uv run --extra mcp --group dev pytest tests/test_mcp.py -q`
- `uv run --extra mcp --group dev ruff check .`
- `uv run --extra mcp --group dev pyright`