### PR TITLE
ci: validate stacked pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main, master]
   pull_request:
-    branches: [main, master]
 
 permissions:
   contents: read


### PR DESCRIPTION
> Stack 2 of 8 · depends on #195 · next: #184

## Summary

Run CI for pull requests targeting any branch, rather than only `main` or `master`.

## Why this is separate

Every later PR targets the branch below it. Without this one-line workflow change, those reviewable stacked PRs would not receive hosted CI.

No SDK or package behavior changes.

## Validation

- `actionlint`
- hosted CI exercises Python 3.11–3.14, packaging, install smokes, integration tests, and conformance

<sub>Managed as a stacked change with [GitHub Stacks](https://github.com/github/gh-stack).</sub>