### PR TITLE
refactor(ci): use shared PR audit workflow

### DIFF
--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -31,7 +31,7 @@ jobs:
       contents: read
       pull-requests: read
       statuses: write
-    uses: tempoxyz/gh-actions/.github/workflows/pr-audit.yml@183a02178c660ce295e9a262edc5857cb7135f06
+    uses: tempoxyz/gh-actions/.github/workflows/pr-audit.yml@dd1014bf8244fded7a501e701cafab240a4f9f0e
     secrets:
       EVENTS_KEY: ${{ secrets.EVENTS_KEY }}
       EVENTS_CERT: ${{ secrets.EVENTS_CERT }}

--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -29,7 +29,7 @@ jobs:
     needs: authorize
     permissions:
       contents: read
-    uses: tempoxyz/gh-actions/.github/workflows/pr-audit.yml@98b1081dcf34361b576aca2ab3041772708582ef
+    uses: tempoxyz/gh-actions/.github/workflows/pr-audit.yml@483bda4a2a4b5e04a51edff03768c1590d271f80
     secrets:
       EVENTS_KEY: ${{ secrets.EVENTS_KEY }}
       EVENTS_CERT: ${{ secrets.EVENTS_CERT }}

--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -29,6 +29,8 @@ jobs:
     needs: authorize
     permissions:
       contents: read
+      pull-requests: read
+      statuses: write
     uses: tempoxyz/gh-actions/.github/workflows/pr-audit.yml@183a02178c660ce295e9a262edc5857cb7135f06
     secrets:
       EVENTS_KEY: ${{ secrets.EVENTS_KEY }}

--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -29,7 +29,7 @@ jobs:
     needs: authorize
     permissions:
       contents: read
-    uses: tempoxyz/gh-actions/.github/workflows/pr-audit.yml@483bda4a2a4b5e04a51edff03768c1590d271f80
+    uses: tempoxyz/gh-actions/.github/workflows/pr-audit.yml@183a02178c660ce295e9a262edc5857cb7135f06
     secrets:
       EVENTS_KEY: ${{ secrets.EVENTS_KEY }}
       EVENTS_CERT: ${{ secrets.EVENTS_CERT }}

--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -4,13 +4,14 @@ on:
   pull_request:
     types: [labeled]
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
-  publish:
+  authorize:
+    if: github.event.label.name == 'cyclops'
     runs-on: ubuntu-latest
-    if: github.event.action == 'labeled' && github.event.label.name == 'cyclops'
+    permissions:
+      contents: read
     steps:
       - name: Check admin permission
         env:
@@ -24,30 +25,12 @@ jobs:
             exit 1
           fi
 
-      - name: Publish event
-        env:
-          EVENTS_KEY: ${{ secrets.EVENTS_KEY }}
-          EVENTS_CERT: ${{ secrets.EVENTS_CERT }}
-          EVENTS_ARGS: ${{ secrets.EVENTS_ARGS }}
-          REPOSITORY: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          PR_SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          set -euo pipefail
-
-          echo "$EVENTS_KEY" > "$RUNNER_TEMP/key"
-          echo "$EVENTS_CERT" > "$RUNNER_TEMP/cert"
-
-          read -r -a events_args <<< "${EVENTS_ARGS:-}"
-          curl -sf -o /dev/null -X POST "${events_args[@]}" \
-            -H "Content-Type: application/json" \
-            --key "$RUNNER_TEMP/key" \
-            --cert "$RUNNER_TEMP/cert" \
-            -d "{
-              \"repository\": \"${REPOSITORY}\",
-              \"event\": \"pr_audit\",
-              \"data\": {
-                \"pr_number\": ${PR_NUMBER},
-                \"sha\": \"${PR_SHA}\"
-              }
-            }"
+  pr-audit:
+    needs: authorize
+    permissions:
+      contents: read
+    uses: tempoxyz/gh-actions/.github/workflows/pr-audit.yml@98b1081dcf34361b576aca2ab3041772708582ef
+    secrets:
+      EVENTS_KEY: ${{ secrets.EVENTS_KEY }}
+      EVENTS_CERT: ${{ secrets.EVENTS_CERT }}
+      EVENTS_ARGS: ${{ secrets.EVENTS_ARGS }}

--- a/.github/workflows/scan-github-actions.yml
+++ b/.github/workflows/scan-github-actions.yml
@@ -18,7 +18,7 @@ permissions: {}
 jobs:
   scan:
     name: Scan GitHub Actions
-    uses: tempoxyz/gh-actions/.github/workflows/scan-github-actions.yml@512158c4e90e42eef8aa7fc3fc3186a79b5b4648
+    uses: tempoxyz/gh-actions/.github/workflows/scan-github-actions.yml@5d3a903b51ce8d1f6d363d1c59d7243ecf80f026
     permissions:
       actions: read
       contents: read

--- a/.pinact.yaml
+++ b/.pinact.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/suzuki-shunsuke/pinact/refs/heads/main/json-schema/pinact.json
+# pinact - https://github.com/suzuki-shunsuke/pinact
+version: 3
+# min_age:
+#   value: 7      # threshold in days
+#   always: true  # also run the passive audit on every `pinact run` (extra GitHub API calls)
+# separator: "  # "
+# files:
+#   - pattern: action.yaml
+#   - pattern: */action.yaml
+
+rules:
+  # tempoxyz/gh-actions has no release version to record in a comment.
+  - ignore: true
+    conditions:
+      - expr: |
+          ActionName matches "tempoxyz/gh-actions/.*"

--- a/.pinact.yaml
+++ b/.pinact.yaml
@@ -1,13 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/suzuki-shunsuke/pinact/refs/heads/main/json-schema/pinact.json
-# pinact - https://github.com/suzuki-shunsuke/pinact
 version: 3
-# min_age:
-#   value: 7      # threshold in days
-#   always: true  # also run the passive audit on every `pinact run` (extra GitHub API calls)
-# separator: "  # "
-# files:
-#   - pattern: action.yaml
-#   - pattern: */action.yaml
 
 rules:
   # tempoxyz/gh-actions has no release version to record in a comment.


### PR DESCRIPTION
## Summary

- Publish PR audit events through the shared `pr-audit` workflow.
- Preserve the existing admin-only trigger check.
- Pin the reusable workflow to a full commit SHA and narrow workflow permissions.

## Validation

- `actionlint .github/workflows/pr-audit.yml`

Part of OSS-541