### PR TITLE
ci: test declared Python versions

### DIFF
--- a/.changelog/good-doves-play.md
+++ b/.changelog/good-doves-play.md
@@ -1,0 +1,5 @@
+---
+pympp: patch
+---
+
+Added Python 3.14 to the list of declared supported versions in package classifiers and added Python 3.11 to the CI test matrix.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.12", "3.13", "3.14"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ server = Mpp.create(
     ),
 )
 
+
 @app.get("/paid")
 @server.pay(amount="0.50")
 async def handler(request, credential: Credential, receipt: Receipt):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Typing :: Typed",
 ]
 


### PR DESCRIPTION
## Summary

- test Python 3.11 through 3.14 in CI
- advertise Python 3.14 in package metadata

## Validation

- hosted CI passes on Python 3.11, 3.12, 3.13, and 3.14
- actionlint, package metadata parsing, formatting, and diff checks pass