### PR TITLE
ci: Add GitHub Actions scanner

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -24,12 +24,11 @@ jobs:
             -o "$HOME/.local/bin/changelogs"
           echo "d4168ee68b612224a26a39e86bfd2c923ac3dd2de12ee43d2bb65a5ea19df6b6  $HOME/.local/bin/changelogs" | sha256sum -c
           chmod +x "$HOME/.local/bin/changelogs"
-      - name: Install Claude CLI
-        run: npm install -g @anthropic-ai/claude-code@2.1.97
       - name: Generate changelog
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           BASE_REF: ${{ github.base_ref }}
+          CLAUDE: npx -y @anthropic-ai/claude-code@2.1.97 --bare -p
         run: |
           rm -rf .claude/
           CHANGED=$(git diff --name-only "origin/${BASE_REF}...HEAD")
@@ -38,7 +37,7 @@ jobs:
             echo "No code changes requiring changelog, skipping"
             exit 0
           fi
-          ~/.local/bin/changelogs add --ecosystem python --ai "claude --bare -p" --ref "origin/${BASE_REF}"
+          ~/.local/bin/changelogs add --ecosystem python --ai "$CLAUDE" --ref "origin/${BASE_REF}"
       - name: Commit changelog
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Add venv to PATH
         if: matrix.python-version == '3.12'
-        run: echo "$PWD/.venv/bin" >> $GITHUB_PATH
+        run: echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
 
       - name: Type check
         if: matrix.python-version == '3.12'
@@ -74,11 +74,11 @@ jobs:
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}
         run: |
-          COV_REPORTS="--cov-report=term-missing"
+          cov_reports=(--cov-report=term-missing)
           if [[ "$PYTHON_VERSION" == "3.12" ]]; then
-            COV_REPORTS="$COV_REPORTS --cov-report=xml:coverage.xml --cov-report=html:htmlcov"
+            cov_reports+=(--cov-report=xml:coverage.xml --cov-report=html:htmlcov)
           fi
-          uv run pytest -v --cov=mpp $COV_REPORTS --cov-fail-under=90
+          uv run pytest -v --cov=mpp "${cov_reports[@]}" --cov-fail-under=90
 
       - name: Upload coverage artifacts
         if: always() && matrix.python-version == '3.12'
@@ -115,7 +115,7 @@ jobs:
       - name: Resolve Tempo image digest
         id: tempo-digest
         run: |
-          digest=$(docker buildx imagetools inspect ghcr.io/tempoxyz/tempo:${TEMPO_TAG} --raw | sha256sum | cut -d' ' -f1)
+          digest=$(docker buildx imagetools inspect "ghcr.io/tempoxyz/tempo:${TEMPO_TAG}" --raw | sha256sum | cut -d' ' -f1)
           echo "digest=${digest}" >> "$GITHUB_OUTPUT"
 
       - name: Cache Tempo Docker image
@@ -132,8 +132,8 @@ jobs:
       - name: Pull and cache Tempo image
         if: steps.docker-cache.outputs.cache-hit != 'true'
         run: |
-          docker pull ghcr.io/tempoxyz/tempo:${TEMPO_TAG}
-          docker save ghcr.io/tempoxyz/tempo:${TEMPO_TAG} -o /tmp/tempo-image.tar
+          docker pull "ghcr.io/tempoxyz/tempo:${TEMPO_TAG}"
+          docker save "ghcr.io/tempoxyz/tempo:${TEMPO_TAG}" -o /tmp/tempo-image.tar
 
       - name: Start Tempo devnet and Redis
         run: docker compose up -d --wait

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   conformance-policy:
-    uses: tempoxyz/mpp-tools/.github/workflows/sdk-conformance-policy.yml@main
+    uses: tempoxyz/mpp-tools/.github/workflows/sdk-conformance-policy.yml@924710544d534332220d164bfa5747340bb85f93
     with:
       protocol-paths: |
         src/**
@@ -31,7 +31,7 @@ jobs:
 
   conformance:
     needs: conformance-policy
-    uses: tempoxyz/mpp-tools/.github/workflows/sdk-conformance.yml@main
+    uses: tempoxyz/mpp-tools/.github/workflows/sdk-conformance.yml@924710544d534332220d164bfa5747340bb85f93
     with:
       adapter: python
       conformance-ref: ${{ needs.conformance-policy.outputs.conformance_ref }}

--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -38,7 +38,8 @@ jobs:
           echo "$EVENTS_KEY" > "$RUNNER_TEMP/key"
           echo "$EVENTS_CERT" > "$RUNNER_TEMP/cert"
 
-          curl -sf -o /dev/null -X POST ${EVENTS_ARGS} \
+          read -r -a events_args <<< "${EVENTS_ARGS:-}"
+          curl -sf -o /dev/null -X POST "${events_args[@]}" \
             -H "Content-Type: application/json" \
             --key "$RUNNER_TEMP/key" \
             --cert "$RUNNER_TEMP/cert" \

--- a/.github/workflows/scan-github-actions.yml
+++ b/.github/workflows/scan-github-actions.yml
@@ -13,12 +13,12 @@ on:
   schedule:
     - cron: "19 7 * * 1"
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   scan:
     name: Scan GitHub Actions
     uses: tempoxyz/gh-actions/.github/workflows/scan-github-actions.yml@512158c4e90e42eef8aa7fc3fc3186a79b5b4648
     permissions:
+      actions: read
       contents: read

--- a/.github/workflows/scan-github-actions.yml
+++ b/.github/workflows/scan-github-actions.yml
@@ -1,0 +1,24 @@
+name: Scan GitHub Actions
+
+on:
+  pull_request:
+    paths:
+      - ".github/**"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/**"
+  workflow_dispatch:
+  schedule:
+    - cron: "19 7 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    name: Scan GitHub Actions
+    uses: tempoxyz/gh-actions/.github/workflows/scan-github-actions.yml@512158c4e90e42eef8aa7fc3fc3186a79b5b4648
+    permissions:
+      contents: read


### PR DESCRIPTION
## Summary
- add the pinned `tempoxyz/gh-actions` GitHub Actions scanner workflow
- fix existing zizmor/actionlint findings without adding ignore baselines
- pin mutable reusable workflow/action refs and move unsafe template expressions through env where needed

Prompted by: @0xalpharush

## Validation
- `uvx zizmor --offline .github/workflows`: passes locally
- `actionlint`: passes locally
