### PR TITLE
fix: preserve receipt subscription ids

### DIFF
--- a/.changelog/preserve-receipt-subscription-id.md
+++ b/.changelog/preserve-receipt-subscription-id.md
@@ -1,0 +1,5 @@
+---
+pympp: patch
+---
+
+Preserve `subscriptionId` when parsing and formatting payment receipts.

--- a/src/mpp/__init__.py
+++ b/src/mpp/__init__.py
@@ -380,6 +380,7 @@ class Receipt:
     reference: str
     method: str = "tempo"
     external_id: str | None = None
+    subscription_id: str | None = None
     extra: dict[str, Any] | None = None
 
     @classmethod
@@ -398,6 +399,7 @@ class Receipt:
         timestamp: datetime | None = None,
         method: str = "tempo",
         external_id: str | None = None,
+        subscription_id: str | None = None,
     ) -> Receipt:
         """Create a success receipt with current timestamp."""
         return cls(
@@ -406,6 +408,7 @@ class Receipt:
             reference=reference,
             method=method,
             external_id=external_id,
+            subscription_id=subscription_id,
         )
 
 

--- a/src/mpp/_parsing.py
+++ b/src/mpp/_parsing.py
@@ -325,6 +325,7 @@ def parse_payment_receipt(header: str) -> Receipt:
         reference=str(data["reference"]),
         method=method,
         external_id=str(data["externalId"]) if data.get("externalId") else None,
+        subscription_id=str(data["subscriptionId"]) if data.get("subscriptionId") else None,
         extra=extra if isinstance(extra, dict) else None,
     )
 
@@ -345,6 +346,8 @@ def format_payment_receipt(receipt: Receipt) -> str:
     payload["method"] = receipt.method
     if receipt.external_id:
         payload["externalId"] = receipt.external_id
+    if receipt.subscription_id:
+        payload["subscriptionId"] = receipt.subscription_id
     if receipt.extra:
         payload["extra"] = receipt.extra
     return _b64_encode(payload)

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -338,6 +338,7 @@ class TestReceipt:
             method="tempo",
             external_id="order-123",
             extra={"plan": "pro"},
+            subscription_id="sub_123",
         )
 
         header = receipt.to_payment_receipt()
@@ -346,6 +347,23 @@ class TestReceipt:
         assert parsed.method == "tempo"
         assert parsed.external_id == "order-123"
         assert parsed.extra == {"plan": "pro"}
+        assert parsed.subscription_id == "sub_123"
+
+    def test_parse_preserves_foreign_subscription_id(self) -> None:
+        payload = {
+            "status": "success",
+            "method": "tempo",
+            "timestamp": "2024-01-20T12:00:00Z",
+            "reference": "0xabc123def456",
+            "subscriptionId": "sub_123",
+        }
+        header = base64.urlsafe_b64encode(json.dumps(payload).encode()).decode().rstrip("=")
+
+        parsed = Receipt.from_payment_receipt(header)
+
+        assert parsed.subscription_id == "sub_123"
+        roundtripped = Receipt.from_payment_receipt(parsed.to_payment_receipt())
+        assert roundtripped.subscription_id == "sub_123"
 
     def test_parse_invalid_timestamp(self) -> None:
         payload = {


### PR DESCRIPTION
## Summary
- Add optional `Receipt.subscription_id` support for `subscriptionId` receipt metadata.
- Preserve `subscriptionId` when parsing receipts produced by another SDK and when formatting receipts back to `Payment-Receipt`.
- Add regression coverage for optional-field roundtrip and foreign receipt parsing.

This aligns pympp with the Rust SDK receipt behavior, where subscription receipts keep `subscriptionId` as a first-class optional field instead of silently dropping it.

## Tests
- `PYTHONPATH=/tmp/pympp-test-deps:src python3 -m pytest tests/test_parsing.py -q`
- `PYTHONPATH=/tmp/pympp-test-deps:src python3 -m ruff check src/mpp/__init__.py src/mpp/_parsing.py tests/test_parsing.py`
- `PYTHONPATH=/tmp/pympp-test-deps:src python3 -m py_compile src/mpp/__init__.py src/mpp/_parsing.py tests/test_parsing.py`
- `git diff --check`