### PR TITLE
feat: add process-global HTTPX instrumentation

### DIFF
--- a/.changelog/httpx-global-instrumentation.md
+++ b/.changelog/httpx-global-instrumentation.md
@@ -1,0 +1,5 @@
+---
+pympp: minor
+---
+
+Added explicit process-global payment instrumentation for HTTPX clients.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,9 @@ jobs:
           HTTPX_VERSION: ${{ matrix.httpx-version }}
 
       - name: Run HTTPX adapter tests
-        run: .venv/bin/python -m pytest --noconftest -q tests/test_httpx_adapters.py
+        run: |
+          .venv/bin/python -m pytest --noconftest -q \
+            tests/test_httpx_adapters.py tests/test_instrumentation.py
 
   integration:
     name: Integration Test

--- a/README.md
+++ b/README.md
@@ -105,8 +105,27 @@ with OwnedPaymentRuntime([method]) as runtime:
 
 Use `runtime.wrap_async_client(httpx.AsyncClient())` for asynchronous clients.
 These adapters support HTTPX 0.27.x and 0.28.x and fail before changing a client
-when its version or private send seam is incompatible. Explicit `PaymentTransport`
-and `SyncPaymentTransport` integrations do not depend on those private seams.
+when its send seams are incompatible. Explicit `PaymentTransport` and
+`SyncPaymentTransport` integrations do not depend on those private seams.
+
+To cover HTTPX clients created by other libraries, install one explicit
+process-global binding:
+
+```python
+from mpp.instrumentation import instrument
+
+with OwnedPaymentRuntime(
+    [method],
+    allowed_origins=["https://api.example.com"],
+) as runtime:
+    with instrument(runtime):
+        response = httpx.get("https://api.example.com/paid")
+```
+
+The binding applies across threads, and per-client adapters take precedence.
+Install or remove it outside concurrent HTTPX use. An unrestricted runtime must
+be enabled explicitly with `instrument(runtime, allow_unrestricted=True)`.
+Payment methods should not spawn raw threads that make instrumented HTTPX calls.
 
 ## Examples
 

--- a/src/mpp/_httpx.py
+++ b/src/mpp/_httpx.py
@@ -104,6 +104,29 @@ class _AsyncSend(httpx.AsyncBaseTransport):
         return await self._send(request)
 
 
+def _send_sync(
+    runtime: OwnedPaymentRuntime,
+    send: Callable[[httpx.Request], httpx.Response],
+    request: httpx.Request,
+) -> httpx.Response:
+    from mpp.client import SyncPaymentTransport
+
+    return SyncPaymentTransport(inner=_SyncSend(send), runtime=runtime).handle_request(request)
+
+
+async def _send_async(
+    runtime: OwnedPaymentRuntime,
+    send: Callable[[httpx.Request], Awaitable[httpx.Response]],
+    request: httpx.Request,
+) -> httpx.Response:
+    from mpp.client import PaymentTransport
+
+    return await PaymentTransport(
+        inner=_AsyncSend(send),
+        runtime=runtime,
+    ).handle_async_request(request)
+
+
 def wrap_client(client: httpx.Client, runtime: OwnedPaymentRuntime) -> httpx.Client:
     """Make one synchronous HTTPX client payment-aware."""
     if not isinstance(client, httpx.Client):
@@ -192,11 +215,34 @@ def _wrap(client: Any, runtime: OwnedPaymentRuntime, *, asynchronous: bool) -> A
 def _validate_client(client: Any, *, asynchronous: bool) -> tuple[Any, Any]:
     _validate_version()
     owner = type(client)
+    _validate_class(owner, asynchronous=asynchronous)
     bound = []
-    for name, expected, bound_expected in (
-        ("_send_single_request", _PRIVATE, _BOUND_PRIVATE),
-        ("_send_handling_auth", _AUTH, _BOUND_AUTH),
+    for name, expected in (
+        ("_send_single_request", _BOUND_PRIVATE),
+        ("_send_handling_auth", _BOUND_AUTH),
     ):
+        value = getattr(client, name)
+        _validate_seam(
+            f"{owner.__name__} instance.{name}",
+            value,
+            expected,
+            asynchronous,
+        )
+        bound.append(value)
+    return bound[0], bound[1]
+
+
+def _validate_httpx_classes() -> tuple[Any, Any, Any, Any]:
+    _validate_version()
+    return (
+        *_validate_class(httpx.Client, asynchronous=False),
+        *_validate_class(httpx.AsyncClient, asynchronous=True),
+    )
+
+
+def _validate_class(owner: Any, *, asynchronous: bool) -> tuple[Any, Any]:
+    seams = []
+    for name, expected in (("_send_single_request", _PRIVATE), ("_send_handling_auth", _AUTH)):
         try:
             seam = inspect.getattr_static(owner, name)
         except AttributeError as error:
@@ -204,15 +250,16 @@ def _validate_client(client: Any, *, asynchronous: bool) -> tuple[Any, Any]:
                 f"HTTPX adapter seam {owner.__name__}.{name} is missing"
             ) from error
         _validate_seam(f"{owner.__name__}.{name}", seam, expected, asynchronous)
-        value = getattr(client, name)
-        _validate_seam(
-            f"{owner.__name__} instance.{name}",
-            value,
-            bound_expected,
-            asynchronous,
-        )
-        bound.append(value)
-    return bound[0], bound[1]
+        seams.append(seam)
+    return seams[0], seams[1]
+
+
+def _client_adapter_active(client: Any) -> bool:
+    adapter = client.__dict__.get(_MARKER)
+    return isinstance(adapter, _Adapter) and (
+        inspect.getattr_static(client, "_send_single_request") is adapter.private
+        and inspect.getattr_static(client, "_send_handling_auth") is adapter.auth
+    )
 
 
 def _validate_version() -> None:

--- a/src/mpp/instrumentation.py
+++ b/src/mpp/instrumentation.py
@@ -1,0 +1,204 @@
+"""Explicit process-global HTTPX payment instrumentation."""
+
+from __future__ import annotations
+
+import inspect
+import threading
+from dataclasses import dataclass
+from functools import partial, wraps
+from typing import Any
+
+import httpx
+
+from mpp._httpx import (
+    _client_adapter_active,
+    _payment_budget,
+    _send_async,
+    _send_operation,
+    _send_sync,
+    _validate_httpx_classes,
+)
+from mpp.runtime import OwnedPaymentRuntime, _owned_in_scope
+
+
+@dataclass(frozen=True, slots=True)
+class _Patch:
+    owner: type[Any]
+    name: str
+    original: Any
+    wrapper: Any
+
+
+@dataclass(slots=True)
+class _Binding:
+    runtime: OwnedPaymentRuntime
+    patches: tuple[_Patch, ...] = ()
+    references: int = 1
+
+
+_LOCK = threading.RLock()
+_binding: _Binding | None = None
+
+
+class Instrumentation:
+    """A reference-counted handle for global HTTPX instrumentation."""
+
+    def __init__(self, binding: _Binding) -> None:
+        self._binding: _Binding | None = binding
+
+    def disable(self) -> None:
+        """Release this handle and restore pympp-owned patches."""
+        global _binding
+
+        with _LOCK:
+            binding = self._binding
+            if binding is None:
+                return
+            if _binding is not binding:
+                self._binding = None
+                return
+            if binding.references > 1:
+                binding.references -= 1
+            else:
+                owned = tuple(
+                    patch
+                    for patch in binding.patches
+                    if inspect.getattr_static(patch.owner, patch.name) is patch.wrapper
+                )
+                _replace(owned, enable=False)
+                _binding = None
+            self._binding = None
+
+    def __enter__(self) -> Instrumentation:
+        return self
+
+    def __exit__(self, *_args: Any) -> None:
+        self.disable()
+
+
+def instrument(
+    runtime: OwnedPaymentRuntime,
+    *,
+    allow_unrestricted: bool = False,
+) -> Instrumentation:
+    """Make otherwise-unadapted HTTPX clients payment-aware."""
+    global _binding
+
+    if not isinstance(runtime, OwnedPaymentRuntime):
+        raise TypeError("instrument requires an OwnedPaymentRuntime")
+    if runtime._allowed_origins._allow_all and not allow_unrestricted:
+        raise ValueError(
+            "Global instrumentation requires allowed_origins or allow_unrestricted=True"
+        )
+
+    with _LOCK:
+        if _binding is not None:
+            if _binding.runtime is not runtime:
+                raise RuntimeError("Another payment runtime is already globally instrumented")
+            if not all(
+                inspect.getattr_static(patch.owner, patch.name) is patch.wrapper
+                for patch in _binding.patches
+            ):
+                raise RuntimeError("Global HTTPX instrumentation was modified while active")
+            _binding.references += 1
+            return Instrumentation(_binding)
+
+        binding = _Binding(runtime)
+        binding.patches = _make_patches(binding, _validate_httpx_classes())
+        _replace(binding.patches, enable=True)
+        _binding = binding
+        return Instrumentation(binding)
+
+
+def _make_patches(binding: _Binding, seams: tuple[Any, Any, Any, Any]) -> tuple[_Patch, ...]:
+    sync_private, sync_auth, async_private, async_auth = seams
+
+    @wraps(sync_private)
+    def patched_sync_private(client: httpx.Client, request: httpx.Request) -> httpx.Response:
+        if _bypass(binding, client):
+            return sync_private(client, request)
+        with _payment_budget(request):
+            return _send_sync(binding.runtime, partial(sync_private, client), request)
+
+    @wraps(sync_auth)
+    def patched_sync_auth(
+        client: httpx.Client,
+        request: httpx.Request,
+        *args: Any,
+        **kwargs: Any,
+    ) -> httpx.Response:
+        if _bypass(binding, client):
+            return sync_auth(client, request, *args, **kwargs)
+        with _send_operation():
+            return sync_auth(client, request, *args, **kwargs)
+
+    @wraps(async_private)
+    async def patched_async_private(
+        client: httpx.AsyncClient,
+        request: httpx.Request,
+    ) -> httpx.Response:
+        if _bypass(binding, client):
+            return await async_private(client, request)
+        with _payment_budget(request):
+            return await _send_async(
+                binding.runtime,
+                partial(async_private, client),
+                request,
+            )
+
+    @wraps(async_auth)
+    async def patched_async_auth(
+        client: httpx.AsyncClient,
+        request: httpx.Request,
+        *args: Any,
+        **kwargs: Any,
+    ) -> httpx.Response:
+        if _bypass(binding, client):
+            return await async_auth(client, request, *args, **kwargs)
+        with _send_operation():
+            return await async_auth(client, request, *args, **kwargs)
+
+    return (
+        _Patch(httpx.Client, "_send_single_request", sync_private, patched_sync_private),
+        _Patch(httpx.Client, "_send_handling_auth", sync_auth, patched_sync_auth),
+        _Patch(httpx.AsyncClient, "_send_single_request", async_private, patched_async_private),
+        _Patch(httpx.AsyncClient, "_send_handling_auth", async_auth, patched_async_auth),
+    )
+
+
+def _bypass(binding: _Binding, client: Any) -> bool:
+    return (
+        _binding is not binding
+        or _client_adapter_active(client)
+        or threading.get_ident() == binding.runtime._owner_thread_id
+        or _owned_in_scope(binding.runtime._scope_key)
+    )
+
+
+def _replace(patches: tuple[_Patch, ...], *, enable: bool) -> None:
+    changed: list[_Patch] = []
+    try:
+        for patch in patches:
+            expected = patch.original if enable else patch.wrapper
+            replacement = patch.wrapper if enable else patch.original
+            if inspect.getattr_static(patch.owner, patch.name) is not expected:
+                raise RuntimeError("HTTPX changed while instrumentation was being updated")
+            changed.append(patch)
+            _assign(patch.owner, patch.name, replacement)
+    except BaseException as error:
+        rollback_error: BaseException | None = None
+        for patch in reversed(changed):
+            expected = patch.original if enable else patch.wrapper
+            replacement = patch.wrapper if enable else patch.original
+            try:
+                if inspect.getattr_static(patch.owner, patch.name) is replacement:
+                    _assign(patch.owner, patch.name, expected)
+            except BaseException as cause:
+                rollback_error = rollback_error or cause
+        if rollback_error is not None:
+            raise RuntimeError("Failed to roll back HTTPX instrumentation") from error
+        raise
+
+
+def _assign(owner: type[Any], name: str, value: Any) -> None:
+    setattr(owner, name, value)

--- a/tests/test_instrumentation.py
+++ b/tests/test_instrumentation.py
@@ -1,0 +1,381 @@
+from __future__ import annotations
+
+import inspect
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import asynccontextmanager
+from functools import wraps
+from typing import Any, Literal, cast
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+
+import mpp._httpx as httpx_adapter
+import mpp.instrumentation as instrumentation
+from mpp import Challenge, Credential
+from mpp.instrumentation import instrument
+from mpp.runtime import OwnedPaymentRuntime, PaymentRuntime
+
+Kind = Literal["sync", "async"]
+SEAMS = (
+    (httpx.Client, "_send_handling_auth"),
+    (httpx.Client, "_send_single_request"),
+    (httpx.AsyncClient, "_send_handling_auth"),
+    (httpx.AsyncClient, "_send_single_request"),
+)
+
+
+@pytest.fixture(autouse=True)
+def restore_httpx_classes():
+    originals = tuple(inspect.getattr_static(owner, name) for owner, name in SEAMS)
+    yield
+    instrumentation._binding = None
+    for (owner, name), original in zip(SEAMS, originals, strict=True):
+        setattr(owner, name, original)
+
+
+class Method:
+    name = "tempo"
+    _intents = {"charge": True}
+
+    def __init__(self) -> None:
+        self.create_credential = AsyncMock(side_effect=self._create_credential)
+
+    async def _create_credential(self, challenge: Challenge) -> Credential:
+        return Credential(challenge=challenge.to_echo(), payload={"hash": "0xabc"})
+
+
+class TwoRequestAuth(httpx.Auth):
+    def auth_flow(self, request: httpx.Request):
+        response = yield request
+        assert response.status_code == 200
+        yield httpx.Request("GET", "https://example.com/second")
+
+
+def required(challenge_id: str = "challenge") -> httpx.Response:
+    challenge = Challenge(id=challenge_id, method="tempo", intent="charge", request={})
+    return httpx.Response(
+        402,
+        headers={"www-authenticate": challenge.to_www_authenticate("example.com")},
+    )
+
+
+def handler(request: httpx.Request) -> httpx.Response:
+    if request.headers.get("authorization", "").startswith("Payment "):
+        return httpx.Response(200, content=b"paid")
+    return required(request.url.path)
+
+
+def make_client(kind: Kind, **kwargs: Any) -> httpx.Client | httpx.AsyncClient:
+    client = httpx.Client if kind == "sync" else httpx.AsyncClient
+    return client(transport=httpx.MockTransport(handler), **kwargs)
+
+
+async def get(kind: Kind, client: httpx.Client | httpx.AsyncClient) -> httpx.Response:
+    if kind == "sync":
+        return cast(httpx.Client, client).get("https://example.com/paid")
+    return await cast(httpx.AsyncClient, client).get("https://example.com/paid")
+
+
+async def close(kind: Kind, client: httpx.Client | httpx.AsyncClient) -> None:
+    if kind == "sync":
+        cast(httpx.Client, client).close()
+    else:
+        await cast(httpx.AsyncClient, client).aclose()
+
+
+async def test_global_sync_async_and_raw_thread() -> None:
+    originals = tuple(inspect.getattr_static(owner, name) for owner, name in SEAMS)
+    signatures = tuple(inspect.signature(value) for value in originals)
+    thread_start = threading.Thread.start
+    executor_submit = ThreadPoolExecutor.submit
+    method = Method()
+    runtime = OwnedPaymentRuntime([method], allowed_origins=["https://example.com"])
+    handle = instrument(runtime)
+    statuses: list[int] = []
+
+    def in_thread() -> None:
+        with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+            statuses.append(client.get("https://example.com/paid").status_code)
+
+    worker = threading.Thread(target=in_thread)
+    worker.start()
+    worker.join()
+    try:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            statuses.append((await client.get("https://example.com/paid")).status_code)
+        patched = tuple(inspect.getattr_static(owner, name) for owner, name in SEAMS)
+        assert all(
+            current is not original for current, original in zip(patched, originals, strict=True)
+        )
+        assert tuple(inspect.signature(value) for value in patched) == signatures
+        assert threading.Thread.start is thread_start
+        assert ThreadPoolExecutor.submit is executor_submit
+    finally:
+        handle.disable()
+        runtime.close()
+
+    assert statuses == [200, 200]
+    assert method.create_credential.await_count == 2
+    assert tuple(inspect.getattr_static(owner, name) for owner, name in SEAMS) == originals
+
+
+def test_origin_policy_lazy_start_and_unrestricted_opt_in() -> None:
+    originals = tuple(inspect.getattr_static(owner, name) for owner, name in SEAMS)
+    unrestricted = OwnedPaymentRuntime()
+    with pytest.raises(ValueError, match="allowed_origins"):
+        instrument(unrestricted)
+    assert tuple(inspect.getattr_static(owner, name) for owner, name in SEAMS) == originals
+    instrument(unrestricted, allow_unrestricted=True).disable()
+    unrestricted.close()
+
+    entered: list[bool] = []
+
+    @asynccontextmanager
+    async def factory():
+        entered.append(True)
+        yield Method()
+
+    runtime = OwnedPaymentRuntime(
+        method_factories=[factory],
+        allowed_origins=["https://allowed.example"],
+    )
+    handle = instrument(runtime)
+    try:
+        with httpx.Client(transport=httpx.MockTransport(lambda _: httpx.Response(200))) as client:
+            assert client.get("https://allowed.example/free").status_code == 200
+        with httpx.Client(transport=httpx.MockTransport(lambda _: required())) as client:
+            assert client.get("https://blocked.example/paid").status_code == 402
+        assert entered == []
+    finally:
+        handle.disable()
+        handle.disable()
+        runtime.close()
+
+    with pytest.raises(TypeError, match="OwnedPaymentRuntime"):
+        instrument(cast(Any, PaymentRuntime()))
+
+
+def test_reference_count_context_manager_and_runtime_exclusivity() -> None:
+    runtime = OwnedPaymentRuntime(allowed_origins=[])
+    other = OwnedPaymentRuntime(allowed_origins=[])
+    first = instrument(runtime)
+    second = instrument(runtime)
+    wrappers = tuple(inspect.getattr_static(owner, name) for owner, name in SEAMS)
+    try:
+        with pytest.raises(RuntimeError, match="Another payment runtime"):
+            instrument(other)
+        first.disable()
+        first.disable()
+        assert tuple(inspect.getattr_static(owner, name) for owner, name in SEAMS) == wrappers
+        second.disable()
+        restored = tuple(inspect.getattr_static(owner, name) for owner, name in SEAMS)
+        assert restored != wrappers
+        with instrument(runtime):
+            assert tuple(inspect.getattr_static(owner, name) for owner, name in SEAMS) != restored
+        assert tuple(inspect.getattr_static(owner, name) for owner, name in SEAMS) == restored
+    finally:
+        first.disable()
+        second.disable()
+        runtime.close()
+        other.close()
+
+
+@pytest.mark.parametrize("kind", ["sync", "async"])
+async def test_per_client_adapter_overrides_global(kind: Kind) -> None:
+    global_method = Method()
+    local_method = Method()
+    global_runtime = OwnedPaymentRuntime(
+        [global_method],
+        allowed_origins=["https://example.com"],
+    )
+    local_runtime = OwnedPaymentRuntime(
+        [local_method],
+        allowed_origins=["https://example.com"],
+    )
+    handle = instrument(global_runtime)
+    client = make_client(kind)
+    client = (
+        local_runtime.wrap_client(cast(httpx.Client, client))
+        if kind == "sync"
+        else local_runtime.wrap_async_client(cast(httpx.AsyncClient, client))
+    )
+    try:
+        assert (await get(kind, client)).status_code == 200
+    finally:
+        await close(kind, client)
+        handle.disable()
+        global_runtime.close()
+        local_runtime.close()
+    global_method.create_credential.assert_not_awaited()
+    local_method.create_credential.assert_awaited_once()
+
+
+async def test_method_internal_httpx_is_not_recursively_instrumented() -> None:
+    internal_statuses: list[int] = []
+
+    class RecursiveMethod:
+        name = "tempo"
+        _intents = {"charge": True}
+
+        async def create_credential(self, challenge: Challenge) -> Credential:
+            async with httpx.AsyncClient(
+                transport=httpx.MockTransport(lambda _: required("internal"))
+            ) as client:
+                internal_statuses.append(
+                    (await client.get("https://example.com/internal")).status_code
+                )
+            return Credential(challenge=challenge.to_echo(), payload={})
+
+    method = RecursiveMethod()
+    runtime = OwnedPaymentRuntime([method], allowed_origins=["https://example.com"])
+    try:
+        with instrument(runtime):
+            with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+                assert client.get("https://example.com/paid").status_code == 200
+    finally:
+        runtime.close()
+    assert internal_statuses == [402]
+
+
+def test_factory_internal_httpx_is_not_recursively_instrumented() -> None:
+    internal_statuses: list[int] = []
+
+    @asynccontextmanager
+    async def factory():
+        async with httpx.AsyncClient(
+            transport=httpx.MockTransport(lambda _: required("internal"))
+        ) as client:
+            internal_statuses.append((await client.get("https://example.com/enter")).status_code)
+            try:
+                yield Method()
+            finally:
+                internal_statuses.append((await client.get("https://example.com/exit")).status_code)
+
+    runtime = OwnedPaymentRuntime(
+        method_factories=[factory],
+        allowed_origins=["https://example.com"],
+    )
+    try:
+        with instrument(runtime):
+            with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+                assert client.get("https://example.com/paid").status_code == 200
+            runtime.close()
+    finally:
+        runtime.close()
+    assert internal_statuses == [402, 402]
+
+
+@pytest.mark.parametrize("kind", ["sync", "async"])
+@pytest.mark.parametrize("cached", [False, True], ids=["lookup", "cached"])
+async def test_one_global_send_never_pays_twice(kind: Kind, cached: bool) -> None:
+    method = Method()
+    runtime = OwnedPaymentRuntime([method], allowed_origins=["https://example.com"])
+    client = make_client(kind, auth=TwoRequestAuth())
+    cached_send: Any = client.send
+    try:
+        with instrument(runtime):
+            if cached:
+                response = cached_send(client.build_request("GET", "https://example.com/paid"))
+                if kind == "async":
+                    response = await response
+            else:
+                response = await get(kind, client)
+    finally:
+        await close(kind, client)
+        runtime.close()
+    assert response.status_code == 402
+    method.create_credential.assert_awaited_once()
+
+
+def test_redirected_send_has_one_payment_budget() -> None:
+    method = Method()
+    runtime = OwnedPaymentRuntime([method], allowed_origins=["https://example.com"])
+
+    def redirect(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/first":
+            if request.headers.get("authorization", "").startswith("Payment "):
+                return httpx.Response(302, headers={"location": "/second"})
+            return required("first")
+        return required("second")
+
+    try:
+        with instrument(runtime):
+            with httpx.Client(
+                transport=httpx.MockTransport(redirect),
+                follow_redirects=True,
+            ) as client:
+                assert client.get("https://example.com/first").status_code == 402
+    finally:
+        runtime.close()
+    method.create_credential.assert_awaited_once()
+
+
+def test_validation_and_install_failure_leave_httpx_unchanged(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    originals = tuple(inspect.getattr_static(owner, name) for owner, name in SEAMS)
+    runtime = OwnedPaymentRuntime(allowed_origins=[])
+    monkeypatch.setattr(httpx_adapter, "version", lambda _: "0.29.0")
+    with pytest.raises(httpx_adapter.HttpxCompatibilityError):
+        instrument(runtime)
+    assert tuple(inspect.getattr_static(owner, name) for owner, name in SEAMS) == originals
+    monkeypatch.undo()
+
+    calls = 0
+
+    def fail_once(owner: type[Any], name: str, value: Any) -> None:
+        nonlocal calls
+        calls += 1
+        if calls == 3:
+            setattr(owner, name, value)
+            raise RuntimeError("assignment failed")
+        setattr(owner, name, value)
+
+    monkeypatch.setattr(instrumentation, "_assign", fail_once)
+    with pytest.raises(RuntimeError, match="assignment failed"):
+        instrument(runtime)
+    assert instrumentation._binding is None
+    assert tuple(inspect.getattr_static(owner, name) for owner, name in SEAMS) == originals
+    runtime.close()
+
+
+def test_restore_is_transactional_and_preserves_later_patch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = OwnedPaymentRuntime(allowed_origins=[])
+    handle = instrument(runtime)
+    wrappers = tuple(inspect.getattr_static(owner, name) for owner, name in SEAMS)
+    calls = 0
+
+    def fail_once(owner: type[Any], name: str, value: Any) -> None:
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            setattr(owner, name, value)
+            raise RuntimeError("restore failed")
+        setattr(owner, name, value)
+
+    monkeypatch.setattr(instrumentation, "_assign", fail_once)
+    with pytest.raises(RuntimeError, match="restore failed"):
+        handle.disable()
+    assert tuple(inspect.getattr_static(owner, name) for owner, name in SEAMS) == wrappers
+    monkeypatch.setattr(instrumentation, "_assign", setattr)
+
+    wrapped_auth = httpx.Client._send_handling_auth
+
+    @wraps(wrapped_auth)
+    def third_party(client: httpx.Client, *args: Any, **kwargs: Any) -> httpx.Response:
+        return wrapped_auth(client, *args, **kwargs)
+
+    httpx.Client._send_handling_auth = third_party  # type: ignore[method-assign]
+    with pytest.raises(RuntimeError, match="modified while active"):
+        instrument(runtime)
+    handle.disable()
+    try:
+        assert httpx.Client._send_handling_auth is third_party
+        with httpx.Client(transport=httpx.MockTransport(lambda _: httpx.Response(200))) as client:
+            assert client.get("https://example.com/free").status_code == 200
+    finally:
+        runtime.close()


### PR DESCRIPTION
> Runtime stack 5 of 5 · depends on #191 · top of stack

## Summary

- add explicit process-global `instrument(runtime)` for HTTPX clients created by other libraries
- require an origin policy unless unrestricted use is explicitly enabled
- share one fixed runtime with reference-counted install/disable handles
- give per-client adapters precedence and suppress payment-method recursion
- validate and transactionally patch/restore the four HTTPX auth/request-send seams

## Review boundary

Process-global HTTPX only. It adds no context-local mode, task registry, thread/executor monkey-patching, response/refetch hooks, receipt extensions, or MCP instrumentation. Raw external worker threads work; payment methods must not spawn raw threads that make instrumented HTTPX calls.

Production delta is 251 lines.

## Validation

- full suite: 939 passed, 41 skipped
- combined adapter/instrumentation suite: 40 passed on HTTPX 0.27.0 and 0.28.1
- Hermes 0.19 and current-main entrypoint smokes, including clients and bound `send` callables created before plugin load
- raw-thread, reference-count, rollback, third-party patch, factory/method recursion, precedence, auth, redirect, and nested-send smokes
- clean wheel build and strict Twine validation
- Ruff, formatting, and Pyright pass
