### PR TITLE
feat: add reusable payment runtime

### DIFF
--- a/.changelog/eager-sharks-drink.md
+++ b/.changelog/eager-sharks-drink.md
@@ -1,0 +1,5 @@
+---
+pympp: minor
+---
+
+Added a transport-neutral `PaymentRuntime` class that provides reusable primitives for matching payment challenges and creating credentials without depending on HTTPX. Refactored `PaymentTransport` and `Client` to accept either a `methods` list or a pre-built `runtime` instance, and consolidated the `Method` protocol into `mpp.runtime`.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,20 @@ async with Client(methods=[tempo(account=account, intents={"charge": ChargeInten
     response = await client.get("https://mpp.dev/api/ping/paid")
 ```
 
+Custom transports can reuse method matching and credential creation without
+depending on HTTPX:
+
+```python
+from mpp.client import PaymentTransport
+from mpp.runtime import PaymentRuntime
+
+payments = PaymentRuntime([method])
+challenge, method = payments.match_challenge(challenges)
+credential = await payments.create_credential(challenge, method)
+
+transport = PaymentTransport(runtime=payments)
+```
+
 ## Examples
 
 | Example | Description |

--- a/src/mpp/client/transport.py
+++ b/src/mpp/client/transport.py
@@ -9,15 +9,13 @@ Implements automatic 402 Payment Required handling by:
 
 from __future__ import annotations
 
-import logging
-from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any
 
 import httpx
 
 from mpp import Challenge, Credential
 from mpp._parsing import ParseError
-from mpp.errors import PaymentError
+from mpp.errors import InvalidChallengeError, PaymentError, PaymentExpiredError
 from mpp.events import (
     CHALLENGE_RECEIVED,
     CREDENTIAL_CREATED,
@@ -28,22 +26,10 @@ from mpp.events import (
     EventHandler,
     Unsubscribe,
 )
-
-logger = logging.getLogger(__name__)
+from mpp.runtime import Method, PaymentRuntime
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
-
-
-@runtime_checkable
-class Method(Protocol):
-    """Payment method interface for client-side credential creation."""
-
-    name: str
-
-    async def create_credential(self, challenge: Challenge) -> Credential:
-        """Create a credential to satisfy the given challenge."""
-        ...
 
 
 def _client_payment_failed_payload(
@@ -88,13 +74,21 @@ class PaymentTransport(httpx.AsyncBaseTransport):
 
     def __init__(
         self,
-        methods: Sequence[Method],
+        methods: Sequence[Method] | None = None,
         inner: httpx.AsyncBaseTransport | None = None,
         events: EventDispatcher | None = None,
+        *,
+        runtime: PaymentRuntime | None = None,
     ) -> None:
-        self._methods = {m.name: m for m in methods}
+        if (methods is None) == (runtime is None):
+            raise TypeError("Provide exactly one of methods or runtime")
+        if runtime is not None and events is not None:
+            raise TypeError("events belongs to the provided runtime")
+        self._runtime = (
+            runtime if runtime is not None else PaymentRuntime(methods or (), events=events)
+        )
         self._inner = inner or httpx.AsyncHTTPTransport()
-        self._events = events or EventDispatcher()
+        self._events = self._runtime.events
 
     def on(self, name: str, handler: EventHandler) -> Unsubscribe:
         """Register a client payment event handler."""
@@ -159,15 +153,9 @@ class PaymentTransport(httpx.AsyncBaseTransport):
                 continue
             challenges.append(parsed)
 
-        challenge = None
-        matched_method = None
-        for parsed in challenges:
-            if parsed.method in self._methods:
-                challenge = parsed
-                matched_method = self._methods[parsed.method]
-                break
-
-        if not challenge or not matched_method:
+        try:
+            challenge, matched_method = self._runtime.match_challenge(challenges)
+        except ValueError as match_error:
             if parse_error is not None or challenges:
                 # Surface parse/method-selection failures to observers while
                 # preserving the original 402 response for the caller.
@@ -177,8 +165,7 @@ class PaymentTransport(httpx.AsyncBaseTransport):
                         challenge=None,
                         challenges=challenges,
                         credential=None,
-                        error=parse_error
-                        or ValueError("No compatible payment method for challenges"),
+                        error=parse_error or match_error,
                         method=None,
                         request=request,
                         response=response,
@@ -186,53 +173,12 @@ class PaymentTransport(httpx.AsyncBaseTransport):
                 )
             return response
 
-        # Check expiry before paying (client-side guardrail)
-        if challenge.expires:
-            try:
-                expires_dt = datetime.fromisoformat(challenge.expires.replace("Z", "+00:00"))
-                if expires_dt < datetime.now(UTC):
-                    logger.warning("Challenge expired at %s, not paying", challenge.expires)
-                    await self._events.emit(
-                        PAYMENT_FAILED,
-                        _client_payment_failed_payload(
-                            challenge=challenge,
-                            challenges=challenges,
-                            credential=None,
-                            error=ValueError(f"Challenge expired at {challenge.expires}"),
-                            method=matched_method,
-                            request=request,
-                            response=response,
-                        ),
-                    )
-                    return response
-            except ValueError:
-                pass  # If we can't parse, let server validate
-
         try:
-            # challenge.received is the one client event that can override the
-            # default credential creation path by returning a Credential.
-            event_credential = await self._events.emit(
-                CHALLENGE_RECEIVED,
-                {
-                    "challenge": challenge,
+            credential = await self._runtime.create_credential(
+                challenge,
+                matched_method,
+                event_payload={
                     "challenges": challenges,
-                    "method": matched_method,
-                    "request": request,
-                    "response": response,
-                },
-                first_result=True,
-            )
-            credential = (
-                event_credential
-                if isinstance(event_credential, Credential)
-                else await matched_method.create_credential(challenge)
-            )
-            await self._events.emit(
-                CREDENTIAL_CREATED,
-                {
-                    "challenge": challenge,
-                    "credential": credential,
-                    "method": matched_method,
                     "request": request,
                     "response": response,
                 },
@@ -251,6 +197,8 @@ class PaymentTransport(httpx.AsyncBaseTransport):
                     response=response,
                 ),
             )
+            if isinstance(error, (InvalidChallengeError, PaymentExpiredError)):
+                return response
             raise
 
         headers = httpx.Headers(request.headers)
@@ -308,8 +256,13 @@ class Client:
             response = await client.get("https://api.example.com/resource")
     """
 
-    def __init__(self, methods: Sequence[Method]) -> None:
-        self._transport = PaymentTransport(methods)
+    def __init__(
+        self,
+        methods: Sequence[Method] | None = None,
+        *,
+        runtime: PaymentRuntime | None = None,
+    ) -> None:
+        self._transport = PaymentTransport(methods, runtime=runtime)
         self._client = httpx.AsyncClient(transport=self._transport)
 
     def on(self, name: str, handler: EventHandler) -> Unsubscribe:

--- a/src/mpp/extensions/mcp/client.py
+++ b/src/mpp/extensions/mcp/client.py
@@ -27,13 +27,11 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+from typing import Any
 
 from mpp.extensions.mcp.constants import CODE_PAYMENT_REQUIRED, META_RECEIPT
 from mpp.extensions.mcp.types import MCPChallenge, MCPCredential, MCPReceipt
-
-if TYPE_CHECKING:
-    from mpp import Challenge, Credential
+from mpp.runtime import Method as Method
 
 logger = logging.getLogger(__name__)
 
@@ -49,17 +47,6 @@ class PaymentOutcomeUnknownError(RuntimeError):
             f"payment outcome is unknown for challenge {challenge.id}. "
             "Do not blindly retry."
         )
-
-
-@runtime_checkable
-class Method(Protocol):
-    """Payment method interface for MCP client credential creation."""
-
-    name: str
-
-    async def create_credential(self, challenge: Challenge) -> Credential:
-        """Create a credential to satisfy the given challenge."""
-        ...
 
 
 def _error_code(error: Exception) -> int | None:

--- a/src/mpp/runtime.py
+++ b/src/mpp/runtime.py
@@ -1,0 +1,93 @@
+"""Transport-neutral client payment handling."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import UTC, datetime
+from typing import Any, Protocol, runtime_checkable
+
+from mpp import Challenge, Credential
+from mpp.errors import InvalidChallengeError, PaymentExpiredError
+from mpp.events import CHALLENGE_RECEIVED, CREDENTIAL_CREATED, EventDispatcher
+
+
+@runtime_checkable
+class Method(Protocol):
+    """Client-side payment method."""
+
+    name: str
+
+    async def create_credential(self, challenge: Challenge) -> Credential:
+        """Create a credential for a challenge."""
+        ...
+
+
+class PaymentRuntime:
+    """Match challenges and create credentials on the caller's event loop."""
+
+    def __init__(
+        self,
+        methods: Sequence[Method] = (),
+        *,
+        events: EventDispatcher | None = None,
+    ) -> None:
+        self.methods = tuple(methods)
+        self._methods = {method.name: method for method in self.methods}
+        self.events = events if events is not None else EventDispatcher()
+
+    def match_challenge(
+        self,
+        challenges: Sequence[Challenge],
+    ) -> tuple[Challenge, Method]:
+        """Return the first challenge with a configured payment method."""
+        for challenge in challenges:
+            method = self._methods.get(challenge.method)
+            if method is not None:
+                return challenge, method
+
+        offered = [challenge.method for challenge in challenges]
+        raise ValueError(f"No compatible payment method for challenges: {offered}")
+
+    async def create_credential(
+        self,
+        challenge: Challenge,
+        method: Method,
+        *,
+        event_payload: dict[str, Any] | None = None,
+    ) -> Credential:
+        """Create a credential and emit its lifecycle events."""
+        if not any(candidate is method for candidate in self.methods):
+            raise ValueError("Method is not installed in this PaymentRuntime")
+        if challenge.method != method.name:
+            raise ValueError(f"Method {method.name!r} does not support {challenge.method!r}")
+        if challenge.expires is not None:
+            try:
+                expires = datetime.fromisoformat(challenge.expires)
+            except (TypeError, ValueError) as error:
+                raise InvalidChallengeError(challenge.id, "invalid expires") from error
+            if expires.tzinfo is None:
+                raise InvalidChallengeError(challenge.id, "invalid expires")
+            if expires < datetime.now(UTC):
+                raise PaymentExpiredError(challenge.expires)
+
+        payload = {
+            **(event_payload or {}),
+            "challenge": challenge,
+            "method": method,
+        }
+        payload.setdefault("challenges", [challenge])
+        supplied = await self.events.emit(
+            CHALLENGE_RECEIVED,
+            payload,
+            first_result=True,
+        )
+        credential = (
+            supplied
+            if isinstance(supplied, Credential)
+            else await method.create_credential(challenge)
+        )
+        await self.events.emit(
+            CREDENTIAL_CREATED,
+            {**payload, "credential": credential},
+        )
+        return credential

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -8,6 +8,8 @@ from pytest_httpx import HTTPXMock
 
 from mpp import Challenge, Credential
 from mpp.client import Client, PaymentTransport, get, post, request
+from mpp.events import EventDispatcher
+from mpp.runtime import PaymentRuntime
 from tests import make_credential
 
 
@@ -44,6 +46,21 @@ class MockTransport(httpx.AsyncBaseTransport):
 
 
 class TestPaymentTransport:
+    def test_runtime_configuration_is_unambiguous(self) -> None:
+        class FalseyRuntime(PaymentRuntime):
+            def __bool__(self) -> bool:
+                return False
+
+        runtime = FalseyRuntime()
+
+        with pytest.raises(TypeError, match="exactly one"):
+            PaymentTransport()
+        with pytest.raises(TypeError, match="exactly one"):
+            PaymentTransport([], runtime=runtime)
+        with pytest.raises(TypeError, match="events belongs"):
+            PaymentTransport(runtime=runtime, events=EventDispatcher())
+        assert PaymentTransport(runtime=runtime)._runtime is runtime
+
     @pytest.mark.asyncio
     async def test_passes_through_non_402(self) -> None:
         """Should pass through non-402 responses unchanged."""
@@ -438,14 +455,18 @@ class TestPaymentTransport:
         await transport.aclose()
 
     @pytest.mark.asyncio
-    async def test_skips_expired_challenge(self) -> None:
-        """Should return 402 without paying if challenge is expired."""
+    @pytest.mark.parametrize(
+        "expires",
+        ["2020-01-01T00:00:00Z", "2020-01-01T00:00:00", "not-a-date"],
+    )
+    async def test_skips_invalid_or_expired_challenge(self, expires: str) -> None:
+        """Should return 402 without paying if challenge expiry is unsafe."""
         challenge = Challenge(
             id="test-id",
             method="tempo",
             intent="charge",
             request={"amount": "1000"},
-            expires="2020-01-01T00:00:00Z",  # Expired
+            expires=expires,
         )
         www_auth = challenge.to_www_authenticate("example.com")
 
@@ -592,6 +613,26 @@ class TestPaymentTransport:
 
 
 class TestClient:
+    @pytest.mark.asyncio
+    async def test_uses_shared_runtime(self, httpx_mock: HTTPXMock) -> None:
+        challenge = Challenge(
+            id="shared",
+            method="tempo",
+            intent="charge",
+            request={"amount": "1000"},
+        )
+        httpx_mock.add_response(
+            status_code=402,
+            headers={"www-authenticate": challenge.to_www_authenticate("example.com")},
+        )
+        httpx_mock.add_response(status_code=200)
+        runtime = PaymentRuntime([MockMethod()])
+
+        async with Client(runtime=runtime) as client:
+            response = await client.get("https://example.com")
+
+        assert response.status_code == 200
+
     @pytest.mark.asyncio
     async def test_context_manager(self) -> None:
         """Should work as async context manager."""

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1,0 +1,140 @@
+"""Tests for transport-neutral client payment handling."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from mpp import Challenge, Credential, InvalidChallengeError, PaymentExpiredError
+from mpp.events import EventDispatcher
+from mpp.runtime import PaymentRuntime
+
+
+def challenge(
+    identifier: str = "test",
+    *,
+    method: str = "tempo",
+    intent: str = "charge",
+    expires: str | None = None,
+) -> Challenge:
+    return Challenge(
+        id=identifier,
+        method=method,
+        intent=intent,
+        request={},
+        expires=expires,
+    )
+
+
+class MockMethod:
+    name = "tempo"
+
+    def __init__(self) -> None:
+        self.loops: list[asyncio.AbstractEventLoop] = []
+
+    async def create_credential(self, challenge: Challenge) -> Credential:
+        self.loops.append(asyncio.get_running_loop())
+        return Credential(challenge=challenge.to_echo(), payload={"ok": True})
+
+
+def test_matching_preserves_transport_selection() -> None:
+    class StripeMethod(MockMethod):
+        name = "stripe"
+
+    first_tempo = MockMethod()
+    last_tempo = MockMethod()
+    stripe = StripeMethod()
+    runtime = PaymentRuntime([first_tempo, stripe, last_tempo])
+    offered = [
+        challenge("stripe", method="stripe", intent="subscription"),
+        challenge("tempo", intent="unsupported"),
+    ]
+
+    assert runtime.match_challenge(offered) == (offered[0], stripe)
+    assert runtime.match_challenge([offered[1]]) == (offered[1], last_tempo)
+    with pytest.raises(ValueError, match="No compatible payment method"):
+        runtime.match_challenge([challenge(method="other")])
+
+
+def test_preserves_falsey_event_dispatcher() -> None:
+    class FalseyEvents(EventDispatcher):
+        def __bool__(self) -> bool:
+            return False
+
+    events = FalseyEvents()
+
+    assert PaymentRuntime(events=events).events is events
+
+
+async def test_credential_creation_and_events_use_caller_loop() -> None:
+    loop = asyncio.get_running_loop()
+    method = MockMethod()
+    runtime = PaymentRuntime([method])
+    event_loops: list[asyncio.AbstractEventLoop] = []
+    runtime.events.on("*", lambda _event: event_loops.append(asyncio.get_running_loop()))
+
+    credential = await runtime.create_credential(challenge(), method)
+
+    assert credential.payload == {"ok": True}
+    assert method.loops == [loop]
+    assert event_loops == [loop, loop]
+
+
+async def test_challenge_handler_can_supply_credential() -> None:
+    method = MockMethod()
+    supplied = Credential(challenge=challenge("supplied").to_echo(), payload={"event": True})
+    created: list[dict[str, Any]] = []
+    runtime = PaymentRuntime([method])
+    runtime.events.on("challenge.received", lambda _payload: supplied)
+    runtime.events.on("credential.created", created.append)
+
+    result = await runtime.create_credential(
+        challenge("requested"),
+        method,
+        event_payload={
+            "challenge": "cannot override",
+            "challenges": [challenge("offered")],
+            "source": "adapter",
+        },
+    )
+
+    assert result is supplied
+    assert method.loops == []
+    assert created[0]["challenge"].id == "requested"
+    assert created[0]["challenges"][0].id == "offered"
+    assert created[0]["source"] == "adapter"
+
+
+async def test_credential_creation_validates_method() -> None:
+    method = MockMethod()
+    runtime = PaymentRuntime([method])
+
+    with pytest.raises(ValueError, match="not installed"):
+        await runtime.create_credential(challenge(), MockMethod())
+    with pytest.raises(ValueError, match="does not support"):
+        await runtime.create_credential(challenge(method="stripe"), method)
+
+    assert method.loops == []
+
+
+@pytest.mark.parametrize(
+    ("expires", "error"),
+    [
+        ("not-a-date", InvalidChallengeError),
+        ("2020-01-01T00:00:00", InvalidChallengeError),
+        ("2020-01-01T00:00:00Z", PaymentExpiredError),
+    ],
+)
+async def test_credential_creation_rejects_invalid_expiry(
+    expires: str,
+    error: type[Exception],
+) -> None:
+    method = MockMethod()
+    runtime = PaymentRuntime([method])
+
+    with pytest.raises(error):
+        await runtime.create_credential(challenge(expires=expires), method)
+
+    assert method.loops == []


### PR DESCRIPTION
## Summary

- Add a transport-neutral, caller-loop `PaymentRuntime` for method matching, challenge expiry validation, credential creation, and shared lifecycle events.
- Let `Client` and `PaymentTransport` share an explicit runtime while preserving the existing `methods=` API.
- Reuse the core `Method` protocol in the existing MCP client instead of maintaining a duplicate.

This is intentionally only the core primitive. It adds no thread or loop ownership, sync bridge, origin policy, global HTTPX patching, or MCP instrumentation.

Stack: 1 of 2.

## Validation

- `790 passed, 41 skipped` on Python 3.11, 3.12, 3.13, and 3.14
- 93.94% coverage on Python 3.12
- Ruff check and format check
- Pyright
- Wheel and sdist build with strict Twine validation
- Fresh base, Tempo, and MCP wheel install smokes
