### PR TITLE
fix: constrain MCP SDK to supported major

### DIFF
--- a/.changelog/mcp-v1-compat.md
+++ b/.changelog/mcp-v1-compat.md
@@ -1,0 +1,5 @@
+---
+pympp: patch
+---
+
+Prevent the optional MCP SDK from resolving to incompatible 2.x releases.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ stripe = [
 server = ["pydantic>=2.0"]
 redis = ["redis>=5.0"]
 sqlite = ["aiosqlite>=0.20"]
-mcp = ["mcp>=1.1.0"]
+mcp = ["mcp>=1.1,<2"]
 dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.24",


### PR DESCRIPTION
## Summary

- constrain the optional MCP SDK to `>=1.1,<2`
- prevent clean installs from selecting the incompatible MCP 2.x API
- preserve the existing MCP 1.x minimum

## Why

A fresh `pympp[mcp]` wheel install currently resolves MCP 2.0 and fails at import because its exception API changed. This is a compatibility patch only; it adds no MCP runtime or instrumentation behavior.

This is an independent prerequisite for #184.

## Validation

- full suite: 778 passed, 41 skipped
- clean wheel with `[tempo,mcp]` resolves MCP 1.29 and imports the existing Tempo and MCP public surfaces
- Ruff, formatting, Pyright, package build, and strict Twine validation pass