### PR TITLE
Add HTTP payment response hooks

### DIFF
--- a/.changelog/http-response-hooks.md
+++ b/.changelog/http-response-hooks.md
@@ -1,0 +1,5 @@
+---
+pympp: minor
+---
+
+Added optional sync and async post-payment HTTP response hooks for payment methods.

--- a/src/mpp/client/sync_transport.py
+++ b/src/mpp/client/sync_transport.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 import httpx
@@ -17,12 +18,15 @@ from mpp.events import (
     EventHandler,
     Unsubscribe,
 )
-from mpp.runtime import Method, PaymentRuntime
+from mpp.runtime import Method, PaymentRuntime, SyncHttpResponseContext
 
 from .transport import (
+    _REFETCHED,
+    _bind_response_request,
     _challenge_is_expired,
     _challenged_request,
     _client_payment_failed_payload,
+    _copy_request,
     _payment_challenges,
 )
 
@@ -163,13 +167,7 @@ class SyncPaymentTransport(httpx.BaseTransport):
 
         headers = httpx.Headers(challenged_request.headers)
         headers["Authorization"] = credential.to_authorization()
-        retry_request = httpx.Request(
-            method=challenged_request.method,
-            url=challenged_request.url,
-            headers=headers,
-            content=challenged_request.content,
-            extensions=challenged_request.extensions,
-        )
+        retry_request = _copy_request(challenged_request, headers=headers)
 
         try:
             payment_response = self._inner.handle_request(retry_request)
@@ -188,19 +186,115 @@ class SyncPaymentTransport(httpx.BaseTransport):
             )
             raise
 
-        if payment_response.is_success:
+        _bind_response_request(payment_response, challenged_request)
+
+        event_emitted = False
+
+        def emit_payment_response(event_response: httpx.Response) -> None:
+            nonlocal event_emitted
+            if event_emitted or not event_response.is_success:
+                return
+            event_emitted = True
+            _bind_response_request(event_response, challenged_request)
             self._runtime.emit_event_sync(
                 PAYMENT_RESPONSE,
                 {
                     "challenge": challenge,
+                    "challenges": challenges,
                     "credential": credential,
                     "method": method,
+                    "request": challenged_request,
+                    "response": event_response,
+                    "protocol": "http",
+                },
+            )
+
+        def create_credential(context: object):
+            return self._runtime.create_credential_sync(
+                challenge,
+                method,
+                context=context,
+                event_payload={
+                    "challenges": challenges,
                     "request": challenged_request,
                     "response": payment_response,
                     "protocol": "http",
                 },
             )
-        return payment_response
+
+        def send(request: httpx.Request) -> httpx.Response:
+            if not self._runtime.allows_http_payment(request.url):
+                raise PaymentError("HTTP response hook request is outside allowed origins")
+            for key, value in challenged_request.extensions.items():
+                request.extensions.setdefault(key, value)
+            hook_response = self._inner.handle_request(request)
+            _bind_response_request(hook_response, request)
+            return hook_response
+
+        refetch: Callable[[], httpx.Response] | None
+        refetched_response: httpx.Response | None = None
+        if not challenged_request.extensions.get(_REFETCHED):
+            refetched = False
+
+            def do_refetch() -> httpx.Response:
+                nonlocal event_emitted, refetched, refetched_response
+                if refetched:
+                    raise PaymentError("Payment response can only be refetched once")
+                refetched = True
+                emit_payment_response(payment_response)
+                event_emitted = True
+                payment_response.close()
+                extensions = dict(challenged_request.extensions)
+                extensions[_REFETCHED] = True
+                refetched_response = self.handle_request(
+                    _copy_request(challenged_request, extensions=extensions)
+                )
+                return refetched_response
+
+            refetch = do_refetch
+        else:
+            refetch = None
+
+        final_response: httpx.Response | None = None
+        try:
+            final_response = self._runtime.handle_http_response(
+                method,
+                SyncHttpResponseContext(
+                    challenge=challenge,
+                    credential=credential,
+                    request=challenged_request,
+                    response=payment_response,
+                    send=send,
+                    refetch=refetch,
+                    create_credential=create_credential,
+                    run_sync=self._runtime.run_sync,
+                ),
+            )
+            emit_payment_response(final_response)
+        except BaseException as error:
+            closed: set[int] = set()
+            for candidate in (final_response, refetched_response, payment_response):
+                if candidate is not None and id(candidate) not in closed:
+                    closed.add(id(candidate))
+                    candidate.close()
+            if isinstance(error, Exception):
+                self._runtime.emit_event_sync(
+                    PAYMENT_FAILED,
+                    _client_payment_failed_payload(
+                        challenge=challenge,
+                        challenges=challenges,
+                        credential=credential,
+                        error=error,
+                        method=method,
+                        request=challenged_request,
+                        response=payment_response,
+                    ),
+                )
+            raise
+
+        assert final_response is not None
+        _bind_response_request(final_response, challenged_request)
+        return final_response
 
     def close(self) -> None:
         """Close the inner transport."""

--- a/src/mpp/client/transport.py
+++ b/src/mpp/client/transport.py
@@ -10,6 +10,7 @@ Implements automatic 402 Payment Required handling by:
 from __future__ import annotations
 
 import logging
+from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
@@ -28,9 +29,10 @@ from mpp.events import (
     EventHandler,
     Unsubscribe,
 )
-from mpp.runtime import Method, PaymentRuntime
+from mpp.runtime import AsyncHttpResponseContext, Method, PaymentRuntime
 
 logger = logging.getLogger(__name__)
+_REFETCHED = "mpp.response_hook_refetched"
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -65,6 +67,28 @@ def _challenged_request(
         return response.request
     except RuntimeError:
         return fallback
+
+
+def _copy_request(
+    request: httpx.Request,
+    *,
+    headers: httpx.Headers | None = None,
+    extensions: dict[str, Any] | None = None,
+) -> httpx.Request:
+    return httpx.Request(
+        method=request.method,
+        url=request.url,
+        headers=request.headers if headers is None else headers,
+        content=request.content,
+        extensions=request.extensions if extensions is None else extensions,
+    )
+
+
+def _bind_response_request(response: httpx.Response, request: httpx.Request) -> None:
+    try:
+        _ = response.request
+    except RuntimeError:
+        response.request = request
 
 
 def _payment_challenges(response: httpx.Response) -> tuple[list[Challenge], ParseError | None]:
@@ -142,7 +166,7 @@ class PaymentTransport(httpx.AsyncBaseTransport):
         return self.on(CREDENTIAL_CREATED, handler)
 
     def on_payment_response(self, handler: EventHandler) -> Unsubscribe:
-        """Register a handler for successful paid retry responses."""
+        """Register a handler for successful payment-aware responses."""
         return self.on(PAYMENT_RESPONSE, handler)
 
     def on_payment_failed(self, handler: EventHandler) -> Unsubscribe:
@@ -261,13 +285,7 @@ class PaymentTransport(httpx.AsyncBaseTransport):
         headers = httpx.Headers(challenged_request.headers)
         headers["Authorization"] = auth_header
 
-        retry_request = httpx.Request(
-            method=challenged_request.method,
-            url=challenged_request.url,
-            headers=headers,
-            content=challenged_request.content,
-            extensions=challenged_request.extensions,
-        )
+        retry_request = _copy_request(challenged_request, headers=headers)
 
         try:
             payment_response = await self._inner.handle_async_request(retry_request)
@@ -286,20 +304,114 @@ class PaymentTransport(httpx.AsyncBaseTransport):
             )
             raise
 
-        if payment_response.is_success:
+        _bind_response_request(payment_response, challenged_request)
+
+        event_emitted = False
+
+        async def emit_payment_response(event_response: httpx.Response) -> None:
+            nonlocal event_emitted
+            if event_emitted or not event_response.is_success:
+                return
+            event_emitted = True
+            _bind_response_request(event_response, challenged_request)
             await self._runtime.emit_event(
                 PAYMENT_RESPONSE,
                 {
                     "challenge": challenge,
+                    "challenges": challenges,
                     "credential": credential,
                     "method": matched_method,
+                    "request": challenged_request,
+                    "response": event_response,
+                    "protocol": "http",
+                },
+            )
+
+        async def create_credential(context: Any) -> Credential:
+            return await self._runtime.create_credential(
+                challenge,
+                matched_method,
+                context=context,
+                event_payload={
+                    "challenges": challenges,
                     "request": challenged_request,
                     "response": payment_response,
                     "protocol": "http",
                 },
             )
 
-        return payment_response
+        async def send(request: httpx.Request) -> httpx.Response:
+            if not self._runtime.allows_http_payment(request.url):
+                raise PaymentError("HTTP response hook request is outside allowed origins")
+            for key, value in challenged_request.extensions.items():
+                request.extensions.setdefault(key, value)
+            hook_response = await self._inner.handle_async_request(request)
+            _bind_response_request(hook_response, request)
+            return hook_response
+
+        refetch: Callable[[], Awaitable[httpx.Response]] | None
+        refetched_response: httpx.Response | None = None
+        if not challenged_request.extensions.get(_REFETCHED):
+            refetched = False
+
+            async def do_refetch() -> httpx.Response:
+                nonlocal event_emitted, refetched, refetched_response
+                if refetched:
+                    raise PaymentError("Payment response can only be refetched once")
+                refetched = True
+                await emit_payment_response(payment_response)
+                event_emitted = True
+                await payment_response.aclose()
+                extensions = dict(challenged_request.extensions)
+                extensions[_REFETCHED] = True
+                refetched_response = await self.handle_async_request(
+                    _copy_request(challenged_request, extensions=extensions)
+                )
+                return refetched_response
+
+            refetch = do_refetch
+        else:
+            refetch = None
+
+        final_response: httpx.Response | None = None
+        try:
+            final_response = await self._runtime.handle_async_http_response(
+                matched_method,
+                AsyncHttpResponseContext(
+                    challenge=challenge,
+                    credential=credential,
+                    request=challenged_request,
+                    response=payment_response,
+                    send=send,
+                    refetch=refetch,
+                    create_credential=create_credential,
+                ),
+            )
+            await emit_payment_response(final_response)
+        except BaseException as error:
+            closed: set[int] = set()
+            for candidate in (final_response, refetched_response, payment_response):
+                if candidate is not None and id(candidate) not in closed:
+                    closed.add(id(candidate))
+                    await candidate.aclose()
+            if isinstance(error, Exception):
+                await self._runtime.emit_event(
+                    PAYMENT_FAILED,
+                    _client_payment_failed_payload(
+                        challenge=challenge,
+                        challenges=challenges,
+                        credential=credential,
+                        error=error,
+                        method=matched_method,
+                        request=challenged_request,
+                        response=payment_response,
+                    ),
+                )
+            raise
+
+        assert final_response is not None
+        _bind_response_request(final_response, challenged_request)
+        return final_response
 
     async def aclose(self) -> None:
         """Close the inner transport."""
@@ -340,7 +452,7 @@ class Client:
         return self.on(CREDENTIAL_CREATED, handler)
 
     def on_payment_response(self, handler: EventHandler) -> Unsubscribe:
-        """Register a handler for successful paid retry responses."""
+        """Register a handler for successful payment-aware responses."""
         return self.on(PAYMENT_RESPONSE, handler)
 
     def on_payment_failed(self, handler: EventHandler) -> Unsubscribe:

--- a/src/mpp/events.py
+++ b/src/mpp/events.py
@@ -7,7 +7,7 @@ import logging
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import TYPE_CHECKING, Any, Final, Literal, TypedDict, overload
+from typing import TYPE_CHECKING, Any, Final, Literal, NotRequired, TypedDict, overload
 
 if TYPE_CHECKING:
     import httpx
@@ -60,6 +60,7 @@ class ClientChallengeReceivedPayload(TypedDict):
     method: Any
     request: httpx.Request
     response: httpx.Response
+    context: NotRequired[Any]
 
 
 class ClientCredentialCreatedPayload(ClientChallengeReceivedPayload):

--- a/src/mpp/runtime.py
+++ b/src/mpp/runtime.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 import threading
 from contextvars import ContextVar, copy_context
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Protocol, TypeVar, runtime_checkable
 from urllib.parse import urlparse
 
@@ -21,16 +23,17 @@ from mpp.events import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Coroutine, Sequence
+    from collections.abc import Awaitable, Callable, Coroutine, Sequence
 
     from mpp.client import PaymentTransport, SyncPaymentTransport
 
 _T = TypeVar("_T")
+_CONTEXT_UNSET = object()
 _PAYMENT_FLOW_ACTIVE: ContextVar[bool] = ContextVar("mpp_payment_flow_active", default=False)
 
 
 def payment_flow_active() -> bool:
-    """Return whether the current context is creating a payment credential."""
+    """Return whether the current context is handling a payment flow."""
     return _PAYMENT_FLOW_ACTIVE.get()
 
 
@@ -43,6 +46,47 @@ class Method(Protocol):
     async def create_credential(self, challenge: Challenge) -> Credential:
         """Create a credential to satisfy the given challenge."""
         ...
+
+
+@dataclass(frozen=True, slots=True)
+class AsyncHttpResponseContext:
+    """Context passed to an async method-specific HTTP response hook.
+
+    A hook returning a replacement response owns the original response. It
+    must either close it or delegate its stream and close it with the wrapper.
+    ``refetch`` is available only once and closes the original response. Close
+    non-streaming responses before using ``send`` so the connection is free.
+    Streaming hooks need another connection while the source remains open.
+    """
+
+    challenge: Challenge
+    credential: Credential
+    request: httpx.Request
+    response: httpx.Response
+    send: Callable[[httpx.Request], Awaitable[httpx.Response]]
+    refetch: Callable[[], Awaitable[httpx.Response]] | None
+    create_credential: Callable[[Any], Awaitable[Credential]]
+
+
+@dataclass(frozen=True, slots=True)
+class SyncHttpResponseContext:
+    """Context passed to a sync method-specific HTTP response hook.
+
+    A hook returning a replacement response owns the original response. It
+    must either close it or delegate its stream and close it with the wrapper.
+    ``refetch`` is available only once and closes the original response. Close
+    non-streaming responses before using ``send`` so the connection is free.
+    Streaming hooks need another connection while the source remains open.
+    """
+
+    challenge: Challenge
+    credential: Credential
+    request: httpx.Request
+    response: httpx.Response
+    send: Callable[[httpx.Request], httpx.Response]
+    refetch: Callable[[], httpx.Response] | None
+    create_credential: Callable[[Any], Credential]
+    run_sync: Callable[[Coroutine[Any, Any, Any]], Any]
 
 
 class _BoundSendTransport(httpx.AsyncBaseTransport):
@@ -290,6 +334,44 @@ class PaymentRuntime:
         transport = _BoundSyncSendTransport(send, args, dict(kwargs))
         return self.sync_payment_transport(inner=transport).handle_request(request)
 
+    async def handle_async_http_response(
+        self,
+        method: Method,
+        context: AsyncHttpResponseContext,
+    ) -> httpx.Response:
+        """Run an optional method-specific async response hook."""
+        handler = getattr(method, "handle_async_http_response", None)
+        if handler is None:
+            return context.response
+        token = _PAYMENT_FLOW_ACTIVE.set(True)
+        try:
+            result = handler(context)
+            if inspect.isawaitable(result):
+                result = await result
+        finally:
+            _PAYMENT_FLOW_ACTIVE.reset(token)
+        if not isinstance(result, httpx.Response):
+            raise TypeError("handle_async_http_response must return an httpx.Response")
+        return result
+
+    def handle_http_response(
+        self,
+        method: Method,
+        context: SyncHttpResponseContext,
+    ) -> httpx.Response:
+        """Run an optional method-specific synchronous response hook."""
+        handler = getattr(method, "handle_http_response", None)
+        if handler is None:
+            return context.response
+        token = _PAYMENT_FLOW_ACTIVE.set(True)
+        try:
+            result = handler(context)
+        finally:
+            _PAYMENT_FLOW_ACTIVE.reset(token)
+        if not isinstance(result, httpx.Response):
+            raise TypeError("handle_http_response must return an httpx.Response")
+        return result
+
     async def call_mcp_tool(
         self,
         call_tool: Any,
@@ -448,9 +530,15 @@ class PaymentRuntime:
         method: Method,
         *,
         event_payload: dict[str, Any] | None = None,
+        context: Any = _CONTEXT_UNSET,
     ) -> Credential:
         """Create a credential on the caller event loop."""
-        return await self._create_credential(challenge, method, event_payload=event_payload)
+        return await self._create_credential(
+            challenge,
+            method,
+            event_payload=event_payload,
+            context=context,
+        )
 
     def create_credential_sync(
         self,
@@ -458,11 +546,21 @@ class PaymentRuntime:
         method: Method,
         *,
         event_payload: dict[str, Any] | None = None,
+        context: Any = _CONTEXT_UNSET,
     ) -> Credential:
         """Synchronously create a credential on the runtime-owned event loop."""
-        return self._bridge.run(
-            self._create_credential(challenge, method, event_payload=event_payload)
+        return self.run_sync(
+            self._create_credential(
+                challenge,
+                method,
+                event_payload=event_payload,
+                context=context,
+            )
         )
+
+    def run_sync(self, coroutine: Coroutine[Any, Any, _T]) -> _T:
+        """Run a coroutine on the runtime-owned loop and block for its result."""
+        return self._bridge.run(coroutine)
 
     async def _create_credential(
         self,
@@ -470,6 +568,7 @@ class PaymentRuntime:
         method: Method,
         *,
         event_payload: dict[str, Any] | None = None,
+        context: Any = _CONTEXT_UNSET,
     ) -> Credential:
         token = _PAYMENT_FLOW_ACTIVE.set(True)
         try:
@@ -479,16 +578,19 @@ class PaymentRuntime:
                 "method": method,
                 **(event_payload or {}),
             }
+            if context is not _CONTEXT_UNSET:
+                payload["context"] = context
             event_credential = await self.events.emit(
                 CHALLENGE_RECEIVED,
                 payload,
                 first_result=True,
             )
-            credential = (
-                event_credential
-                if isinstance(event_credential, Credential)
-                else await method.create_credential(challenge)
-            )
+            if isinstance(event_credential, Credential):
+                credential = event_credential
+            elif context is _CONTEXT_UNSET:
+                credential = await method.create_credential(challenge)
+            else:
+                credential = await method.create_credential(challenge, context=context)  # type: ignore[call-arg]
             await self.events.emit(
                 CREDENTIAL_CREATED,
                 {**payload, "credential": credential},
@@ -499,11 +601,15 @@ class PaymentRuntime:
 
     async def emit_event(self, name: str, payload: EventPayload) -> Any:
         """Emit an asynchronous lifecycle event on the caller event loop."""
-        return await self.events.emit(name, payload)
+        token = _PAYMENT_FLOW_ACTIVE.set(True)
+        try:
+            return await self.events.emit(name, payload)
+        finally:
+            _PAYMENT_FLOW_ACTIVE.reset(token)
 
     def emit_event_sync(self, name: str, payload: EventPayload) -> Any:
         """Synchronously emit a lifecycle event on the runtime-owned event loop."""
-        return self._bridge.run(self.events.emit(name, payload))
+        return self.run_sync(self.emit_event(name, payload))
 
     def close(self) -> None:
         """Release the runtime background loop."""

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,5 +1,6 @@
 """Tests for client-side transport."""
 
+import asyncio
 from unittest.mock import AsyncMock
 
 import httpx
@@ -8,7 +9,8 @@ from pytest_httpx import HTTPXMock
 
 from mpp import Challenge, Credential
 from mpp.client import Client, PaymentTransport, get, post, request
-from mpp.runtime import PaymentRuntime
+from mpp.errors import PaymentError
+from mpp.runtime import PaymentRuntime, payment_flow_active
 from tests import make_credential
 
 
@@ -42,6 +44,21 @@ class MockTransport(httpx.AsyncBaseTransport):
 
     async def aclose(self) -> None:
         pass
+
+
+class TrackingAsyncStream(httpx.AsyncByteStream):
+    def __init__(self, chunks: list[bytes]) -> None:
+        self.chunks = chunks
+        self.started = False
+        self.closed = False
+
+    async def __aiter__(self):
+        self.started = True
+        for chunk in self.chunks:
+            yield chunk
+
+    async def aclose(self) -> None:
+        self.closed = True
 
 
 def payment_challenge_header() -> str:
@@ -98,6 +115,183 @@ class TestPaymentTransport:
         assert retry_request.headers["Authorization"].startswith("Payment ")
 
         method.create_credential.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_async_response_hook_can_send_create_and_refetch(self) -> None:
+        contexts: list[object | None] = []
+        hook_calls = 0
+
+        class HookMethod:
+            name = "tempo"
+            _intents = {"charge": True}
+
+            async def create_credential(
+                self,
+                challenge: Challenge,
+                *,
+                context: object | None = None,
+            ) -> Credential:
+                contexts.append(context)
+                return make_credential({"context": context}, challenge_id=challenge.id)
+
+            async def handle_async_http_response(self, exchange):
+                nonlocal hook_calls
+                hook_calls += 1
+                assert payment_flow_active()
+                if hook_calls == 2:
+                    assert exchange.refetch is None
+                    return exchange.response
+                credential = await exchange.create_credential({"action": "voucher"})
+                await exchange.response.aclose()
+                management = await exchange.send(
+                    httpx.Request(
+                        "POST",
+                        exchange.request.url,
+                        headers={"authorization": credential.to_authorization()},
+                    )
+                )
+                await management.aread()
+                assert exchange.refetch is not None
+                return await exchange.refetch()
+
+        paid_response = httpx.Response(204)
+        inner = MockTransport(
+            [
+                httpx.Response(
+                    402,
+                    headers={"www-authenticate": payment_challenge_header()},
+                ),
+                paid_response,
+                httpx.Response(204),
+                httpx.Response(
+                    402,
+                    headers={"www-authenticate": payment_challenge_header()},
+                ),
+                httpx.Response(200, content=b"stream"),
+            ]
+        )
+        transport = PaymentTransport(methods=[HookMethod()], inner=inner)
+        events: list[tuple[object | None, int, bool]] = []
+        transport.on_payment_response(
+            lambda payload: events.append(
+                (
+                    payload["credential"].payload["context"],
+                    payload["response"].status_code,
+                    payment_flow_active(),
+                )
+            )
+        )
+
+        response = await transport.handle_async_request(
+            httpx.Request(
+                "GET",
+                "https://example.com/paid",
+                extensions={"timeout": {"read": 1.0}},
+            )
+        )
+
+        assert response.content == b"stream"
+        assert response.request.url == httpx.URL("https://example.com/paid")
+        assert contexts == [None, {"action": "voucher"}, None]
+        assert events == [(None, 204, True), (None, 200, True)]
+        assert len(inner.requests) == 5
+        assert inner.requests[2].headers["authorization"].startswith("Payment ")
+        assert inner.requests[2].extensions["timeout"] == {"read": 1.0}
+        assert "authorization" not in inner.requests[3].headers
+        assert paid_response.is_closed
+
+    @pytest.mark.asyncio
+    async def test_response_hook_send_respects_origin_policy(self) -> None:
+        class HookMethod(MockMethod):
+            async def handle_async_http_response(self, exchange):
+                await exchange.send(httpx.Request("POST", "https://other.example/manage"))
+
+        paid_response = httpx.Response(200)
+        runtime = PaymentRuntime(
+            [HookMethod()],
+            allowed_origins=["https://example.com"],
+        )
+        transport = PaymentTransport(
+            runtime=runtime,
+            inner=MockTransport(
+                [
+                    httpx.Response(
+                        402,
+                        headers={"www-authenticate": payment_challenge_header()},
+                    ),
+                    paid_response,
+                ]
+            ),
+        )
+
+        with pytest.raises(PaymentError, match="outside allowed origins"):
+            await transport.handle_async_request(httpx.Request("GET", "https://example.com/paid"))
+
+        assert paid_response.is_closed
+        await runtime.aclose()
+
+    @pytest.mark.asyncio
+    async def test_replacement_response_can_own_paid_stream(self) -> None:
+        class HookMethod(MockMethod):
+            async def handle_async_http_response(self, exchange):
+                return httpx.Response(
+                    exchange.response.status_code,
+                    headers=exchange.response.headers,
+                    stream=exchange.response.stream,
+                )
+
+        stream = TrackingAsyncStream([b"one", b"two"])
+        inner = MockTransport(
+            [
+                httpx.Response(
+                    402,
+                    headers={"www-authenticate": payment_challenge_header()},
+                ),
+                httpx.Response(200, stream=stream),
+            ]
+        )
+        transport = PaymentTransport(methods=[HookMethod()], inner=inner)
+
+        response = await transport.handle_async_request(
+            httpx.Request("GET", "https://example.com/paid")
+        )
+        assert stream.started is False
+        assert await response.aread() == b"onetwo"
+        await response.aclose()
+
+        assert stream.closed
+
+    @pytest.mark.asyncio
+    async def test_cancelling_response_hook_closes_paid_response(self) -> None:
+        started = asyncio.Event()
+
+        class HookMethod(MockMethod):
+            async def handle_async_http_response(self, exchange):
+                started.set()
+                await asyncio.Event().wait()
+
+        stream = TrackingAsyncStream([b"never read"])
+        transport = PaymentTransport(
+            methods=[HookMethod()],
+            inner=MockTransport(
+                [
+                    httpx.Response(
+                        402,
+                        headers={"www-authenticate": payment_challenge_header()},
+                    ),
+                    httpx.Response(200, stream=stream),
+                ]
+            ),
+        )
+        task = asyncio.create_task(
+            transport.handle_async_request(httpx.Request("GET", "https://example.com/paid"))
+        )
+        await started.wait()
+        task.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert stream.closed
 
     @pytest.mark.asyncio
     async def test_delegates_payment_matching_to_runtime(self) -> None:

--- a/tests/test_sync_client.py
+++ b/tests/test_sync_client.py
@@ -14,7 +14,7 @@ import pytest
 from mpp import Challenge
 from mpp.client import SyncPaymentTransport
 from mpp.errors import PaymentError
-from mpp.runtime import PaymentRuntime
+from mpp.runtime import PaymentRuntime, payment_flow_active
 from tests import make_credential
 
 
@@ -131,6 +131,100 @@ class TestSyncPaymentTransport:
             assert stream.started is True
         finally:
             transport.close()
+
+    def test_sync_response_hook_runs_for_credentialed_402(self) -> None:
+        contexts: list[object | None] = []
+
+        class HookMethod:
+            name = "tempo"
+            _intents = {"charge": True}
+
+            async def create_credential(
+                self,
+                challenge: Challenge,
+                *,
+                context: object | None = None,
+            ):
+                contexts.append(context)
+                return make_credential({"context": context}, challenge_id=challenge.id)
+
+            def handle_http_response(self, exchange):
+                exchange.create_credential({"action": "voucher"})
+                exchange.response.close()
+                return httpx.Response(200, content=b"handled")
+
+        paid_response = httpx.Response(402)
+        inner = MockTransport([payment_required(), paid_response])
+        transport = SyncPaymentTransport(methods=[HookMethod()], inner=inner)
+        try:
+            response = transport.handle_request(httpx.Request("GET", "https://example.com/paid"))
+        finally:
+            transport.close()
+
+        assert response.content == b"handled"
+        assert response.request.url == httpx.URL("https://example.com/paid")
+        assert contexts == [None, {"action": "voucher"}]
+        assert paid_response.is_closed
+
+    def test_sync_response_hook_can_run_async_and_refetch_once(self) -> None:
+        hook_calls = 0
+
+        class HookMethod(MockMethod):
+            def handle_http_response(self, exchange):
+                nonlocal hook_calls
+                hook_calls += 1
+                assert payment_flow_active()
+                assert exchange.run_sync(asyncio.sleep(0, result="ok")) == "ok"
+                if hook_calls == 2:
+                    assert exchange.refetch is None
+                    return exchange.response
+                assert exchange.refetch is not None
+                return exchange.refetch()
+
+        inner = MockTransport(
+            [
+                payment_required(),
+                httpx.Response(204),
+                payment_required(),
+                httpx.Response(200, content=b"stream"),
+            ]
+        )
+        transport = SyncPaymentTransport(methods=[HookMethod()], inner=inner)
+        events: list[tuple[int, bool]] = []
+        transport.on_payment_response(
+            lambda payload: events.append((payload["response"].status_code, payment_flow_active()))
+        )
+        try:
+            response = transport.handle_request(httpx.Request("GET", "https://example.com/paid"))
+        finally:
+            transport.close()
+
+        assert response.content == b"stream"
+        assert response.request.url == httpx.URL("https://example.com/paid")
+        assert events == [(204, True), (200, True)]
+        assert len(inner.requests) == 4
+
+    def test_replacement_response_can_own_paid_stream(self) -> None:
+        class HookMethod(MockMethod):
+            def handle_http_response(self, exchange):
+                return httpx.Response(
+                    exchange.response.status_code,
+                    headers=exchange.response.headers,
+                    stream=exchange.response.stream,
+                )
+
+        stream = TrackingStream([b"one", b"two"])
+        inner = MockTransport([payment_required(), httpx.Response(200, stream=stream)])
+        transport = SyncPaymentTransport(methods=[HookMethod()], inner=inner)
+        try:
+            response = transport.handle_request(httpx.Request("GET", "https://example.com/paid"))
+            assert stream.started is False
+            assert response.read() == b"onetwo"
+            response.close()
+        finally:
+            transport.close()
+
+        assert stream.closed
 
 
 class TestWrappedSyncClient:


### PR DESCRIPTION
Stacked on #178.

## Summary
- add optional sync and async post-payment response hooks
- expose contextual credential creation, policy-checked raw sends, and one-shot refetch
- preserve streaming ownership, request metadata, cleanup, and shared lifecycle events

## Testing
- uv run --all-extras --group dev ruff check .
- uv run --all-extras --group dev pyright
- uv run --all-extras --group dev pytest -q (812 passed, 41 skipped)