### PR TITLE
fix: harden async payment retries

### DIFF
--- a/.changelog/jolly-fish-shout.md
+++ b/.changelog/jolly-fish-shout.md
@@ -1,0 +1,5 @@
+---
+pympp: minor
+---
+
+Improved HTTP challenge parsing to correctly split merged `WWW-Authenticate` headers with quoted commas, added pass-through support for streaming request bodies on non-402 responses, and introduced `PaymentOutcomeUnknownError` (consolidated from the MCP client into core) to surface explicit errors when a paid retry outcome is uncertain due to network failures or task cancellation.

--- a/.changelog/jolly-fish-shout.md
+++ b/.changelog/jolly-fish-shout.md
@@ -2,4 +2,4 @@
 pympp: minor
 ---
 
-Improved HTTP challenge parsing to correctly split merged `WWW-Authenticate` headers with quoted commas, added pass-through support for streaming request bodies on non-402 responses, and introduced `PaymentOutcomeUnknownError` (consolidated from the MCP client into core) to surface explicit errors when a paid retry outcome is uncertain due to network failures or task cancellation.
+Improved HTTP challenge parsing to correctly split merged `WWW-Authenticate` headers with quoted commas, added pass-through support for streaming request bodies on ordinary and unrelated 402 responses, and introduced `PaymentOutcomeUnknownError` (consolidated from the MCP client into core) to surface explicit errors when a paid retry outcome is uncertain due to network failures or task cancellation.

--- a/src/mpp/__init__.py
+++ b/src/mpp/__init__.py
@@ -32,6 +32,7 @@ from mpp.errors import (
     PaymentExpiredError,
     PaymentInsufficientError,
     PaymentMethodUnsupportedError,
+    PaymentOutcomeUnknownError,
     PaymentRequiredError,
     VerificationFailedError,
 )

--- a/src/mpp/client/transport.py
+++ b/src/mpp/client/transport.py
@@ -10,6 +10,7 @@ Implements automatic 402 Payment Required handling by:
 from __future__ import annotations
 
 import asyncio
+from contextlib import suppress
 from typing import TYPE_CHECKING, Any
 
 import httpx
@@ -133,21 +134,15 @@ class PaymentTransport(httpx.AsyncBaseTransport):
         try:
             await response.aread()
         except BaseException:
-            try:
+            with suppress(BaseException):
                 await response.aclose()
-            except BaseException:
-                pass
             raise
 
         # Handle multiple WWW-Authenticate headers (per RFC 9110)
-        www_auth_headers = response.headers.get_list("www-authenticate")
-
         challenges: list[Challenge] = []
         parse_error: ParseError | None = None
-        for header in www_auth_headers:
-            for field in _auth_challenges(header):
-                if field.partition(" ")[0].lower() != "payment":
-                    continue
+        for header in response.headers.get_list("www-authenticate"):
+            for field in _payment_challenges(header):
                 try:
                     parsed = Challenge.from_www_authenticate(field)
                 except ParseError as error:
@@ -366,8 +361,8 @@ async def post(url: str, *, methods: Sequence[Method], **kwargs: Any) -> httpx.R
     return await request("POST", url, methods=methods, **kwargs)
 
 
-def _auth_challenges(value: str) -> list[str]:
-    """Split a merged WWW-Authenticate value without splitting quoted commas."""
+def _payment_challenges(value: str) -> list[str]:
+    """Return Payment challenges, preserving quoted commas and escapes."""
     fields: list[str] = []
     start = 0
     quoted = escaped = False
@@ -384,15 +379,15 @@ def _auth_challenges(value: str) -> list[str]:
     fields.append(value[start:])
 
     challenges: list[str] = []
-    token = "!#$%&'*+-.^_`|~0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
-    for field in fields:
-        field = field.strip()
-        end = 0
-        while end < len(field) and field[end] in token:
-            end += 1
-        new_challenge = end > 0 and not field[end:].lstrip().startswith("=")
-        if new_challenge or not challenges:
-            challenges.append(field)
-        else:
-            challenges[-1] += f", {field}"
+    current: list[str] | None = None
+    for field in map(str.strip, fields):
+        scheme, _, remainder = field.partition(" ")
+        if "=" not in scheme and not remainder.lstrip().startswith("="):
+            if current:
+                challenges.append(", ".join(current))
+            current = [field] if scheme.lower() == "payment" else None
+        elif current:
+            current.append(field)
+    if current:
+        challenges.append(", ".join(current))
     return challenges

--- a/src/mpp/client/transport.py
+++ b/src/mpp/client/transport.py
@@ -129,12 +129,6 @@ class PaymentTransport(httpx.AsyncBaseTransport):
 
         if response.status_code != 402:
             return response
-        if not replayable:
-            await response.aclose()
-            raise PaymentError(
-                "Streaming request bodies cannot be replayed after a payment challenge. "
-                "Use a buffered body for paid requests."
-            )
 
         try:
             await response.aread()
@@ -180,6 +174,13 @@ class PaymentTransport(httpx.AsyncBaseTransport):
                     ),
                 )
             return response
+
+        if not replayable:
+            await response.aclose()
+            raise PaymentError(
+                "Streaming request bodies cannot be replayed after a payment challenge. "
+                "Use a buffered body for paid requests."
+            )
 
         try:
             credential = await self._runtime.create_credential(

--- a/src/mpp/client/transport.py
+++ b/src/mpp/client/transport.py
@@ -9,13 +9,19 @@ Implements automatic 402 Payment Required handling by:
 
 from __future__ import annotations
 
+import asyncio
 from typing import TYPE_CHECKING, Any
 
 import httpx
 
 from mpp import Challenge, Credential
 from mpp._parsing import ParseError
-from mpp.errors import InvalidChallengeError, PaymentError, PaymentExpiredError
+from mpp.errors import (
+    InvalidChallengeError,
+    PaymentError,
+    PaymentExpiredError,
+    PaymentOutcomeUnknownError,
+)
 from mpp.events import (
     CHALLENGE_RECEIVED,
     CREDENTIAL_CREATED,
@@ -112,31 +118,32 @@ class PaymentTransport(httpx.AsyncBaseTransport):
 
     async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
         """Handle request, automatically retrying on 402 with credentials."""
-        # Async-generator bodies (content=async_gen()) produce an AsyncByteStream
-        # that is not also a SyncByteStream. They cannot be safely buffered for
-        # replay: the generator may be infinite, already partially consumed, or
-        # tied to a one-shot I/O source. Reject early so callers get a clear
-        # message instead of a silent empty body on the paid retry.
-        if isinstance(request.stream, httpx.AsyncByteStream) and not isinstance(
-            request.stream, httpx.SyncByteStream
-        ):
-            raise PaymentError(
-                "Streaming request bodies (async generators) are not supported "
-                "through the payment retry flow. Use a buffered body "
-                "(bytes, str, files=, or data=) instead."
-            )
-
-        # Buffer the request body before the first dispatch so it can be replayed
-        # on a paid 402 retry. Handles bytes bodies and multipart/files= bodies.
-        # After aread() the stream is replaced with a replayable ByteStream.
-        await request.aread()
+        replayable = not (
+            isinstance(request.stream, httpx.AsyncByteStream)
+            and not isinstance(request.stream, httpx.SyncByteStream)
+        )
+        if replayable:
+            await request.aread()
 
         response = await self._inner.handle_async_request(request)
 
         if response.status_code != 402:
             return response
+        if not replayable:
+            await response.aclose()
+            raise PaymentError(
+                "Streaming request bodies cannot be replayed after a payment challenge. "
+                "Use a buffered body for paid requests."
+            )
 
-        await response.aread()
+        try:
+            await response.aread()
+        except BaseException:
+            try:
+                await response.aclose()
+            except BaseException:
+                pass
+            raise
 
         # Handle multiple WWW-Authenticate headers (per RFC 9110)
         www_auth_headers = response.headers.get_list("www-authenticate")
@@ -144,14 +151,15 @@ class PaymentTransport(httpx.AsyncBaseTransport):
         challenges: list[Challenge] = []
         parse_error: ParseError | None = None
         for header in www_auth_headers:
-            if not header.lower().startswith("payment "):
-                continue
-            try:
-                parsed = Challenge.from_www_authenticate(header)
-            except ParseError as error:
-                parse_error = error
-                continue
-            challenges.append(parsed)
+            for field in _auth_challenges(header):
+                if field.partition(" ")[0].lower() != "payment":
+                    continue
+                try:
+                    parsed = Challenge.from_www_authenticate(field)
+                except ParseError as error:
+                    parse_error = error
+                    continue
+                challenges.append(parsed)
 
         try:
             challenge, matched_method = self._runtime.match_challenge(challenges)
@@ -214,7 +222,13 @@ class PaymentTransport(httpx.AsyncBaseTransport):
 
         try:
             payment_response = await self._inner.handle_async_request(retry_request)
-        except Exception as error:
+        except (Exception, asyncio.CancelledError) as cause:
+            error = PaymentOutcomeUnknownError(
+                challenge,
+                cause,
+                credential=credential,
+                request=request,
+            )
             await self._events.emit(
                 PAYMENT_FAILED,
                 _client_payment_failed_payload(
@@ -227,7 +241,7 @@ class PaymentTransport(httpx.AsyncBaseTransport):
                     response=response,
                 ),
             )
-            raise
+            raise error from cause
 
         if payment_response.is_success:
             await self._events.emit(
@@ -349,3 +363,35 @@ async def get(url: str, *, methods: Sequence[Method], **kwargs: Any) -> httpx.Re
 async def post(url: str, *, methods: Sequence[Method], **kwargs: Any) -> httpx.Response:
     """Send a POST request with automatic payment handling."""
     return await request("POST", url, methods=methods, **kwargs)
+
+
+def _auth_challenges(value: str) -> list[str]:
+    """Split a merged WWW-Authenticate value without splitting quoted commas."""
+    fields: list[str] = []
+    start = 0
+    quoted = escaped = False
+    for index, character in enumerate(value):
+        if escaped:
+            escaped = False
+        elif quoted and character == "\\":
+            escaped = True
+        elif character == '"':
+            quoted = not quoted
+        elif character == "," and not quoted:
+            fields.append(value[start:index])
+            start = index + 1
+    fields.append(value[start:])
+
+    challenges: list[str] = []
+    token = "!#$%&'*+-.^_`|~0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    for field in fields:
+        field = field.strip()
+        end = 0
+        while end < len(field) and field[end] in token:
+            end += 1
+        new_challenge = end > 0 and not field[end:].lstrip().startswith("=")
+        if new_challenge or not challenges:
+            challenges.append(field)
+        else:
+            challenges[-1] += f", {field}"
+    return challenges

--- a/src/mpp/errors.py
+++ b/src/mpp/errors.py
@@ -71,6 +71,27 @@ class PaymentError(Exception):
         return details
 
 
+class PaymentOutcomeUnknownError(PaymentError, RuntimeError):
+    """A credential was sent, but the payment result could not be confirmed."""
+
+    def __init__(
+        self,
+        challenge: Any,
+        cause: BaseException,
+        *,
+        credential: Any = None,
+        request: Any = None,
+    ) -> None:
+        self.challenge = challenge
+        self.cause = cause
+        self.credential = credential
+        self.request = request
+        super().__init__(
+            "Payment outcome is unknown after sending a credential "
+            f"for challenge {challenge.id}. Do not blindly retry."
+        )
+
+
 class PaymentRequiredError(PaymentError):
     """No credential was provided but payment is required."""
 

--- a/src/mpp/extensions/mcp/client.py
+++ b/src/mpp/extensions/mcp/client.py
@@ -29,24 +29,12 @@ import logging
 from dataclasses import dataclass
 from typing import Any
 
+from mpp.errors import PaymentOutcomeUnknownError as PaymentOutcomeUnknownError
 from mpp.extensions.mcp.constants import CODE_PAYMENT_REQUIRED, META_RECEIPT
 from mpp.extensions.mcp.types import MCPChallenge, MCPCredential, MCPReceipt
 from mpp.runtime import Method as Method
 
 logger = logging.getLogger(__name__)
-
-
-class PaymentOutcomeUnknownError(RuntimeError):
-    """Raised when a paid retry fails after a credential was attached."""
-
-    def __init__(self, challenge: MCPChallenge, cause: Exception) -> None:
-        self.challenge = challenge
-        self.cause = cause
-        super().__init__(
-            "Tool call failed after sending a payment credential; "
-            f"payment outcome is unknown for challenge {challenge.id}. "
-            "Do not blindly retry."
-        )
 
 
 def _error_code(error: Exception) -> int | None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -596,7 +596,7 @@ class TestPaymentTransport:
             method="tempo",
             intent="charge",
             request={"amount": "1000"},
-            description="one, two",
+            description='one "two", three',
         )
         second = Challenge(
             id="second",
@@ -608,6 +608,7 @@ class TestPaymentTransport:
             [
                 'Bearer realm="example"',
                 first.to_www_authenticate("example.com"),
+                'Basic realm="other"',
                 second.to_www_authenticate("example.com"),
             ]
         )
@@ -626,7 +627,7 @@ class TestPaymentTransport:
 
         assert response.status_code == 200
         assert [(item.id, item.description) for item in received] == [
-            ("first", "one, two"),
+            ("first", 'one "two", three'),
             ("second", None),
         ]
         assert method.create_credential.call_args.args[0].id == "first"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,12 +1,13 @@
 """Tests for client-side transport."""
 
+import asyncio
 from unittest.mock import AsyncMock
 
 import httpx
 import pytest
 from pytest_httpx import HTTPXMock
 
-from mpp import Challenge, Credential
+from mpp import Challenge, Credential, PaymentOutcomeUnknownError
 from mpp.client import Client, PaymentTransport, get, post, request
 from mpp.events import EventDispatcher
 from mpp.runtime import PaymentRuntime
@@ -232,7 +233,7 @@ class TestPaymentTransport:
 
     @pytest.mark.asyncio
     async def test_paid_retry_raises_for_streaming_body(self) -> None:
-        """Should raise PaymentError upfront for async generator (streaming) bodies.
+        """Should raise after a 402 for an async generator body.
 
         Streaming bodies cannot be reliably buffered and replayed: the generator
         may be infinite, already partially consumed, or tied to a one-shot source.
@@ -264,7 +265,45 @@ class TestPaymentTransport:
         with pytest.raises(PaymentError, match="Streaming request bodies"):
             await transport.handle_async_request(request)
 
-        assert len(inner.requests) == 0
+        assert len(inner.requests) == 1
+
+    @pytest.mark.asyncio
+    async def test_streaming_body_passes_through_non_402(self) -> None:
+        inner = MockTransport([httpx.Response(200)])
+        transport = PaymentTransport(methods=[], inner=inner)
+
+        async def body():
+            yield b"one-shot"
+
+        response = await transport.handle_async_request(
+            httpx.Request("POST", "https://example.com", content=body())
+        )
+
+        assert response.status_code == 200
+        assert len(inner.requests) == 1
+
+    @pytest.mark.asyncio
+    async def test_closes_challenge_response_when_read_fails(self) -> None:
+        class FailingStream(httpx.AsyncByteStream):
+            closed = False
+
+            async def __aiter__(self):
+                raise RuntimeError("read failed")
+                yield b""  # pragma: no cover
+
+            async def aclose(self) -> None:
+                self.closed = True
+
+        stream = FailingStream()
+        transport = PaymentTransport(
+            methods=[MockMethod()],
+            inner=MockTransport([httpx.Response(402, stream=stream)]),
+        )
+
+        with pytest.raises(RuntimeError, match="read failed"):
+            await transport.handle_async_request(httpx.Request("GET", "https://example.com"))
+
+        assert stream.closed
 
     @pytest.mark.asyncio
     async def test_emits_client_payment_events(self) -> None:
@@ -521,6 +560,48 @@ class TestPaymentTransport:
         method.create_credential.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_handles_merged_www_authenticate_challenges(self) -> None:
+        first = Challenge(
+            id="first",
+            method="tempo",
+            intent="charge",
+            request={"amount": "1000"},
+            description="one, two",
+        )
+        second = Challenge(
+            id="second",
+            method="stripe",
+            intent="charge",
+            request={"amount": "1000"},
+        )
+        header = ", ".join(
+            [
+                'Bearer realm="example"',
+                first.to_www_authenticate("example.com"),
+                second.to_www_authenticate("example.com"),
+            ]
+        )
+        inner = MockTransport(
+            [
+                httpx.Response(402, headers={"www-authenticate": header}),
+                httpx.Response(200),
+            ]
+        )
+        method = MockMethod()
+        transport = PaymentTransport(methods=[method], inner=inner)
+        received: list[Challenge] = []
+        transport.on_challenge_received(lambda payload: received.extend(payload["challenges"]))
+
+        response = await transport.handle_async_request(httpx.Request("GET", "https://example.com"))
+
+        assert response.status_code == 200
+        assert [(item.id, item.description) for item in received] == [
+            ("first", "one, two"),
+            ("second", None),
+        ]
+        assert method.create_credential.call_args.args[0].id == "first"
+
+    @pytest.mark.asyncio
     async def test_does_not_retry_when_method_rejects_challenge(self) -> None:
         """Should not send an Authorization retry when the method rejects the challenge."""
         challenge = Challenge(
@@ -606,10 +687,76 @@ class TestPaymentTransport:
             )
         )
 
-        with pytest.raises(RuntimeError, match="network failed"):
+        with pytest.raises(PaymentOutcomeUnknownError, match="Do not blindly retry") as raised:
             await transport.handle_async_request(httpx.Request("GET", "https://example.com"))
 
-        assert events == ["failed:test-id:RuntimeError"]
+        assert isinstance(raised.value.__cause__, RuntimeError)
+        assert raised.value.challenge.id == challenge.id
+        assert raised.value.credential is not None
+        assert raised.value.request.url == httpx.URL("https://example.com")
+        assert events == ["failed:test-id:PaymentOutcomeUnknownError"]
+
+    @pytest.mark.asyncio
+    async def test_cancelled_paid_retry_has_unknown_outcome(self) -> None:
+        challenge = Challenge(
+            id="test-id",
+            method="tempo",
+            intent="charge",
+            request={"amount": "1000"},
+        )
+        retry_started = asyncio.Event()
+
+        class CancelledRetryTransport(MockTransport):
+            async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+                self.requests.append(request)
+                if len(self.requests) == 1:
+                    return httpx.Response(
+                        402,
+                        headers={"www-authenticate": challenge.to_www_authenticate("example.com")},
+                    )
+                retry_started.set()
+                await asyncio.Event().wait()
+                raise AssertionError("unreachable")
+
+        transport = PaymentTransport(
+            methods=[MockMethod()],
+            inner=CancelledRetryTransport([]),
+        )
+        failed: list[Exception] = []
+        transport.on_payment_failed(lambda payload: failed.append(payload["error"]))
+        task = asyncio.create_task(
+            transport.handle_async_request(httpx.Request("GET", "https://example.com"))
+        )
+        await retry_started.wait()
+        task.cancel()
+
+        with pytest.raises(PaymentOutcomeUnknownError) as raised:
+            await task
+        assert isinstance(raised.value.__cause__, asyncio.CancelledError)
+        assert failed == [raised.value]
+        assert not task.cancelled()
+
+    @pytest.mark.asyncio
+    async def test_does_not_pay_again_after_repeated_402(self) -> None:
+        challenge = Challenge(
+            id="test-id",
+            method="tempo",
+            intent="charge",
+            request={"amount": "1000"},
+        )
+        required = httpx.Response(
+            402,
+            headers={"www-authenticate": challenge.to_www_authenticate("example.com")},
+        )
+        inner = MockTransport([required, required])
+        method = MockMethod()
+        transport = PaymentTransport(methods=[method], inner=inner)
+
+        response = await transport.handle_async_request(httpx.Request("GET", "https://example.com"))
+
+        assert response.status_code == 402
+        assert len(inner.requests) == 2
+        method.create_credential.assert_awaited_once()
 
 
 class TestClient:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -283,6 +283,36 @@ class TestPaymentTransport:
         assert len(inner.requests) == 1
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "www_authenticate",
+        [
+            None,
+            "Bearer realm=test",
+            Challenge(
+                id="test-id",
+                method="stripe",
+                intent="charge",
+                request={"amount": "1000"},
+            ).to_www_authenticate("example.com"),
+        ],
+    )
+    async def test_streaming_body_returns_unmatched_402(self, www_authenticate: str | None) -> None:
+        headers = {"www-authenticate": www_authenticate} if www_authenticate else {}
+        inner = MockTransport([httpx.Response(402, headers=headers, content=b"unmatched")])
+        transport = PaymentTransport(methods=[MockMethod()], inner=inner)
+
+        async def body():
+            yield b"one-shot"
+
+        response = await transport.handle_async_request(
+            httpx.Request("POST", "https://example.com", content=body())
+        )
+
+        assert response.status_code == 402
+        assert response.content == b"unmatched"
+        assert len(inner.requests) == 1
+
+    @pytest.mark.asyncio
     async def test_closes_challenge_response_when_read_fails(self) -> None:
         class FailingStream(httpx.AsyncByteStream):
             closed = False

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -12,6 +12,7 @@ from mpp.errors import (
     PaymentExpiredError,
     PaymentInsufficientError,
     PaymentMethodUnsupportedError,
+    PaymentOutcomeUnknownError,
     PaymentRequiredError,
     VerificationFailedError,
 )
@@ -105,6 +106,25 @@ class TestAutoTitle:
 
 
 class TestSubclassInstantiation:
+    def test_payment_outcome_unknown_preserves_context(self) -> None:
+        challenge = type("Challenge", (), {"id": "challenge-id"})()
+        cause = TimeoutError("lost response")
+        credential = object()
+        request = object()
+
+        error = PaymentOutcomeUnknownError(
+            challenge,
+            cause,
+            credential=credential,
+            request=request,
+        )
+
+        assert "Do not blindly retry" in str(error)
+        assert error.challenge is challenge
+        assert error.cause is cause
+        assert error.credential is credential
+        assert error.request is request
+
     def test_payment_required_with_args(self) -> None:
         err = PaymentRequiredError(realm="api.example.com", description="Monthly quota")
         assert "api.example.com" in str(err)

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from mpp import Challenge, Credential
+from mpp import PaymentOutcomeUnknownError as CoreOutcomeUnknownError
 from mpp.extensions.mcp import (
     META_CREDENTIAL,
     META_RECEIPT,
@@ -18,6 +19,11 @@ from mpp.extensions.mcp import (
 )
 from mpp.extensions.mcp.client import _extract_challenges, _is_payment_required_error
 from mpp.extensions.mcp.types import MCPChallenge, MCPReceipt
+
+
+def test_outcome_unknown_error_is_shared() -> None:
+    assert PaymentOutcomeUnknownError is CoreOutcomeUnknownError
+
 
 # ---------------------------------------------------------------------------
 # Helpers


### PR DESCRIPTION
## Summary

- Parse merged `WWW-Authenticate` fields correctly, including multiple schemes and quoted commas.
- Pass one-shot async bodies through for ordinary and unrelated 402 responses; reject them only when a supported payment challenge actually requires replay.
- Close failed challenge reads and surface cancelled or failed credentialed retries as the shared `PaymentOutcomeUnknownError`.
- Reuse that same outcome error from the existing MCP client instead of maintaining a second type.

This remains async and transport-local. It adds no sync bridge, global instrumentation, thread lifecycle, or origin policy. Together with the reusable runtime from #201, it is the complete pympp surface needed by the charge-only Hermes v1; HTTPX instrumentation and harness policy remain in the plugin.

## Validation

- `800 passed, 41 skipped` with 94% coverage; the changed transport is at 100%
- Ruff check and format check
- Pyright
- Source distribution and wheel build; strict Twine validation
- Full Python 3.11–3.14 matrix, integration, package/install, conformance, and security checks
- Charge-only Hermes Agent 0.19 plugin against this exact head on HTTPX 0.28.1: `28 passed`, including real plugin discovery with zero exposed tools and transparent sync, async, and pre-existing clients
- Built Hermes wheel loaded through the packaged `hermes_agent.plugins` entry point
- Live Moderato charges against `mpp.dev` succeeded through direct pympp and ordinary Hermes sync and async HTTPX requests, returning paid `200` responses and Tempo receipts
- A transient repeated live `402` was bounded and failed closed without a second retry or wallet balance movement
