### PR TITLE
feat: add Tempo relay and verifiable intents

### DIFF
--- a/.changelog/dry-wolves-write.md
+++ b/.changelog/dry-wolves-write.md
@@ -2,4 +2,4 @@
 pympp: minor
 ---
 
-Added a `SplitIntent` protocol with split `validate_credential`/`broadcast_credential` lifecycle APIs to separate non-mutating validation from terminal settlement, introduced a `Relay` adapter that delegates Tempo charge validation and finalization to the Tempo API relay (surfacing only safe machine-readable error codes and retryable 402 challenges on decline), and added a runnable `charge-relay` FastAPI example with a payer client. Relay and Stripe idempotency keys now use the `pympp_` namespace, internal route scope uses `_mpp_scope`, and Python validation details use snake_case.
+Added a `SplitIntent` protocol with separate `validate` and `broadcast` hooks plus bound `Mpp.validate_credential()` and `Mpp.broadcast_credential()` APIs, introduced a `Relay` adapter that delegates Tempo charge validation and finalization to the Tempo API relay (surfacing only safe machine-readable error codes and retryable 402 challenges on decline), and added a runnable `charge-relay` FastAPI example with a payer client. Relay and Stripe idempotency keys now use the `pympp_` namespace, and Python validation details use snake_case.

--- a/.changelog/dry-wolves-write.md
+++ b/.changelog/dry-wolves-write.md
@@ -2,4 +2,4 @@
 pympp: minor
 ---
 
-Added a `SplitIntent` protocol with split `validate_credential`/`broadcast_credential` lifecycle APIs to separate non-mutating validation from terminal settlement, introduced a `Relay` adapter that delegates Tempo charge validation and finalization to the Tempo API relay (surfacing only safe machine-readable error codes and retryable 402 challenges on decline), and added a runnable `charge-relay` FastAPI example with a payer client.
+Added a `SplitIntent` protocol with split `validate_credential`/`broadcast_credential` lifecycle APIs to separate non-mutating validation from terminal settlement, introduced a `Relay` adapter that delegates Tempo charge validation and finalization to the Tempo API relay (surfacing only safe machine-readable error codes and retryable 402 challenges on decline), and added a runnable `charge-relay` FastAPI example with a payer client. Relay and Stripe idempotency keys now use the `pympp_` namespace, internal route scope uses `_mpp_scope`, and Python validation details use snake_case.

--- a/.changelog/dry-wolves-write.md
+++ b/.changelog/dry-wolves-write.md
@@ -2,4 +2,4 @@
 pympp: minor
 ---
 
-Added a `SplitIntent` protocol with separate `validate` and `broadcast` hooks plus bound `Mpp.validate_credential()` and `Mpp.broadcast_credential()` APIs, introduced a `Relay` adapter that delegates Tempo charge validation and finalization to the Tempo API relay (surfacing only safe machine-readable error codes and retryable 402 challenges on decline), and added a runnable `charge-relay` FastAPI example with a payer client. Relay and Stripe idempotency keys now use the `pympp_` namespace, and Python validation details use snake_case.
+Added a `VerifiableIntent` protocol with separate `validate` and `broadcast` hooks plus bound `Mpp.validate_credential()` and `Mpp.broadcast_credential()` APIs, introduced a `Relay` adapter that delegates Tempo charge validation and finalization to the Tempo API relay (surfacing only safe machine-readable error codes and retryable 402 challenges on decline), and added a runnable `charge-relay` FastAPI example with a payer client. Relay idempotency keys use the `pympp_` namespace, existing Stripe idempotency behavior remains unchanged, and Python validation details use snake_case.

--- a/.changelog/dry-wolves-write.md
+++ b/.changelog/dry-wolves-write.md
@@ -2,4 +2,4 @@
 pympp: minor
 ---
 
-Added split credential validation and broadcast APIs (`validate_credential`, `broadcast_credential`) alongside a new `SplitIntent` protocol to separate advisory and terminal charge phases. Introduced a `Relay` class that delegates Tempo charge validation and finalization to the Tempo API relay, and added a `charge-relay` example demonstrating FastAPI route protection settled through the relay.
+Added a `SplitIntent` protocol with split `validate_credential`/`broadcast_credential` lifecycle APIs to separate non-mutating validation from terminal settlement, introduced a `Relay` adapter that delegates Tempo charge validation and finalization to the Tempo API relay (surfacing only safe machine-readable error codes and retryable 402 challenges on decline), and added a runnable `charge-relay` FastAPI example with a payer client.

--- a/.changelog/dry-wolves-write.md
+++ b/.changelog/dry-wolves-write.md
@@ -1,0 +1,5 @@
+---
+pympp: minor
+---
+
+Added split credential validation and broadcast APIs (`validate_credential`, `broadcast_credential`) alongside a new `SplitIntent` protocol to separate advisory and terminal charge phases. Introduced a `Relay` class that delegates Tempo charge validation and finalization to the Tempo API relay, and added a `charge-relay` example demonstrating FastAPI route protection settled through the relay.

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,6 +6,7 @@ Code examples for using the Machine Payments Protocol (pympp).
 
 | Example | Description |
 |---------|-------------|
+| [charge-relay/](charge-relay/) | FastAPI charge settled through the Tempo API relay |
 | [fetch/](fetch/) | CLI tool for fetching URLs with automatic payment handling |
 | [mcp-server/](mcp-server/) | MCP server with payment-protected tools |
 | [stripe/](stripe/) | Stripe SPT payment flow (server + headless client) |

--- a/examples/charge-relay/README.md
+++ b/examples/charge-relay/README.md
@@ -4,7 +4,8 @@ This example protects a FastAPI route with a 0.01 pathUSD charge on Tempo
 Moderato. pympp authenticates the challenge while Tempo API validates and
 finalizes the submitted credential.
 
-Start the server:
+Create a Tempo API key with the `mpp:write` scope, provide it only to the
+server process, and start the server:
 
 ```bash
 export TEMPO_API_KEY=tempo:sk:...
@@ -12,6 +13,11 @@ export MPP_SECRET_KEY=$(openssl rand -base64 32)
 uv sync
 uv run server.py
 ```
+
+`TEMPO_API_URL` can target a compatible self-hosted or preview Tempo API
+(default `https://api.tempo.xyz`). `MPP_SECRET_KEY` protects the
+server-issued challenges; the example has a development-only default so it
+can run locally without one.
 
 Then run the included payer in another terminal:
 
@@ -34,3 +40,8 @@ The server flow is:
 `Mpp.validate_credential()` exposes the advisory phase independently;
 `Mpp.broadcast_credential()` revalidates before the terminal phase.
 `Mpp.verify_credential()` remains a terminal alias.
+
+When the relay declines a payment, the route responds with a 402
+problem-details body carrying only safe machine-readable error codes (for
+example `insufficient_funds`) and a fresh challenge for retry; relay
+internals are never exposed.

--- a/examples/charge-relay/README.md
+++ b/examples/charge-relay/README.md
@@ -39,7 +39,7 @@ The server flow is:
 
 `Mpp.validate_credential()` exposes the advisory phase independently;
 `Mpp.broadcast_credential()` revalidates before the terminal phase.
-`Mpp.verify_credential()` is a terminal alias matching mppx's `verifyCredential`.
+`Mpp.verify_credential()` remains available as a terminal compatibility alias.
 
 When the relay declines a payment, the route responds with a 402
 problem-details body carrying only safe machine-readable error codes (for

--- a/examples/charge-relay/README.md
+++ b/examples/charge-relay/README.md
@@ -39,7 +39,7 @@ The server flow is:
 
 `Mpp.validate_credential()` exposes the advisory phase independently;
 `Mpp.broadcast_credential()` revalidates before the terminal phase.
-`Mpp.verify_credential()` remains a terminal alias.
+`Mpp.verify_credential()` is a terminal alias matching mppx's `verifyCredential`.
 
 When the relay declines a payment, the route responds with a 402
 problem-details body carrying only safe machine-readable error codes (for

--- a/examples/charge-relay/README.md
+++ b/examples/charge-relay/README.md
@@ -17,7 +17,8 @@ uv run server.py
 `TEMPO_API_URL` can target a compatible self-hosted or preview Tempo API
 (default `https://api.tempo.xyz`). `MPP_SECRET_KEY` protects the
 server-issued challenges; the example has a development-only default so it
-can run locally without one.
+can run locally without one. The server listens on port 8000 by default; set
+`PORT` to override it.
 
 Then run the included payer in another terminal:
 
@@ -39,7 +40,6 @@ The server flow is:
 
 `Mpp.validate_credential()` exposes the advisory phase independently;
 `Mpp.broadcast_credential()` revalidates before the terminal phase.
-`Mpp.verify_credential()` remains available as a terminal compatibility alias.
 
 When the relay declines a payment, the route responds with a 402
 problem-details body carrying only safe machine-readable error codes (for

--- a/examples/charge-relay/README.md
+++ b/examples/charge-relay/README.md
@@ -1,0 +1,36 @@
+# Tempo API charge relay
+
+This example protects a FastAPI route with a 0.01 pathUSD charge on Tempo
+Moderato. pympp authenticates the challenge while Tempo API validates and
+finalizes the submitted credential.
+
+Start the server:
+
+```bash
+export TEMPO_API_KEY=tempo:sk:...
+export MPP_SECRET_KEY=$(openssl rand -base64 32)
+uv sync
+uv run server.py
+```
+
+Then run the included payer in another terminal:
+
+```bash
+uv run client.py
+```
+
+The client creates and funds a disposable Moderato account, handles the initial
+402 challenge, pays it, and prints the decoded `Payment-Receipt`. Set
+`TEMPO_PRIVATE_KEY` to reuse a test account or `PAYMENT_URL` to call another
+deployment.
+
+The server flow is:
+
+1. Issue a bound `tempo/charge` challenge.
+2. Call `POST /v1/mpp/validate` without consuming the credential.
+3. Call `POST /v1/mpp/broadcast` with a deterministic idempotency key.
+4. Return the relay receipt in `Payment-Receipt`.
+
+`Mpp.validate_credential()` exposes the advisory phase independently;
+`Mpp.broadcast_credential()` revalidates before the terminal phase.
+`Mpp.verify_credential()` remains a terminal alias.

--- a/examples/charge-relay/client.py
+++ b/examples/charge-relay/client.py
@@ -1,0 +1,81 @@
+"""Fund a disposable Moderato account and call the paid example route."""
+
+import asyncio
+import json
+import os
+import secrets
+from typing import Any
+
+import httpx
+
+from mpp import Receipt
+from mpp.client import Client
+from mpp.methods.tempo import ChargeIntent, TempoAccount, tempo
+from mpp.methods.tempo._defaults import PATH_USD, TESTNET_CHAIN_ID, TESTNET_RPC_URL
+
+
+async def rpc(client: httpx.AsyncClient, method: str, params: list[Any]) -> Any:
+    response = await client.post(
+        TESTNET_RPC_URL,
+        json={"jsonrpc": "2.0", "id": 1, "method": method, "params": params},
+    )
+    response.raise_for_status()
+    result = response.json()
+    if "error" in result:
+        raise RuntimeError(str(result["error"]))
+    return result["result"]
+
+
+async def fund(account: TempoAccount) -> None:
+    balance_call = "0x70a08231" + "0" * 24 + account.address[2:].lower()
+    async with httpx.AsyncClient(timeout=30) as client:
+        await rpc(client, "tempo_fundAddress", [account.address])
+        for _ in range(60):
+            balance = await rpc(
+                client,
+                "eth_call",
+                [{"to": PATH_USD, "data": balance_call}, "latest"],
+            )
+            if int(balance, 16) > 0:
+                return
+            await asyncio.sleep(0.5)
+    raise RuntimeError("Moderato funding was not visible after 30 seconds")
+
+
+async def main() -> None:
+    account = TempoAccount.from_key(
+        os.environ.get("TEMPO_PRIVATE_KEY", "0x" + secrets.token_hex(32))
+    )
+    await fund(account)
+
+    method = tempo(
+        account=account,
+        chain_id=TESTNET_CHAIN_ID,
+        rpc_url=TESTNET_RPC_URL,
+        intents={"charge": ChargeIntent()},
+    )
+    async with Client(methods=[method]) as client:
+        response = await client.get(os.environ.get("PAYMENT_URL", "http://127.0.0.1:5173/photo"))
+    response.raise_for_status()
+
+    receipt = Receipt.from_payment_receipt(response.headers["Payment-Receipt"])
+    print(
+        json.dumps(
+            {
+                "payer": account.address,
+                "response": response.json(),
+                "status": response.status_code,
+                "receipt": {
+                    "method": receipt.method,
+                    "reference": receipt.reference,
+                    "status": receipt.status,
+                    "timestamp": receipt.timestamp.isoformat(),
+                },
+            },
+            indent=2,
+        )
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/charge-relay/client.py
+++ b/examples/charge-relay/client.py
@@ -4,7 +4,6 @@ import asyncio
 import json
 import os
 import secrets
-from typing import Any
 
 import httpx
 
@@ -12,29 +11,19 @@ from mpp import Receipt
 from mpp.client import Client
 from mpp.methods.tempo import ChargeIntent, TempoAccount, tempo
 from mpp.methods.tempo._defaults import PATH_USD, TESTNET_CHAIN_ID, TESTNET_RPC_URL
-
-
-async def rpc(client: httpx.AsyncClient, method: str, params: list[Any]) -> Any:
-    response = await client.post(
-        TESTNET_RPC_URL,
-        json={"jsonrpc": "2.0", "id": 1, "method": method, "params": params},
-    )
-    response.raise_for_status()
-    result = response.json()
-    if "error" in result:
-        raise RuntimeError(str(result["error"]))
-    return result["result"]
+from mpp.methods.tempo._rpc import _rpc_call
 
 
 async def fund(account: TempoAccount) -> None:
     balance_call = "0x70a08231" + "0" * 24 + account.address[2:].lower()
     async with httpx.AsyncClient(timeout=30) as client:
-        await rpc(client, "tempo_fundAddress", [account.address])
+        await _rpc_call(TESTNET_RPC_URL, "tempo_fundAddress", [account.address], client=client)
         for _ in range(60):
-            balance = await rpc(
-                client,
+            balance = await _rpc_call(
+                TESTNET_RPC_URL,
                 "eth_call",
                 [{"to": PATH_USD, "data": balance_call}, "latest"],
+                client=client,
             )
             if int(balance, 16) > 0:
                 return

--- a/examples/charge-relay/client.py
+++ b/examples/charge-relay/client.py
@@ -11,21 +11,20 @@ from mpp import Receipt
 from mpp.client import Client
 from mpp.methods.tempo import ChargeIntent, TempoAccount, tempo
 from mpp.methods.tempo._defaults import PATH_USD, TESTNET_CHAIN_ID, TESTNET_RPC_URL
-from mpp.methods.tempo._rpc import _rpc_call
+from mpp.methods.tempo._rpc import _rpc_call, _tip20_balance
 
 
 async def fund(account: TempoAccount) -> None:
-    balance_call = "0x70a08231" + "0" * 24 + account.address[2:].lower()
     async with httpx.AsyncClient(timeout=30) as client:
         await _rpc_call(TESTNET_RPC_URL, "tempo_fundAddress", [account.address], client=client)
         for _ in range(60):
-            balance = await _rpc_call(
+            balance = await _tip20_balance(
                 TESTNET_RPC_URL,
-                "eth_call",
-                [{"to": PATH_USD, "data": balance_call}, "latest"],
+                PATH_USD,
+                account.address,
                 client=client,
             )
-            if int(balance, 16) > 0:
+            if balance > 0:
                 return
             await asyncio.sleep(0.5)
     raise RuntimeError("Moderato funding was not visible after 30 seconds")
@@ -44,7 +43,7 @@ async def main() -> None:
         intents={"charge": ChargeIntent()},
     )
     async with Client(methods=[method]) as client:
-        response = await client.get(os.environ.get("PAYMENT_URL", "http://127.0.0.1:5173/photo"))
+        response = await client.get(os.environ.get("PAYMENT_URL", "http://127.0.0.1:8000/photo"))
     response.raise_for_status()
 
     receipt = Receipt.from_payment_receipt(response.headers["Payment-Receipt"])

--- a/examples/charge-relay/pyproject.toml
+++ b/examples/charge-relay/pyproject.toml
@@ -1,0 +1,8 @@
+[project]
+name = "pympp-charge-relay-example"
+version = "0.1.0"
+requires-python = ">=3.12"
+dependencies = ["pympp[server,tempo]", "fastapi", "uvicorn"]
+
+[tool.uv.sources]
+pympp = { path = "../.." }

--- a/examples/charge-relay/server.py
+++ b/examples/charge-relay/server.py
@@ -8,7 +8,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 
-from mpp import Challenge
+from mpp import Credential, Receipt
 from mpp.methods.tempo import ChargeIntent, Relay, TempoAccount, tempo
 from mpp.methods.tempo._defaults import PATH_USD, TESTNET_CHAIN_ID
 from mpp.server import Mpp
@@ -52,20 +52,8 @@ async def health() -> dict[str, str]:
 
 
 @app.get("/photo")
-async def photo(request: Request):
-    payment = await payments.charge(
-        authorization=request.headers.get("Authorization"),
-        amount="0.01",
-        description="Random photo",
-    )
-    if isinstance(payment, Challenge):
-        return JSONResponse(
-            {"error": "Payment required"},
-            status_code=402,
-            headers={"WWW-Authenticate": payment.to_www_authenticate(payments.realm)},
-        )
-
-    _, receipt = payment
+@payments.pay(amount="0.01", description="Random photo")
+async def photo(request: Request, credential: Credential, receipt: Receipt):
     return JSONResponse(
         {"url": "https://picsum.photos/1024/1024"},
         headers={"Payment-Receipt": receipt.to_payment_receipt()},

--- a/examples/charge-relay/server.py
+++ b/examples/charge-relay/server.py
@@ -63,4 +63,4 @@ async def photo(request: Request, credential: Credential, receipt: Receipt):
 if __name__ == "__main__":
     import uvicorn
 
-    uvicorn.run(app, host="127.0.0.1", port=5173)
+    uvicorn.run(app, host="127.0.0.1", port=int(os.environ.get("PORT", "8000")))

--- a/examples/charge-relay/server.py
+++ b/examples/charge-relay/server.py
@@ -1,0 +1,78 @@
+"""Payment-gated FastAPI route settled by the Tempo API relay."""
+
+import os
+import secrets
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+
+from mpp import Challenge
+from mpp.methods.tempo import ChargeIntent, Relay, TempoAccount, tempo
+from mpp.methods.tempo._defaults import PATH_USD, TESTNET_CHAIN_ID
+from mpp.server import Mpp
+
+api_key = os.environ.get("TEMPO_API_KEY")
+if api_key is None:
+    raise RuntimeError("TEMPO_API_KEY is required")
+
+recipient = os.environ.get("PAYMENT_DESTINATION")
+if recipient is None:
+    recipient = TempoAccount.from_key("0x" + secrets.token_hex(32)).address
+
+relay = Relay(
+    api_key=api_key,
+    api_base_url=os.environ.get("TEMPO_API_URL", "https://api.tempo.xyz"),
+)
+payments = Mpp.create(
+    method=tempo(
+        chain_id=TESTNET_CHAIN_ID,
+        currency=PATH_USD,
+        recipient=recipient,
+        intents={"charge": ChargeIntent()},
+        relay=relay,
+    ),
+    secret_key=os.environ.get("MPP_SECRET_KEY", "local-relay-example-secret"),
+)
+
+
+@asynccontextmanager
+async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
+    yield
+    await relay.aclose()
+
+
+app = FastAPI(lifespan=lifespan)
+
+
+@app.get("/health")
+async def health() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.get("/photo")
+async def photo(request: Request):
+    payment = await payments.charge(
+        authorization=request.headers.get("Authorization"),
+        amount="0.01",
+        description="Random photo",
+    )
+    if isinstance(payment, Challenge):
+        return JSONResponse(
+            {"error": "Payment required"},
+            status_code=402,
+            headers={"WWW-Authenticate": payment.to_www_authenticate(payments.realm)},
+        )
+
+    _, receipt = payment
+    return JSONResponse(
+        {"url": "https://picsum.photos/1024/1024"},
+        headers={"Payment-Receipt": receipt.to_payment_receipt()},
+    )
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="127.0.0.1", port=5173)

--- a/src/mpp/_validation.py
+++ b/src/mpp/_validation.py
@@ -1,0 +1,22 @@
+"""Dependency-neutral credential validation result."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from mpp import ChallengeEcho, Credential
+
+
+@dataclass(frozen=True, slots=True)
+class Validation:
+    """Result of non-mutating credential validation."""
+
+    challenge: ChallengeEcho
+    credential: Credential
+    details: Any
+    intent: str
+    method: str
+    request: dict[str, Any]
+    source: str | None = None

--- a/src/mpp/_validation.py
+++ b/src/mpp/_validation.py
@@ -13,10 +13,19 @@ if TYPE_CHECKING:
 class Validation:
     """Result of non-mutating credential validation."""
 
-    challenge: ChallengeEcho
     credential: Credential
     details: Any
     intent: str
-    method: str
     request: dict[str, Any]
-    source: str | None = None
+
+    @property
+    def challenge(self) -> ChallengeEcho:
+        return self.credential.challenge
+
+    @property
+    def method(self) -> str:
+        return self.credential.challenge.method
+
+    @property
+    def source(self) -> str | None:
+        return self.credential.source

--- a/src/mpp/_validation.py
+++ b/src/mpp/_validation.py
@@ -11,7 +11,20 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True, slots=True)
 class Validation:
-    """Result of non-mutating credential validation."""
+    """Result of non-mutating credential validation.
+
+    Returned by ``SplitIntent.validate`` and exposed from
+    ``Mpp.validate_credential()``. A validation confirms that a credential is
+    currently acceptable to the payment method; it does not settle, reserve,
+    or otherwise consume the payment, and a later broadcast may still fail.
+
+    Attributes:
+        credential: The exact credential the validation examined.
+        details: Method-specific validation details (for Tempo charges, the
+            settlement ``mode`` and, in pull mode, the serialized transaction).
+        intent: Name of the intent that accepted the credential.
+        request: The request parameters the credential was validated against.
+    """
 
     credential: Credential
     details: Any
@@ -20,12 +33,15 @@ class Validation:
 
     @property
     def challenge(self) -> ChallengeEcho:
+        """The challenge echoed by the validated credential."""
         return self.credential.challenge
 
     @property
     def method(self) -> str:
+        """Name of the payment method that issued the challenge."""
         return self.credential.challenge.method
 
     @property
     def source(self) -> str | None:
+        """Payer identity submitted with the credential, if any."""
         return self.credential.source

--- a/src/mpp/_validation.py
+++ b/src/mpp/_validation.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 class Validation:
     """Result of non-mutating credential validation.
 
-    Returned by ``SplitIntent.validate`` and exposed from
+    Returned by ``VerifiableIntent.validate`` and exposed from
     ``Mpp.validate_credential()``. A validation confirms that a credential is
     currently acceptable to the payment method; it does not settle, reserve,
     or otherwise consume the payment, and a later broadcast may still fail.

--- a/src/mpp/errors.py
+++ b/src/mpp/errors.py
@@ -56,6 +56,10 @@ class PaymentError(Exception):
 
     type: str = f"{_BASE_URI}/payment-error"
 
+    def __init__(self, message: str, *, details: dict[str, Any] | None = None) -> None:
+        super().__init__(message)
+        self.details = details
+
     def to_problem_details(self, challenge_id: str | None = None) -> dict[str, Any]:
         """Convert to RFC 9457 Problem Details format."""
         details: dict[str, Any] = {
@@ -68,6 +72,8 @@ class PaymentError(Exception):
             details["challengeId"] = challenge_id
         if self.hint is not None:
             details["hint"] = self.hint
+        if self.details is not None:
+            details["details"] = self.details
         return details
 
 
@@ -128,11 +134,16 @@ class InvalidChallengeError(PaymentError):
 class VerificationFailedError(PaymentError):
     """Payment proof is invalid or verification failed."""
 
-    def __init__(self, reason: str | None = None) -> None:
+    def __init__(
+        self,
+        reason: str | None = None,
+        *,
+        details: dict[str, Any] | None = None,
+    ) -> None:
         msg = (
             f"Payment verification failed: {reason}." if reason else "Payment verification failed."
         )
-        super().__init__(msg)
+        super().__init__(msg, details=details)
 
 
 class PaymentExpiredError(PaymentError):

--- a/src/mpp/errors.py
+++ b/src/mpp/errors.py
@@ -47,7 +47,10 @@ class PaymentError(Exception):
     title: str = "Payment Error"
     hint: str | None = None
     details: dict[str, Any] | None = None
+    """Machine-readable details safe to expose in problem details output."""
     retry_challenge: Any | None = None
+    """Fresh :class:`~mpp.Challenge` attached by the server verification flow
+    when payment fails, so transports can return a retryable 402 response."""
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)

--- a/src/mpp/errors.py
+++ b/src/mpp/errors.py
@@ -46,6 +46,7 @@ class PaymentError(Exception):
     status: int = 402
     title: str = "Payment Error"
     hint: str | None = None
+    details: dict[str, Any] | None = None
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)
@@ -55,10 +56,6 @@ class PaymentError(Exception):
             cls.title = _to_title(cls.__name__)
 
     type: str = f"{_BASE_URI}/payment-error"
-
-    def __init__(self, message: str, *, details: dict[str, Any] | None = None) -> None:
-        super().__init__(message)
-        self.details = details
 
     def to_problem_details(self, challenge_id: str | None = None) -> dict[str, Any]:
         """Convert to RFC 9457 Problem Details format."""
@@ -143,7 +140,8 @@ class VerificationFailedError(PaymentError):
         msg = (
             f"Payment verification failed: {reason}." if reason else "Payment verification failed."
         )
-        super().__init__(msg, details=details)
+        super().__init__(msg)
+        self.details = details
 
 
 class PaymentExpiredError(PaymentError):

--- a/src/mpp/errors.py
+++ b/src/mpp/errors.py
@@ -47,6 +47,7 @@ class PaymentError(Exception):
     title: str = "Payment Error"
     hint: str | None = None
     details: dict[str, Any] | None = None
+    retry_challenge: Any | None = None
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)

--- a/src/mpp/extensions/mcp/decorator.py
+++ b/src/mpp/extensions/mcp/decorator.py
@@ -41,7 +41,7 @@ from mpp.extensions.mcp.verify import (
 from mpp.server._defaults import detect_realm, detect_secret_key
 
 if TYPE_CHECKING:
-    from mpp.server.intent import Intent
+    from mpp.server.intent import Intent, SplitIntent
 
 P = ParamSpec("P")
 R = TypeVar("R")
@@ -51,7 +51,7 @@ RequestParamsType = dict[str, Any] | Callable[..., dict[str, Any]]
 
 def pay(
     *,
-    intent: Intent,
+    intent: Intent | SplitIntent,
     request: RequestParamsType,
     realm: str | None = None,
     secret_key: str | None = None,

--- a/src/mpp/extensions/mcp/decorator.py
+++ b/src/mpp/extensions/mcp/decorator.py
@@ -41,7 +41,7 @@ from mpp.extensions.mcp.verify import (
 from mpp.server._defaults import detect_realm, detect_secret_key
 
 if TYPE_CHECKING:
-    from mpp.server.intent import Intent, SplitIntent
+    from mpp.server.intent import Intent, VerifiableIntent
 
 P = ParamSpec("P")
 R = TypeVar("R")
@@ -51,7 +51,7 @@ RequestParamsType = dict[str, Any] | Callable[..., dict[str, Any]]
 
 def pay(
     *,
-    intent: Intent | SplitIntent,
+    intent: Intent | VerifiableIntent,
     request: RequestParamsType,
     realm: str | None = None,
     secret_key: str | None = None,

--- a/src/mpp/extensions/mcp/errors.py
+++ b/src/mpp/extensions/mcp/errors.py
@@ -79,7 +79,9 @@ class PaymentVerificationError(McpError):
     """Payment verification failed.
 
     Raised when a credential was provided but verification failed.
-    Returns error code -32043 with a fresh challenge.
+    Returns error code -32043 with a fresh challenge. Machine-readable
+    ``details`` (e.g. safe relay error codes) are included in the failure
+    payload when provided.
 
     Example:
         raise PaymentVerificationError(
@@ -94,49 +96,44 @@ class PaymentVerificationError(McpError):
         challenges: list[MCPChallenge],
         reason: str | None = None,
         detail: str | None = None,
+        details: dict[str, Any] | None = None,
         message: str = "Payment Verification Failed",
     ) -> None:
         self.challenges = challenges
         self.reason = reason
         self.detail = detail
+        self.details = details
         self.message = message
-
-        data: dict[str, Any] = {
-            "httpStatus": HTTP_STATUS_PAYMENT_REQUIRED,
-            "challenges": [c.to_dict() for c in challenges],
-        }
-        if reason is not None or detail is not None:
-            failure: dict[str, str] = {}
-            if reason is not None:
-                failure["reason"] = reason
-            if detail is not None:
-                failure["detail"] = detail
-            data["failure"] = failure
 
         error = ErrorData(
             code=CODE_PAYMENT_VERIFICATION_FAILED,
             message=message,
-            data=data,
+            data=self._error_data(),
         )
         super().__init__(error)
 
-    def to_jsonrpc_error(self) -> dict[str, Any]:
-        """Convert to JSON-RPC error response format."""
+    def _error_data(self) -> dict[str, Any]:
         data: dict[str, Any] = {
             "httpStatus": HTTP_STATUS_PAYMENT_REQUIRED,
             "challenges": [c.to_dict() for c in self.challenges],
         }
-        if self.reason is not None or self.detail is not None:
-            failure: dict[str, str] = {}
-            if self.reason is not None:
-                failure["reason"] = self.reason
-            if self.detail is not None:
-                failure["detail"] = self.detail
+        failure: dict[str, Any] = {}
+        if self.reason is not None:
+            failure["reason"] = self.reason
+        if self.detail is not None:
+            failure["detail"] = self.detail
+        if self.details is not None:
+            failure["details"] = self.details
+        if failure:
             data["failure"] = failure
+        return data
+
+    def to_jsonrpc_error(self) -> dict[str, Any]:
+        """Convert to JSON-RPC error response format."""
         return {
             "code": CODE_PAYMENT_VERIFICATION_FAILED,
             "message": self.message,
-            "data": data,
+            "data": self._error_data(),
         }
 
 

--- a/src/mpp/extensions/mcp/verify.py
+++ b/src/mpp/extensions/mcp/verify.py
@@ -210,6 +210,7 @@ async def verify_or_challenge(
             challenges=[new_challenge()],
             reason="verification-failed",
             detail=str(e),
+            details=getattr(e, "details", None),
         ) from e
 
     mcp_receipt = MCPReceipt.from_core(

--- a/src/mpp/extensions/mcp/verify.py
+++ b/src/mpp/extensions/mcp/verify.py
@@ -39,7 +39,7 @@ from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
 from mpp import _constant_time_equal, generate_challenge_id
-from mpp.errors import PaymentError
+from mpp.errors import PaymentError, PaymentOutcomeUnknownError
 from mpp.extensions.mcp.constants import META_CREDENTIAL
 from mpp.extensions.mcp.errors import (
     MalformedCredentialError,
@@ -205,6 +205,8 @@ async def verify_or_challenge(
             credential=core_credential,
             request=request,
         )
+    except PaymentOutcomeUnknownError:
+        raise
     except (PaymentError, VerificationError) as e:
         raise PaymentVerificationError(
             challenges=[new_challenge()],

--- a/src/mpp/extensions/mcp/verify.py
+++ b/src/mpp/extensions/mcp/verify.py
@@ -48,7 +48,7 @@ from mpp.extensions.mcp.errors import (
 from mpp.extensions.mcp.types import MCPChallenge, MCPCredential, MCPReceipt
 
 if TYPE_CHECKING:
-    from mpp.server.intent import Intent, SplitIntent
+    from mpp.server.intent import Intent, VerifiableIntent
 
 DEFAULT_CHALLENGE_TTL = timedelta(minutes=5)
 
@@ -56,7 +56,7 @@ DEFAULT_CHALLENGE_TTL = timedelta(minutes=5)
 async def verify_or_challenge(
     *,
     meta: dict[str, Any] | None,
-    intent: Intent | SplitIntent,
+    intent: Intent | VerifiableIntent,
     request: dict[str, Any],
     realm: str,
     secret_key: str,

--- a/src/mpp/extensions/mcp/verify.py
+++ b/src/mpp/extensions/mcp/verify.py
@@ -39,6 +39,7 @@ from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
 from mpp import _constant_time_equal, generate_challenge_id
+from mpp.errors import PaymentError
 from mpp.extensions.mcp.constants import META_CREDENTIAL
 from mpp.extensions.mcp.errors import (
     MalformedCredentialError,
@@ -204,7 +205,7 @@ async def verify_or_challenge(
             credential=core_credential,
             request=request,
         )
-    except VerificationError as e:
+    except (PaymentError, VerificationError) as e:
         raise PaymentVerificationError(
             challenges=[new_challenge()],
             reason="verification-failed",

--- a/src/mpp/extensions/mcp/verify.py
+++ b/src/mpp/extensions/mcp/verify.py
@@ -48,7 +48,7 @@ from mpp.extensions.mcp.errors import (
 from mpp.extensions.mcp.types import MCPChallenge, MCPCredential, MCPReceipt
 
 if TYPE_CHECKING:
-    from mpp.server.intent import Intent
+    from mpp.server.intent import Intent, SplitIntent
 
 DEFAULT_CHALLENGE_TTL = timedelta(minutes=5)
 
@@ -56,7 +56,7 @@ DEFAULT_CHALLENGE_TTL = timedelta(minutes=5)
 async def verify_or_challenge(
     *,
     meta: dict[str, Any] | None,
-    intent: Intent,
+    intent: Intent | SplitIntent,
     request: dict[str, Any],
     realm: str,
     secret_key: str,

--- a/src/mpp/extensions/mcp/verify.py
+++ b/src/mpp/extensions/mcp/verify.py
@@ -194,12 +194,16 @@ async def verify_or_challenge(
     if expires_dt < datetime.now(UTC):
         return new_challenge()
 
-    from mpp.server.intent import VerificationError
+    from mpp.server.intent import VerificationError, broadcast_credential
 
     core_credential = mcp_credential.to_core()
 
     try:
-        core_receipt = await intent.verify(core_credential, request)
+        core_receipt = await broadcast_credential(
+            intent=intent,
+            credential=core_credential,
+            request=request,
+        )
     except VerificationError as e:
         raise PaymentVerificationError(
             challenges=[new_challenge()],

--- a/src/mpp/methods/stripe/client.py
+++ b/src/mpp/methods/stripe/client.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from collections.abc import Mapping
 
     from mpp import Credential as CredentialType
-    from mpp.server.intent import Intent, SplitIntent
+    from mpp.server.intent import Intent, VerifiableIntent
 
 
 @dataclass(frozen=True)
@@ -66,10 +66,10 @@ class StripeMethod:
     recipient: str | None = None
     network_id: str | None = None
     payment_method_types: list[str] = field(default_factory=lambda: ["card"])
-    _intents: dict[str, Intent | SplitIntent] = field(default_factory=dict)
+    _intents: dict[str, Intent | VerifiableIntent] = field(default_factory=dict)
 
     @property
-    def intents(self) -> dict[str, Intent | SplitIntent]:
+    def intents(self) -> dict[str, Intent | VerifiableIntent]:
         """Available intents for this method."""
         return self._intents
 
@@ -185,7 +185,7 @@ def _parse_iso_timestamp(iso_str: str) -> float:
 
 
 def stripe(
-    intents: Mapping[str, Intent | SplitIntent],
+    intents: Mapping[str, Intent | VerifiableIntent],
     create_token: CreateTokenFn | None = None,
     payment_method: str | None = None,
     external_id: str | None = None,

--- a/src/mpp/methods/stripe/client.py
+++ b/src/mpp/methods/stripe/client.py
@@ -14,8 +14,10 @@ from typing import TYPE_CHECKING, Any
 from mpp import Challenge, Credential
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from mpp import Credential as CredentialType
-    from mpp.server.intent import Intent
+    from mpp.server.intent import Intent, SplitIntent
 
 
 @dataclass(frozen=True)
@@ -64,10 +66,10 @@ class StripeMethod:
     recipient: str | None = None
     network_id: str | None = None
     payment_method_types: list[str] = field(default_factory=lambda: ["card"])
-    _intents: dict[str, Intent] = field(default_factory=dict)
+    _intents: dict[str, Intent | SplitIntent] = field(default_factory=dict)
 
     @property
-    def intents(self) -> dict[str, Intent]:
+    def intents(self) -> dict[str, Intent | SplitIntent]:
         """Available intents for this method."""
         return self._intents
 
@@ -183,7 +185,7 @@ def _parse_iso_timestamp(iso_str: str) -> float:
 
 
 def stripe(
-    intents: dict[str, Intent],
+    intents: Mapping[str, Intent | SplitIntent],
     create_token: CreateTokenFn | None = None,
     payment_method: str | None = None,
     external_id: str | None = None,

--- a/src/mpp/methods/stripe/intents.py
+++ b/src/mpp/methods/stripe/intents.py
@@ -223,7 +223,7 @@ class ChargeIntent:
                 "payment_method_types": list(request.methodDetails.paymentMethodTypes),
                 "shared_payment_granted_token": spt,
             }
-            options = {"idempotency_key": f"pympp_{challenge_id}_{spt}"}
+            options = {"idempotency_key": f"mppx_{challenge_id}_{spt}"}
 
             create_async = getattr(payment_intents, "create_async", None)
             if callable(create_async):
@@ -265,7 +265,7 @@ class ChargeIntent:
             headers={
                 "Authorization": f"Basic {auth_value}",
                 "Content-Type": "application/x-www-form-urlencoded",
-                "Idempotency-Key": f"pympp_{challenge_id}_{spt}",
+                "Idempotency-Key": f"mppx_{challenge_id}_{spt}",
             },
             data=body,
         )

--- a/src/mpp/methods/stripe/intents.py
+++ b/src/mpp/methods/stripe/intents.py
@@ -223,7 +223,7 @@ class ChargeIntent:
                 "payment_method_types": list(request.methodDetails.paymentMethodTypes),
                 "shared_payment_granted_token": spt,
             }
-            options = {"idempotency_key": f"mppx_{challenge_id}_{spt}"}
+            options = {"idempotency_key": f"pympp_{challenge_id}_{spt}"}
 
             create_async = getattr(payment_intents, "create_async", None)
             if callable(create_async):
@@ -265,7 +265,7 @@ class ChargeIntent:
             headers={
                 "Authorization": f"Basic {auth_value}",
                 "Content-Type": "application/x-www-form-urlencoded",
-                "Idempotency-Key": f"mppx_{challenge_id}_{spt}",
+                "Idempotency-Key": f"pympp_{challenge_id}_{spt}",
             },
             data=body,
         )

--- a/src/mpp/methods/tempo/__init__.py
+++ b/src/mpp/methods/tempo/__init__.py
@@ -50,6 +50,7 @@ _LAZY_EXPORTS = {
         "ValidateSender",
         "get_transfers",
     ),
+    "mpp.methods.tempo.relay": ("Relay", "RelayErrorCode"),
     "mpp.methods.tempo.schemas": ("Split",),
 }
 

--- a/src/mpp/methods/tempo/__init__.pyi
+++ b/src/mpp/methods/tempo/__init__.pyi
@@ -14,6 +14,8 @@ from mpp.methods.tempo.intents import SenderValidation as _SenderValidation
 from mpp.methods.tempo.intents import Transfer as _Transfer
 from mpp.methods.tempo.intents import ValidateSender as _ValidateSender
 from mpp.methods.tempo.intents import get_transfers as _get_transfers
+from mpp.methods.tempo.relay import Relay as _Relay
+from mpp.methods.tempo.relay import RelayErrorCode as _RelayErrorCode
 from mpp.methods.tempo.schemas import Split as _Split
 
 CHAIN_ID = _CHAIN_ID
@@ -32,4 +34,6 @@ SenderValidation = _SenderValidation
 Transfer = _Transfer
 ValidateSender = _ValidateSender
 get_transfers = _get_transfers
+Relay = _Relay
+RelayErrorCode = _RelayErrorCode
 Split = _Split

--- a/src/mpp/methods/tempo/_rpc.py
+++ b/src/mpp/methods/tempo/_rpc.py
@@ -1,4 +1,4 @@
-"""Low-level JSON-RPC helpers for Tempo transactions."""
+"""Low-level JSON-RPC helpers for Tempo."""
 
 from __future__ import annotations
 
@@ -31,6 +31,24 @@ async def _rpc_call(
     if "error" in result:
         raise RuntimeError(f"RPC error: {result['error']}")
     return result["result"]
+
+
+async def _tip20_balance(
+    rpc_url: str,
+    token: str,
+    address: str,
+    *,
+    client: Any | None = None,
+) -> int:
+    """Return an address's TIP-20 balance."""
+    data = "0x70a08231" + address.removeprefix("0x").lower().zfill(64)
+    result = await _rpc_call(
+        rpc_url,
+        "eth_call",
+        [{"to": token, "data": data}, "latest"],
+        client=client,
+    )
+    return int(result, 16)
 
 
 async def get_tx_params(

--- a/src/mpp/methods/tempo/client.py
+++ b/src/mpp/methods/tempo/client.py
@@ -23,6 +23,7 @@ from mpp.methods.tempo.fee_payer_policy import get_policy
 
 if TYPE_CHECKING:
     from mpp.methods.tempo.account import TempoAccount
+    from mpp.methods.tempo.relay import Relay
     from mpp.server.intent import Intent
 
 
@@ -393,6 +394,7 @@ def tempo(
     recipient: str | None = None,
     decimals: int = 6,
     client_id: str | None = None,
+    relay: Relay | None = None,
 ) -> TempoMethod:
     """Create a Tempo payment method.
 
@@ -414,6 +416,7 @@ def tempo(
         recipient: Default recipient address for charges.
         decimals: Token decimal places for amount conversion (default: 6).
         client_id: Optional client identity for attribution memos.
+        relay: Optional server-side Tempo API relay for the charge intent.
 
     Returns:
         A configured TempoMethod instance.
@@ -468,5 +471,11 @@ def tempo(
             intent.rpc_url = rpc_url  # type: ignore[union-attr]
         if hasattr(intent, "_method"):
             intent._method = method  # type: ignore[union-attr]
-    method._intents = dict(intents)
+    configured_intents = dict(intents)
+    if relay is not None:
+        charge = configured_intents.get("charge")
+        if charge is None:
+            raise ValueError("relay requires a charge intent")
+        configured_intents["charge"] = relay.configure(charge)
+    method._intents = configured_intents
     return method

--- a/src/mpp/methods/tempo/client.py
+++ b/src/mpp/methods/tempo/client.py
@@ -22,9 +22,11 @@ from mpp.methods.tempo._rpc import _rpc_call, estimate_gas
 from mpp.methods.tempo.fee_payer_policy import get_policy
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from mpp.methods.tempo.account import TempoAccount
     from mpp.methods.tempo.relay import Relay
-    from mpp.server.intent import Intent
+    from mpp.server.intent import Intent, SplitIntent
 
 
 # Tempo AA (type-0x76) transactions have higher intrinsic gas than legacy txs
@@ -75,14 +77,14 @@ class TempoMethod:
     recipient: str | None = None
     decimals: int = 6
     client_id: str | None = None
-    _intents: dict[str, Intent] = field(default_factory=dict)
+    _intents: dict[str, Intent | SplitIntent] = field(default_factory=dict)
     _cached_chain_ids: dict[str, int] = field(default_factory=dict, init=False, repr=False)
     _chain_id_explicit: bool = field(default=False, init=False, repr=False)
     _chain_id_lock: asyncio.Lock | None = field(default=None, init=False, repr=False)
     _rpc_url_explicit: bool = field(default=False, init=False, repr=False)
 
     @property
-    def intents(self) -> dict[str, Intent]:
+    def intents(self) -> dict[str, Intent | SplitIntent]:
         """Available intents for this method."""
         return self._intents
 
@@ -384,7 +386,7 @@ class TempoMethod:
 
 
 def tempo(
-    intents: dict[str, Intent],
+    intents: Mapping[str, Intent | SplitIntent],
     account: TempoAccount | None = None,
     fee_payer: TempoAccount | None = None,
     chain_id: int | None | object = _CHAIN_ID_UNSET,

--- a/src/mpp/methods/tempo/client.py
+++ b/src/mpp/methods/tempo/client.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
 
     from mpp.methods.tempo.account import TempoAccount
     from mpp.methods.tempo.relay import Relay
-    from mpp.server.intent import Intent, SplitIntent
+    from mpp.server.intent import Intent, VerifiableIntent
 
 
 # Tempo AA (type-0x76) transactions have higher intrinsic gas than legacy txs
@@ -77,14 +77,14 @@ class TempoMethod:
     recipient: str | None = None
     decimals: int = 6
     client_id: str | None = None
-    _intents: dict[str, Intent | SplitIntent] = field(default_factory=dict)
+    _intents: dict[str, Intent | VerifiableIntent] = field(default_factory=dict)
     _cached_chain_ids: dict[str, int] = field(default_factory=dict, init=False, repr=False)
     _chain_id_explicit: bool = field(default=False, init=False, repr=False)
     _chain_id_lock: asyncio.Lock | None = field(default=None, init=False, repr=False)
     _rpc_url_explicit: bool = field(default=False, init=False, repr=False)
 
     @property
-    def intents(self) -> dict[str, Intent | SplitIntent]:
+    def intents(self) -> dict[str, Intent | VerifiableIntent]:
         """Available intents for this method."""
         return self._intents
 
@@ -386,7 +386,7 @@ class TempoMethod:
 
 
 def tempo(
-    intents: Mapping[str, Intent | SplitIntent],
+    intents: Mapping[str, Intent | VerifiableIntent],
     account: TempoAccount | None = None,
     fee_payer: TempoAccount | None = None,
     chain_id: int | None | object = _CHAIN_ID_UNSET,

--- a/src/mpp/methods/tempo/intents.py
+++ b/src/mpp/methods/tempo/intents.py
@@ -604,6 +604,7 @@ class ChargeIntent:
         req, payload = self._prepare_credential(credential, request)
 
         if isinstance(payload, HashCredentialPayload):
+            await self._ensure_hash_unused(payload.hash)
             await self._validate_hash(
                 payload,
                 req,
@@ -684,10 +685,21 @@ class ChargeIntent:
     async def _reserve_hash(self, tx_hash: str) -> str | None:
         if self._store is None:
             return None
-        store_key = f"mpp:charge:{tx_hash.lower()}"
+        store_key = self._hash_store_key(tx_hash)
         if not await self._store.put_if_absent(store_key, tx_hash):
             raise VerificationError("Transaction hash already used")
         return store_key
+
+    async def _ensure_hash_unused(self, tx_hash: str) -> None:
+        if (
+            self._store is not None
+            and await self._store.get(self._hash_store_key(tx_hash)) is not None
+        ):
+            raise VerificationError("Transaction hash already used")
+
+    @staticmethod
+    def _hash_store_key(tx_hash: str) -> str:
+        return f"mpp:charge:{tx_hash.lower()}"
 
     def _parse_hash_credential_source(
         self, source: str | None, expected_chain_id: int

--- a/src/mpp/methods/tempo/intents.py
+++ b/src/mpp/methods/tempo/intents.py
@@ -584,7 +584,23 @@ class ChargeIntent:
         credential: Credential,
         request: dict[str, Any],
     ) -> Validation:
-        """Validate a charge credential without consuming or broadcasting it."""
+        """Validate a charge credential without consuming or broadcasting it.
+
+        Push-mode credentials are verified against the chain without
+        consuming the transaction hash's replay key; pull-mode transactions
+        are decoded and checked against the request without being broadcast.
+
+        Args:
+            credential: The payment credential from the client.
+            request: The original payment request parameters.
+
+        Returns:
+            A validation record whose ``details`` carry the settlement
+            ``mode`` and, in pull mode, the serialized transaction.
+
+        Raises:
+            VerificationError: If the credential is invalid.
+        """
         req, payload = self._prepare_credential(credential, request)
 
         if isinstance(payload, HashCredentialPayload):
@@ -612,7 +628,24 @@ class ChargeIntent:
         credential: Credential,
         request: dict[str, Any],
     ) -> Receipt:
-        """Perform the terminal charge operation."""
+        """Perform the terminal charge operation.
+
+        Push-mode credentials reserve the transaction hash's replay key
+        before re-verification — so concurrent duplicates fail fast — and
+        release it again if verification fails. Pull-mode transactions are
+        broadcast to the network.
+
+        Args:
+            credential: The payment credential from the client.
+            request: The original payment request parameters.
+
+        Returns:
+            A receipt for the settled payment.
+
+        Raises:
+            VerificationError: If verification fails or the transaction hash
+                was already used.
+        """
         req, payload = self._prepare_credential(credential, request)
 
         if isinstance(payload, HashCredentialPayload):
@@ -641,7 +674,11 @@ class ChargeIntent:
         credential: Credential,
         request: dict[str, Any],
     ) -> Receipt:
-        """Backward-compatible terminal charge hook."""
+        """Backward-compatible terminal charge hook.
+
+        Equivalent to :meth:`broadcast`; prefer :meth:`validate` for the
+        non-mutating pre-check and :meth:`broadcast` for settlement.
+        """
         return await self.broadcast(credential, request)
 
     async def _reserve_hash(self, tx_hash: str) -> str | None:

--- a/src/mpp/methods/tempo/intents.py
+++ b/src/mpp/methods/tempo/intents.py
@@ -18,6 +18,7 @@ from eth_abi.exceptions import DecodingError
 
 from mpp import Credential, Receipt
 from mpp._defaults import DEFAULT_TIMEOUT
+from mpp._validation import Validation
 from mpp.errors import VerificationError
 from mpp.methods.tempo._defaults import PATH_USD, rpc_url_for_chain
 from mpp.methods.tempo.fee_payer_policy import get_policy
@@ -547,23 +548,12 @@ class ChargeIntent:
             self._http_client = httpx.AsyncClient(timeout=self._timeout)
         return self._http_client
 
-    async def verify(
+    def _prepare_credential(
         self,
         credential: Credential,
         request: dict[str, Any],
-    ) -> Receipt:
-        """Verify a charge credential.
-
-        Args:
-            credential: The payment credential from the client.
-            request: The original payment request parameters.
-
-        Returns:
-            A receipt indicating success or failure.
-
-        Raises:
-            VerificationError: If verification fails.
-        """
+    ) -> tuple[ChargeRequest, CredentialPayload]:
+        """Parse the charge request and credential payload."""
         req = ChargeRequest.model_validate(request)
 
         # Expiry is conveyed via the challenge-level expires auth-param,
@@ -587,21 +577,83 @@ class ChargeIntent:
         else:
             raise VerificationError(f"Invalid credential type: {payload_data['type']}")
 
+        return req, payload
+
+    async def validate(
+        self,
+        credential: Credential,
+        request: dict[str, Any],
+    ) -> Validation:
+        """Validate a charge credential without consuming or broadcasting it."""
+        req, payload = self._prepare_credential(credential, request)
+
         if isinstance(payload, HashCredentialPayload):
-            return await self._verify_hash(
+            await self._validate_hash(
                 payload,
                 req,
                 challenge_id=credential.challenge.id,
                 realm=credential.challenge.realm,
                 source=credential.source,
             )
+            details: dict[str, Any] = {"mode": "push"}
         else:
-            return await self._verify_transaction(
-                payload,
-                req,
-                challenge_id=credential.challenge.id,
-                realm=credential.challenge.realm,
-            )
+            self._validate_transaction_payload(payload.signature, req)
+            details = {"mode": "pull", "serializedTransaction": payload.signature}
+
+        return Validation(
+            challenge=credential.challenge,
+            credential=credential,
+            details=details,
+            intent=self.name,
+            method=credential.challenge.method,
+            request=dict(request),
+            source=credential.source,
+        )
+
+    async def broadcast(
+        self,
+        credential: Credential,
+        request: dict[str, Any],
+    ) -> Receipt:
+        """Perform the terminal charge operation."""
+        req, payload = self._prepare_credential(credential, request)
+
+        if isinstance(payload, HashCredentialPayload):
+            store_key = await self._reserve_hash(payload.hash)
+            try:
+                return await self._validate_hash(
+                    payload,
+                    req,
+                    challenge_id=credential.challenge.id,
+                    realm=credential.challenge.realm,
+                    source=credential.source,
+                )
+            except Exception:
+                if store_key is not None and self._store is not None:
+                    await self._store.delete(store_key)
+                raise
+        return await self._broadcast_transaction(
+            payload,
+            req,
+            challenge_id=credential.challenge.id,
+            realm=credential.challenge.realm,
+        )
+
+    async def verify(
+        self,
+        credential: Credential,
+        request: dict[str, Any],
+    ) -> Receipt:
+        """Backward-compatible terminal charge hook."""
+        return await self.broadcast(credential, request)
+
+    async def _reserve_hash(self, tx_hash: str) -> str | None:
+        if self._store is None:
+            return None
+        store_key = f"mpp:charge:{tx_hash.lower()}"
+        if not await self._store.put_if_absent(store_key, tx_hash):
+            raise VerificationError("Transaction hash already used")
+        return store_key
 
     def _parse_hash_credential_source(
         self, source: str | None, expected_chain_id: int
@@ -644,7 +696,7 @@ class ChargeIntent:
             )
         )
 
-    async def _verify_hash(
+    async def _validate_hash(
         self,
         payload: HashCredentialPayload,
         request: ChargeRequest,
@@ -652,33 +704,20 @@ class ChargeIntent:
         realm: str,
         source: str | None = None,
     ) -> Receipt:
-        """Verify a credential with a transaction hash."""
-        # Validate the source before reserving the hash.
+        """Validate a transaction hash without consuming its replay key."""
         source_address = self._parse_hash_credential_source(source, request.methodDetails.chainId)
 
         client = await self._get_client()
-
-        store_key: str | None = None
-        if self._store is not None:
-            store_key = f"mpp:charge:{payload.hash.lower()}"
-            if not await self._store.put_if_absent(store_key, payload.hash):
-                raise VerificationError("Transaction hash already used")
-
-        try:
-            receipt_data = await self._fetch_transaction_receipt(client, payload.hash)
-            self._verify_receipt_transfers(
-                receipt_data,
-                request,
-                challenge_id=challenge_id,
-                realm=realm,
-                source=source,
-                source_address=source_address,
-                validate_sender=self._validate_sender,
-            )
-        except Exception:
-            if self._store is not None and store_key is not None:
-                await self._store.delete(store_key)
-            raise
+        receipt_data = await self._fetch_transaction_receipt(client, payload.hash)
+        self._verify_receipt_transfers(
+            receipt_data,
+            request,
+            challenge_id=challenge_id,
+            realm=realm,
+            source=source,
+            source_address=source_address,
+            validate_sender=self._validate_sender,
+        )
 
         return Receipt.success(payload.hash)
 
@@ -951,7 +990,7 @@ class ChargeIntent:
 
         return all_matches
 
-    async def _verify_transaction(
+    async def _broadcast_transaction(
         self,
         payload: TransactionCredentialPayload,
         request: ChargeRequest,

--- a/src/mpp/methods/tempo/intents.py
+++ b/src/mpp/methods/tempo/intents.py
@@ -614,7 +614,7 @@ class ChargeIntent:
             details: dict[str, Any] = {"mode": "push"}
         else:
             self._validate_transaction_payload(payload.signature, req)
-            details = {"mode": "pull", "serializedTransaction": payload.signature}
+            details = {"mode": "pull", "serialized_transaction": payload.signature}
 
         return Validation(
             credential=credential,

--- a/src/mpp/methods/tempo/intents.py
+++ b/src/mpp/methods/tempo/intents.py
@@ -614,7 +614,7 @@ class ChargeIntent:
             )
             details: dict[str, Any] = {"mode": "push"}
         else:
-            self._validate_transaction_payload(payload.signature, req)
+            self._validate_transaction_payload(payload.signature, req, strict=True)
             details = {"mode": "pull", "serialized_transaction": payload.signature}
 
         return Validation(
@@ -1460,23 +1460,39 @@ class ChargeIntent:
         ]
         _validate_normalized_calls(normalized_calls, request)
 
-    def _validate_transaction_payload(self, signature: str, request: ChargeRequest) -> None:
-        """Best-effort pre-broadcast check. Silently skips if decoding fails."""
+    def _validate_transaction_payload(
+        self,
+        signature: str,
+        request: ChargeRequest,
+        *,
+        strict: bool = False,
+    ) -> None:
+        """Validate a transaction, failing closed for advisory validation."""
         try:
             import rlp
-        except ImportError:
+        except ImportError as error:
+            if strict:
+                raise VerificationError("Transaction decoding is unavailable") from error
             return
         try:
             tx_bytes = bytes.fromhex(signature[2:] if signature.startswith("0x") else signature)
-        except ValueError:
+        except ValueError as error:
+            if strict:
+                raise VerificationError("Invalid serialized transaction") from error
             return
         if not tx_bytes or tx_bytes[0] not in (0x76, 0x78):
+            if strict:
+                raise VerificationError("Only Tempo (0x76/0x78) transactions are supported")
             return
         try:
             decoded = rlp.decode(tx_bytes[1:])
-        except Exception:
+        except Exception as error:
+            if strict:
+                raise VerificationError("Invalid serialized transaction") from error
             return
         if not isinstance(decoded, list) or len(decoded) < 5:
+            if strict:
+                raise VerificationError("Invalid serialized transaction")
             return
 
         calls_data = decoded[4] if len(decoded) > 4 else []

--- a/src/mpp/methods/tempo/intents.py
+++ b/src/mpp/methods/tempo/intents.py
@@ -601,13 +601,10 @@ class ChargeIntent:
             details = {"mode": "pull", "serializedTransaction": payload.signature}
 
         return Validation(
-            challenge=credential.challenge,
             credential=credential,
             details=details,
             intent=self.name,
-            method=credential.challenge.method,
             request=dict(request),
-            source=credential.source,
         )
 
     async def broadcast(

--- a/src/mpp/methods/tempo/relay.py
+++ b/src/mpp/methods/tempo/relay.py
@@ -16,7 +16,7 @@ from mpp.errors import PaymentExpiredError, VerificationError, VerificationFaile
 if TYPE_CHECKING:
     import httpx
 
-    from mpp.server.intent import Intent, SplitIntent
+    from mpp.server.intent import Intent, VerifiableIntent
 
 logger = logging.getLogger(__name__)
 
@@ -98,7 +98,7 @@ class Relay:
         self._owns_client = http_client is None
         self._timeout = timeout
 
-    def configure(self, intent: Intent | SplitIntent) -> SplitIntent:
+    def configure(self, intent: Intent | VerifiableIntent) -> VerifiableIntent:
         """Wrap an intent so its lifecycle is served by the relay.
 
         The returned intent delegates ``validate`` and ``broadcast`` to

--- a/src/mpp/methods/tempo/relay.py
+++ b/src/mpp/methods/tempo/relay.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import json
 import logging
@@ -11,7 +12,13 @@ from mpp import Credential, Receipt
 from mpp._defaults import DEFAULT_TIMEOUT
 from mpp._parsing import ParseError, _b64_decode, _parse_timestamp
 from mpp._validation import Validation
-from mpp.errors import PaymentExpiredError, VerificationError, VerificationFailedError
+from mpp.errors import (
+    PaymentError,
+    PaymentExpiredError,
+    PaymentOutcomeUnknownError,
+    VerificationError,
+    VerificationFailedError,
+)
 
 if TYPE_CHECKING:
     import httpx
@@ -145,15 +152,12 @@ class Relay:
             headers["idempotency-key"] = idempotency_key
 
         logger.debug("relay request method=POST path=/%s", path)
-        try:
-            response = await (await self._get_client()).post(
-                self.api_base_url + path,
-                json=body,
-                headers=headers,
-            )
-            result = response.json() if response.is_success else None
-        except Exception:
-            raise _failure() from None
+        response = await (await self._get_client()).post(
+            self.api_base_url + path,
+            json=body,
+            headers=headers,
+        )
+        result = response.json() if response.is_success else None
         if not isinstance(result, dict) or result.get("success") is not True:
             raise _failure(result)
         return result
@@ -170,7 +174,12 @@ class _RelayIntent:
         request: dict[str, Any],
     ) -> Validation:
         body = _relay_input(credential, request)
-        await self._relay._post("v1/mpp/validate", body)
+        try:
+            await self._relay._post("v1/mpp/validate", body)
+        except PaymentError:
+            raise
+        except Exception:
+            raise _failure() from None
         # The relay validates the echoed challenge request, so report the
         # exact request that was checked.
         return Validation(
@@ -182,12 +191,22 @@ class _RelayIntent:
 
     async def broadcast(self, credential: Credential, request: dict[str, Any]) -> Receipt:
         body = _relay_input(credential, request)
-        result = await self._relay._post(
-            "v1/mpp/broadcast",
-            body,
-            idempotency_key=_idempotency_key(body),
-        )
-        return _receipt(result.get("receipt"))
+        try:
+            result = await self._relay._post(
+                "v1/mpp/broadcast",
+                body,
+                idempotency_key=_idempotency_key(body),
+            )
+            return _receipt(result.get("receipt"))
+        except PaymentError:
+            raise
+        except (Exception, asyncio.CancelledError) as error:
+            raise PaymentOutcomeUnknownError(
+                credential.challenge,
+                error,
+                credential=credential,
+                request=request,
+            ) from error
 
 
 def _relay_input(credential: Credential, expected_request: dict[str, Any]) -> dict[str, Any]:

--- a/src/mpp/methods/tempo/relay.py
+++ b/src/mpp/methods/tempo/relay.py
@@ -99,7 +99,7 @@ class Relay:
         self._timeout = timeout
 
     def configure(self, intent: Intent) -> SplitIntent:
-        """Wrap a charge intent so its lifecycle is served by the relay.
+        """Wrap an intent so its lifecycle is served by the relay.
 
         The returned intent delegates ``validate``, ``broadcast``, and the
         legacy ``verify`` entirely to ``/v1/mpp/validate`` and
@@ -107,9 +107,7 @@ class Relay:
         configuration (RPC URL, replay store, sender validation) is not
         consulted because the relay performs those checks itself.
         """
-        if intent.name != "charge":
-            raise ValueError("Relay can only configure a charge intent")
-        return _RelayCharge(self)
+        return _RelayIntent(self, intent.name)
 
     async def __aenter__(self) -> Relay:
         await self._get_client()
@@ -160,22 +158,10 @@ class Relay:
             raise _failure(result)
         return result
 
-    async def _validate(self, body: dict[str, Any]) -> None:
-        await self._post("v1/mpp/validate", body)
 
-    async def _broadcast(self, body: dict[str, Any]) -> Receipt:
-        result = await self._post(
-            "v1/mpp/broadcast",
-            body,
-            idempotency_key=_idempotency_key(body),
-        )
-        return _receipt(result.get("receipt"))
-
-
-class _RelayCharge:
-    name = "charge"
-
-    def __init__(self, relay: Relay) -> None:
+class _RelayIntent:
+    def __init__(self, relay: Relay, name: str = "charge") -> None:
+        self.name = name
         self._relay = relay
 
     async def validate(
@@ -184,18 +170,28 @@ class _RelayCharge:
         request: dict[str, Any],
     ) -> Validation:
         body = _relay_input(credential)
-        await self._relay._validate(body)
+        await self._relay._post("v1/mpp/validate", body)
+        # The relay validated the credential's echoed challenge request, so
+        # the validation record reports that request (mirrors mppx).
         return Validation(
             credential=credential,
             details={},
             intent=self.name,
-            request=dict(request),
+            request=body["challenge"]["request"],
         )
 
     async def broadcast(self, credential: Credential, request: dict[str, Any]) -> Receipt:
-        return await self._relay._broadcast(_relay_input(credential))
+        body = _relay_input(credential)
+        result = await self._relay._post(
+            "v1/mpp/broadcast",
+            body,
+            idempotency_key=_idempotency_key(body),
+        )
+        return _receipt(result.get("receipt"))
 
     async def verify(self, credential: Credential, request: dict[str, Any]) -> Receipt:
+        # Preserve the legacy combined hook for direct intent consumers,
+        # mirroring mppx's relay adapter.
         await self.validate(credential, request)
         return await self.broadcast(credential, request)
 
@@ -228,8 +224,9 @@ def _idempotency_key(body: dict[str, Any]) -> str:
     """Derive a deterministic broadcast idempotency key.
 
     Pull-mode credentials use the signed transaction's hash so retries of the
-    same transaction collapse server-side; other payloads fall back to a hash
-    of the canonical relay input.
+    same transaction collapse server-side — the ``mppx_`` namespace is shared
+    across MPP SDKs; other payloads fall back to a hash of the canonical
+    relay input.
     """
     payload = body.get("payload")
     if isinstance(payload, dict):
@@ -238,12 +235,12 @@ def _idempotency_key(body: dict[str, Any]) -> str:
             from mpp.methods.tempo.intents import _raw_transaction_hash
 
             try:
-                return f"pympp_{_raw_transaction_hash(signature)}"
+                return f"mppx_{_raw_transaction_hash(signature)}"
             except VerificationError:
                 pass
 
     canonical = json.dumps(body, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
-    return f"pympp_0x{hashlib.sha256(canonical.encode()).hexdigest()}"
+    return f"mppx_0x{hashlib.sha256(canonical.encode()).hexdigest()}"
 
 
 def _receipt(value: Any) -> Receipt:

--- a/src/mpp/methods/tempo/relay.py
+++ b/src/mpp/methods/tempo/relay.py
@@ -5,14 +5,13 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
-from datetime import datetime
-from typing import TYPE_CHECKING, Any, Literal, get_args
+from typing import TYPE_CHECKING, Any, Literal
 
 from mpp import Credential, Receipt
 from mpp._defaults import DEFAULT_TIMEOUT
-from mpp._parsing import ParseError, _b64_decode
+from mpp._parsing import ParseError, _b64_decode, _parse_timestamp
 from mpp._validation import Validation
-from mpp.errors import PaymentExpiredError, VerificationFailedError
+from mpp.errors import PaymentExpiredError, VerificationError, VerificationFailedError
 
 if TYPE_CHECKING:
     import httpx
@@ -37,7 +36,6 @@ RelayErrorCode = Literal[
     "unknown",
 ]
 
-_ERROR_CODES = frozenset(get_args(RelayErrorCode))
 _SAFE_ERROR_CODES = frozenset(
     {
         "already_used",
@@ -103,7 +101,7 @@ class Relay:
         body: dict[str, Any],
         *,
         idempotency_key: str | None = None,
-    ) -> Any:
+    ) -> dict[str, Any]:
         headers = {
             "Accept": "application/json",
             "content-type": "application/json",
@@ -119,18 +117,15 @@ class Relay:
                 json=body,
                 headers=headers,
             )
-            if not response.is_success:
-                raise _failure()
-            return response.json()
-        except (PaymentExpiredError, VerificationFailedError):
-            raise
+            result = response.json() if response.is_success else None
         except Exception:
             raise _failure() from None
-
-    async def _validate(self, body: dict[str, Any]) -> None:
-        result = await self._post("v1/mpp/validate", body)
         if not isinstance(result, dict) or result.get("success") is not True:
             raise _failure(result)
+        return result
+
+    async def _validate(self, body: dict[str, Any]) -> None:
+        await self._post("v1/mpp/validate", body)
 
     async def _broadcast(self, body: dict[str, Any]) -> Receipt:
         result = await self._post(
@@ -138,8 +133,6 @@ class Relay:
             body,
             idempotency_key=_idempotency_key(body),
         )
-        if not isinstance(result, dict) or result.get("success") is not True:
-            raise _failure(result)
         return _receipt(result.get("receipt"))
 
 
@@ -157,13 +150,10 @@ class _RelayCharge:
         body = _relay_input(credential)
         await self._relay._validate(body)
         return Validation(
-            challenge=credential.challenge,
             credential=credential,
             details={},
             intent=self.name,
-            method=credential.challenge.method,
             request=dict(request),
-            source=credential.source,
         )
 
     async def broadcast(self, credential: Credential, request: dict[str, Any]) -> Receipt:
@@ -203,14 +193,12 @@ def _idempotency_key(body: dict[str, Any]) -> str:
     if isinstance(payload, dict):
         signature = payload.get("signature")
         if payload.get("type") == "transaction" and isinstance(signature, str):
-            try:
-                raw = bytes.fromhex(signature.removeprefix("0x"))
-            except ValueError:
-                pass
-            else:
-                from eth_hash.auto import keccak
+            from mpp.methods.tempo.intents import _raw_transaction_hash
 
-                return f"pympp_0x{keccak(raw).hex()}"
+            try:
+                return f"pympp_{_raw_transaction_hash(signature)}"
+            except VerificationError:
+                pass
 
     canonical = json.dumps(body, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
     return f"pympp_0x{hashlib.sha256(canonical.encode()).hexdigest()}"
@@ -231,8 +219,8 @@ def _receipt(value: Any) -> Receipt:
     ):
         raise _failure()
     try:
-        parsed_timestamp = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
-    except ValueError:
+        parsed_timestamp = _parse_timestamp(timestamp)
+    except ParseError:
         raise _failure() from None
     if parsed_timestamp.tzinfo is None:
         raise _failure()
@@ -260,4 +248,4 @@ def _error_code(value: Any) -> str | None:
     if not isinstance(value, dict) or not isinstance(value.get("error"), dict):
         return None
     code = value["error"].get("code")
-    return code if isinstance(code, str) and code in _ERROR_CODES else None
+    return code if isinstance(code, str) else None

--- a/src/mpp/methods/tempo/relay.py
+++ b/src/mpp/methods/tempo/relay.py
@@ -169,7 +169,7 @@ class _RelayIntent:
         credential: Credential,
         request: dict[str, Any],
     ) -> Validation:
-        body = _relay_input(credential)
+        body = _relay_input(credential, request)
         await self._relay._post("v1/mpp/validate", body)
         # The relay validates the echoed challenge request, so report the
         # exact request that was checked.
@@ -181,7 +181,7 @@ class _RelayIntent:
         )
 
     async def broadcast(self, credential: Credential, request: dict[str, Any]) -> Receipt:
-        body = _relay_input(credential)
+        body = _relay_input(credential, request)
         result = await self._relay._post(
             "v1/mpp/broadcast",
             body,
@@ -190,11 +190,13 @@ class _RelayIntent:
         return _receipt(result.get("receipt"))
 
 
-def _relay_input(credential: Credential) -> dict[str, Any]:
+def _relay_input(credential: Credential, expected_request: dict[str, Any]) -> dict[str, Any]:
     try:
         request = _b64_decode(credential.challenge.request)
     except ParseError:
         raise _failure() from None
+    if request != expected_request:
+        raise _failure()
 
     echo = credential.challenge
     challenge: dict[str, Any] = {

--- a/src/mpp/methods/tempo/relay.py
+++ b/src/mpp/methods/tempo/relay.py
@@ -171,8 +171,8 @@ class _RelayIntent:
     ) -> Validation:
         body = _relay_input(credential)
         await self._relay._post("v1/mpp/validate", body)
-        # The relay validated the credential's echoed challenge request, so
-        # the validation record reports that request (mirrors mppx).
+        # The relay validates the echoed challenge request, so report the
+        # exact request that was checked.
         return Validation(
             credential=credential,
             details={},
@@ -190,8 +190,7 @@ class _RelayIntent:
         return _receipt(result.get("receipt"))
 
     async def verify(self, credential: Credential, request: dict[str, Any]) -> Receipt:
-        # Preserve the legacy combined hook for direct intent consumers,
-        # mirroring mppx's relay adapter.
+        # Preserve the legacy combined hook for direct intent consumers.
         await self.validate(credential, request)
         return await self.broadcast(credential, request)
 
@@ -224,9 +223,8 @@ def _idempotency_key(body: dict[str, Any]) -> str:
     """Derive a deterministic broadcast idempotency key.
 
     Pull-mode credentials use the signed transaction's hash so retries of the
-    same transaction collapse server-side — the ``mppx_`` namespace is shared
-    across MPP SDKs; other payloads fall back to a hash of the canonical
-    relay input.
+    same transaction collapse server-side. Other payloads fall back to a hash
+    of the canonical relay input.
     """
     payload = body.get("payload")
     if isinstance(payload, dict):
@@ -235,12 +233,12 @@ def _idempotency_key(body: dict[str, Any]) -> str:
             from mpp.methods.tempo.intents import _raw_transaction_hash
 
             try:
-                return f"mppx_{_raw_transaction_hash(signature)}"
+                return f"pympp_{_raw_transaction_hash(signature)}"
             except VerificationError:
                 pass
 
     canonical = json.dumps(body, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
-    return f"mppx_0x{hashlib.sha256(canonical.encode()).hexdigest()}"
+    return f"pympp_0x{hashlib.sha256(canonical.encode()).hexdigest()}"
 
 
 def _receipt(value: Any) -> Receipt:

--- a/src/mpp/methods/tempo/relay.py
+++ b/src/mpp/methods/tempo/relay.py
@@ -1,0 +1,263 @@
+"""Tempo API relay adapter for server-side charges."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from datetime import datetime
+from typing import TYPE_CHECKING, Any, Literal, get_args
+
+from mpp import Credential, Receipt
+from mpp._defaults import DEFAULT_TIMEOUT
+from mpp._parsing import ParseError, _b64_decode
+from mpp._validation import Validation
+from mpp.errors import PaymentExpiredError, VerificationFailedError
+
+if TYPE_CHECKING:
+    import httpx
+
+    from mpp.server.intent import Intent, SplitIntent
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_API_BASE_URL = "https://api.tempo.xyz"
+
+RelayErrorCode = Literal[
+    "already_used",
+    "broadcast_failed",
+    "expired",
+    "invalid_payment",
+    "insufficient_funds",
+    "policy_denied",
+    "screen_rejected",
+    "simulation_failed",
+    "temporarily_unavailable",
+    "unsupported",
+    "unknown",
+]
+
+_ERROR_CODES = frozenset(get_args(RelayErrorCode))
+_SAFE_ERROR_CODES = frozenset(
+    {
+        "already_used",
+        "broadcast_failed",
+        "invalid_payment",
+        "insufficient_funds",
+        "simulation_failed",
+        "temporarily_unavailable",
+        "unsupported",
+    }
+)
+
+
+class Relay:
+    """Delegate Tempo charge validation and finalization to an MPP relay."""
+
+    def __init__(
+        self,
+        api_key: str,
+        api_base_url: str = DEFAULT_API_BASE_URL,
+        http_client: httpx.AsyncClient | None = None,
+        timeout: float = DEFAULT_TIMEOUT,
+    ) -> None:
+        if not api_key:
+            raise ValueError("api_key is required")
+        if not api_base_url:
+            raise ValueError("api_base_url is required")
+        self.api_key = api_key
+        self.api_base_url = api_base_url.rstrip("/") + "/"
+        self._client = http_client
+        self._owns_client = http_client is None
+        self._timeout = timeout
+
+    def configure(self, intent: Intent) -> SplitIntent:
+        """Replace a charge intent's lifecycle hooks with relay calls."""
+        if intent.name != "charge":
+            raise ValueError("Relay can only configure a charge intent")
+        return _RelayCharge(self)
+
+    async def __aenter__(self) -> Relay:
+        await self._get_client()
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        await self.aclose()
+
+    async def aclose(self) -> None:
+        """Close the internally owned HTTP client."""
+        if self._owns_client and self._client is not None:
+            await self._client.aclose()
+            self._client = None
+
+    async def _get_client(self) -> httpx.AsyncClient:
+        if self._client is None:
+            import httpx
+
+            self._client = httpx.AsyncClient(timeout=self._timeout)
+        return self._client
+
+    async def _post(
+        self,
+        path: str,
+        body: dict[str, Any],
+        *,
+        idempotency_key: str | None = None,
+    ) -> Any:
+        headers = {
+            "Accept": "application/json",
+            "content-type": "application/json",
+            "tempo-api-key": self.api_key,
+        }
+        if idempotency_key is not None:
+            headers["idempotency-key"] = idempotency_key
+
+        logger.debug("relay request method=POST path=/%s", path)
+        try:
+            response = await (await self._get_client()).post(
+                self.api_base_url + path,
+                json=body,
+                headers=headers,
+            )
+            if not response.is_success:
+                raise _failure()
+            return response.json()
+        except (PaymentExpiredError, VerificationFailedError):
+            raise
+        except Exception:
+            raise _failure() from None
+
+    async def _validate(self, body: dict[str, Any]) -> None:
+        result = await self._post("v1/mpp/validate", body)
+        if not isinstance(result, dict) or result.get("success") is not True:
+            raise _failure(result)
+
+    async def _broadcast(self, body: dict[str, Any]) -> Receipt:
+        result = await self._post(
+            "v1/mpp/broadcast",
+            body,
+            idempotency_key=_idempotency_key(body),
+        )
+        if not isinstance(result, dict) or result.get("success") is not True:
+            raise _failure(result)
+        return _receipt(result.get("receipt"))
+
+
+class _RelayCharge:
+    name = "charge"
+
+    def __init__(self, relay: Relay) -> None:
+        self._relay = relay
+
+    async def validate(
+        self,
+        credential: Credential,
+        request: dict[str, Any],
+    ) -> Validation:
+        body = _relay_input(credential)
+        await self._relay._validate(body)
+        return Validation(
+            challenge=credential.challenge,
+            credential=credential,
+            details={},
+            intent=self.name,
+            method=credential.challenge.method,
+            request=dict(request),
+            source=credential.source,
+        )
+
+    async def broadcast(self, credential: Credential, request: dict[str, Any]) -> Receipt:
+        return await self._relay._broadcast(_relay_input(credential))
+
+    async def verify(self, credential: Credential, request: dict[str, Any]) -> Receipt:
+        await self.validate(credential, request)
+        return await self.broadcast(credential, request)
+
+
+def _relay_input(credential: Credential) -> dict[str, Any]:
+    try:
+        request = _b64_decode(credential.challenge.request)
+    except ParseError:
+        raise _failure() from None
+
+    echo = credential.challenge
+    challenge: dict[str, Any] = {
+        "id": echo.id,
+        "realm": echo.realm,
+        "method": echo.method,
+        "intent": echo.intent,
+        "request": request,
+    }
+    for name in ("expires", "digest", "opaque"):
+        if (value := getattr(echo, name)) is not None:
+            challenge[name] = value
+
+    result: dict[str, Any] = {"challenge": challenge, "payload": credential.payload}
+    if credential.source:
+        result["source"] = credential.source
+    return result
+
+
+def _idempotency_key(body: dict[str, Any]) -> str:
+    payload = body.get("payload")
+    if isinstance(payload, dict):
+        signature = payload.get("signature")
+        if payload.get("type") == "transaction" and isinstance(signature, str):
+            try:
+                raw = bytes.fromhex(signature.removeprefix("0x"))
+            except ValueError:
+                pass
+            else:
+                from eth_hash.auto import keccak
+
+                return f"pympp_0x{keccak(raw).hex()}"
+
+    canonical = json.dumps(body, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+    return f"pympp_0x{hashlib.sha256(canonical.encode()).hexdigest()}"
+
+
+def _receipt(value: Any) -> Receipt:
+    if not isinstance(value, dict):
+        raise _failure()
+    method = value.get("method")
+    reference = value.get("reference")
+    timestamp = value.get("timestamp")
+    external_id = value.get("externalId")
+    if (
+        method != "tempo"
+        or not isinstance(reference, str)
+        or not isinstance(timestamp, str)
+        or (external_id is not None and not isinstance(external_id, str))
+    ):
+        raise _failure()
+    try:
+        parsed_timestamp = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+    except ValueError:
+        raise _failure() from None
+    if parsed_timestamp.tzinfo is None:
+        raise _failure()
+    return Receipt.success(
+        reference,
+        timestamp=parsed_timestamp,
+        method=method,
+        external_id=external_id,
+    )
+
+
+def _failure(value: Any = None) -> VerificationFailedError | PaymentExpiredError:
+    code = _error_code(value)
+    if code == "expired":
+        return PaymentExpiredError()
+    if code in _SAFE_ERROR_CODES:
+        details = {"code": code}
+        if code == "temporarily_unavailable":
+            details["retry"] = "same_credential"
+        return VerificationFailedError(details=details)
+    return VerificationFailedError()
+
+
+def _error_code(value: Any) -> str | None:
+    if not isinstance(value, dict) or not isinstance(value.get("error"), dict):
+        return None
+    code = value["error"].get("code")
+    return code if isinstance(code, str) and code in _ERROR_CODES else None

--- a/src/mpp/methods/tempo/relay.py
+++ b/src/mpp/methods/tempo/relay.py
@@ -98,14 +98,14 @@ class Relay:
         self._owns_client = http_client is None
         self._timeout = timeout
 
-    def configure(self, intent: Intent) -> SplitIntent:
+    def configure(self, intent: Intent | SplitIntent) -> SplitIntent:
         """Wrap an intent so its lifecycle is served by the relay.
 
-        The returned intent delegates ``validate``, ``broadcast``, and the
-        legacy ``verify`` entirely to ``/v1/mpp/validate`` and
-        ``/v1/mpp/broadcast``; the wrapped intent's local verification
-        configuration (RPC URL, replay store, sender validation) is not
-        consulted because the relay performs those checks itself.
+        The returned intent delegates ``validate`` and ``broadcast`` to
+        ``/v1/mpp/validate`` and ``/v1/mpp/broadcast``; the wrapped intent's
+        local verification configuration (RPC URL, replay store, sender
+        validation) is not consulted because the relay performs those checks
+        itself.
         """
         return _RelayIntent(self, intent.name)
 
@@ -188,11 +188,6 @@ class _RelayIntent:
             idempotency_key=_idempotency_key(body),
         )
         return _receipt(result.get("receipt"))
-
-    async def verify(self, credential: Credential, request: dict[str, Any]) -> Receipt:
-        # Preserve the legacy combined hook for direct intent consumers.
-        await self.validate(credential, request)
-        return await self.broadcast(credential, request)
 
 
 def _relay_input(credential: Credential) -> dict[str, Any]:

--- a/src/mpp/methods/tempo/relay.py
+++ b/src/mpp/methods/tempo/relay.py
@@ -35,7 +35,10 @@ RelayErrorCode = Literal[
     "unsupported",
     "unknown",
 ]
+"""Stable machine-readable failure codes returned by the Tempo API relay."""
 
+# Only these codes surface to payers in problem details; everything else stays
+# opaque so relay internals and policy decisions do not leak.
 _SAFE_ERROR_CODES = frozenset(
     {
         "already_used",
@@ -50,7 +53,22 @@ _SAFE_ERROR_CODES = frozenset(
 
 
 class Relay:
-    """Delegate Tempo charge validation and finalization to an MPP relay."""
+    """Delegate Tempo charge validation and finalization to an MPP relay.
+
+    The relay receives every submitted credential: it validates both modes,
+    broadcasts pull-mode transactions, and finalizes push-mode transaction
+    hashes that are already on chain without sending them again. Relay
+    failures surface as payment errors that stay opaque except for the safe
+    machine-readable codes exposed in error ``details``.
+
+    Pass a relay to :func:`~mpp.methods.tempo.tempo` to serve a charge
+    intent's lifecycle through the Tempo API::
+
+        method = tempo(
+            intents={"charge": ChargeIntent()},
+            relay=Relay(api_key=os.environ["TEMPO_API_KEY"]),
+        )
+    """
 
     def __init__(
         self,
@@ -59,6 +77,17 @@ class Relay:
         http_client: httpx.AsyncClient | None = None,
         timeout: float = DEFAULT_TIMEOUT,
     ) -> None:
+        """Create a relay adapter.
+
+        Args:
+            api_key: Tempo API key with the ``mpp:write`` scope.
+            api_base_url: Tempo API or compatible relay base URL; a path
+                prefix is preserved.
+            http_client: Optional HTTP client to reuse. An injected client is
+                owned by the caller; otherwise the relay creates one lazily
+                and ``aclose()`` (or ``async with``) closes it.
+            timeout: HTTP timeout for the internally created client.
+        """
         if not api_key:
             raise ValueError("api_key is required")
         if not api_base_url:
@@ -70,7 +99,14 @@ class Relay:
         self._timeout = timeout
 
     def configure(self, intent: Intent) -> SplitIntent:
-        """Replace a charge intent's lifecycle hooks with relay calls."""
+        """Wrap a charge intent so its lifecycle is served by the relay.
+
+        The returned intent delegates ``validate``, ``broadcast``, and the
+        legacy ``verify`` entirely to ``/v1/mpp/validate`` and
+        ``/v1/mpp/broadcast``; the wrapped intent's local verification
+        configuration (RPC URL, replay store, sender validation) is not
+        consulted because the relay performs those checks itself.
+        """
         if intent.name != "charge":
             raise ValueError("Relay can only configure a charge intent")
         return _RelayCharge(self)
@@ -189,6 +225,12 @@ def _relay_input(credential: Credential) -> dict[str, Any]:
 
 
 def _idempotency_key(body: dict[str, Any]) -> str:
+    """Derive a deterministic broadcast idempotency key.
+
+    Pull-mode credentials use the signed transaction's hash so retries of the
+    same transaction collapse server-side; other payloads fall back to a hash
+    of the canonical relay input.
+    """
     payload = body.get("payload")
     if isinstance(payload, dict):
         signature = payload.get("signature")

--- a/src/mpp/server/__init__.py
+++ b/src/mpp/server/__init__.py
@@ -49,7 +49,6 @@ from mpp.server.intent import (
     broadcast_credential,
     intent,
     validate_credential,
-    verify_credential,
 )
 from mpp.server.method import Method, transform_request
 from mpp.server.mpp import Mpp

--- a/src/mpp/server/__init__.py
+++ b/src/mpp/server/__init__.py
@@ -43,8 +43,8 @@ from mpp.events import (
 from mpp.server.decorator import pay
 from mpp.server.intent import (
     Intent,
-    SplitIntent,
     Validation,
+    VerifiableIntent,
     VerificationError,
     broadcast_credential,
     intent,

--- a/src/mpp/server/__init__.py
+++ b/src/mpp/server/__init__.py
@@ -41,7 +41,16 @@ from mpp.events import (
     PaymentEventName,
 )
 from mpp.server.decorator import pay
-from mpp.server.intent import Intent, VerificationError, intent
+from mpp.server.intent import (
+    Intent,
+    SplitIntent,
+    Validation,
+    VerificationError,
+    broadcast_credential,
+    intent,
+    validate_credential,
+    verify_credential,
+)
 from mpp.server.method import Method, transform_request
 from mpp.server.mpp import Mpp
 from mpp.server.verify import verify_or_challenge

--- a/src/mpp/server/_defaults.py
+++ b/src/mpp/server/_defaults.py
@@ -30,8 +30,8 @@ def detect_realm() -> str:
 def detect_secret_key() -> str:
     """Get server secret key from environment.
 
-    Mirrors mppx behavior: the secret key is required and must be provided
-    via `MPP_SECRET_KEY` or passed explicitly to server APIs.
+    The secret key is required and must be provided via ``MPP_SECRET_KEY`` or
+    passed explicitly to server APIs.
     """
     value = os.environ.get(_SECRET_KEY_NAME)
     if value and value.strip():

--- a/src/mpp/server/decorator.py
+++ b/src/mpp/server/decorator.py
@@ -15,7 +15,7 @@ from mpp.server._defaults import detect_realm, detect_secret_key
 from mpp.server.verify import verify_or_challenge
 
 if TYPE_CHECKING:
-    from mpp.server.intent import Intent
+    from mpp.server.intent import Intent, SplitIntent
 
 R = TypeVar("R")
 
@@ -111,12 +111,12 @@ def framework_scope(request: Any) -> dict[str, str]:
 
 def bind_framework_scope(request_params: dict[str, Any], request_obj: Any) -> dict[str, Any]:
     """Return request params with automatic framework scope when available."""
-    if "_mpp_scope" in request_params:
+    if "_mppx_scope" in request_params:
         return request_params
     scope = framework_scope(request_obj)
     if not scope:
         return request_params
-    return {**request_params, "_mpp_scope": scope}
+    return {**request_params, "_mppx_scope": scope}
 
 
 def make_challenge_response(
@@ -227,7 +227,7 @@ def wrap_payment_handler(
 
 def pay(
     *,
-    intent: Intent,
+    intent: Intent | SplitIntent,
     request: RequestParamsType,
     realm: str | None = None,
     secret_key: str | None = None,

--- a/src/mpp/server/decorator.py
+++ b/src/mpp/server/decorator.py
@@ -15,7 +15,7 @@ from mpp.server._defaults import detect_realm, detect_secret_key
 from mpp.server.verify import verify_or_challenge
 
 if TYPE_CHECKING:
-    from mpp.server.intent import Intent, SplitIntent
+    from mpp.server.intent import Intent, VerifiableIntent
 
 R = TypeVar("R")
 
@@ -227,7 +227,7 @@ def wrap_payment_handler(
 
 def pay(
     *,
-    intent: Intent | SplitIntent,
+    intent: Intent | VerifiableIntent,
     request: RequestParamsType,
     realm: str | None = None,
     secret_key: str | None = None,

--- a/src/mpp/server/decorator.py
+++ b/src/mpp/server/decorator.py
@@ -111,12 +111,12 @@ def framework_scope(request: Any) -> dict[str, str]:
 
 def bind_framework_scope(request_params: dict[str, Any], request_obj: Any) -> dict[str, Any]:
     """Return request params with automatic framework scope when available."""
-    if "_mppx_scope" in request_params:
+    if "_mpp_scope" in request_params:
         return request_params
     scope = framework_scope(request_obj)
     if not scope:
         return request_params
-    return {**request_params, "_mppx_scope": scope}
+    return {**request_params, "_mpp_scope": scope}
 
 
 def make_challenge_response(

--- a/src/mpp/server/decorator.py
+++ b/src/mpp/server/decorator.py
@@ -9,7 +9,7 @@ from functools import wraps
 from typing import TYPE_CHECKING, Any, TypeVar
 
 from mpp import Challenge, Credential, Receipt
-from mpp.errors import PaymentRequiredError
+from mpp.errors import PaymentError, PaymentRequiredError
 from mpp.events import EventDispatcher
 from mpp.server._defaults import detect_realm, detect_secret_key
 from mpp.server.verify import verify_or_challenge
@@ -119,13 +119,17 @@ def bind_framework_scope(request_params: dict[str, Any], request_obj: Any) -> di
     return {**request_params, "_mppx_scope": scope}
 
 
-def make_challenge_response(challenge: Challenge, realm: str) -> Any:
+def make_challenge_response(
+    challenge: Challenge,
+    realm: str,
+    error: PaymentError | None = None,
+) -> Any:
     """Build a 402 response for a payment challenge with RFC 9457 problem details body.
 
     Returns a Starlette ``Response`` when starlette is installed,
     otherwise a plain dict with ``_mpp_challenge``, ``status``, and ``headers``.
     """
-    error = PaymentRequiredError(realm=realm, description=challenge.description)
+    error = error or PaymentRequiredError(realm=realm, description=challenge.description)
     body = _json.dumps(error.to_problem_details(challenge.id))
     headers = {
         "WWW-Authenticate": challenge.to_www_authenticate(realm),
@@ -203,7 +207,12 @@ def wrap_payment_handler(
 
         authorization = get_authorization(request_obj)
 
-        result = await verify_fn(authorization, request_obj)
+        try:
+            result = await verify_fn(authorization, request_obj)
+        except PaymentError as error:
+            if not isinstance(error.retry_challenge, Challenge):
+                raise
+            return make_challenge_response(error.retry_challenge, realm_fn(), error)
 
         if isinstance(result, Challenge):
             return make_challenge_response(result, realm_fn())

--- a/src/mpp/server/intent.py
+++ b/src/mpp/server/intent.py
@@ -64,7 +64,14 @@ class Intent(Protocol):
 
 @runtime_checkable
 class SplitIntent(Intent, Protocol):
-    """Intent with separate validation and terminal broadcast hooks."""
+    """Intent with separate non-mutating validation and terminal broadcast hooks.
+
+    Implement both hooks to participate in the split lifecycle; intents that
+    implement only ``verify`` are dispatched through that legacy combined hook
+    instead. ``validate`` must not settle, reserve, or otherwise consume
+    payment state, so it can back a safe pre-check. ``broadcast`` performs the
+    terminal payment operation and returns its receipt.
+    """
 
     async def validate(
         self,
@@ -85,7 +92,19 @@ async def validate_credential(
     credential: Credential,
     request: dict[str, Any],
 ) -> Validation:
-    """Validate a credential without consuming payment state."""
+    """Run an intent's non-mutating validation hook.
+
+    Legacy intents that only implement ``verify`` are rejected: verification
+    may consume payment state, so it cannot back a safe pre-check. This is the
+    low-level dispatcher — it does not authenticate that the credential's
+    challenge was issued by a particular server. Use
+    :meth:`~mpp.server.Mpp.validate_credential` for credentials from
+    untrusted callers.
+
+    Raises:
+        VerificationFailedError: If the intent does not support non-mutating
+            validation or returns an invalid validation result.
+    """
     if not isinstance(intent, SplitIntent):
         raise VerificationFailedError(
             f"{intent.name} does not support non-mutating credential validation"
@@ -102,7 +121,14 @@ async def broadcast_credential(
     credential: Credential,
     request: dict[str, Any],
 ) -> Receipt:
-    """Revalidate and perform the credential's terminal payment operation."""
+    """Revalidate and perform the credential's terminal payment operation.
+
+    Split intents run ``validate`` before ``broadcast`` so a credential that
+    is no longer acceptable fails before settlement; legacy intents fall back
+    to their combined ``verify`` hook. Like :func:`validate_credential`, this
+    does not authenticate challenge issuance — use
+    :meth:`~mpp.server.Mpp.broadcast_credential` for untrusted input.
+    """
     if isinstance(intent, SplitIntent):
         await validate_credential(intent=intent, credential=credential, request=request)
         return await intent.broadcast(credential, request)

--- a/src/mpp/server/intent.py
+++ b/src/mpp/server/intent.py
@@ -22,10 +22,10 @@ from mpp.errors import VerificationFailedError
 
 @runtime_checkable
 class Intent(Protocol):
-    """Payment intent interface.
+    """Payment intent with a combined verification hook.
 
-    Implement this protocol to define custom payment intents.
-    Duck typing is supported - just implement the required attributes.
+    This is the original intent interface and remains supported for custom
+    intents that combine validation and settlement in ``verify``.
 
     Example:
         class MyChargeIntent:
@@ -63,15 +63,16 @@ class Intent(Protocol):
 
 
 @runtime_checkable
-class SplitIntent(Intent, Protocol):
+class SplitIntent(Protocol):
     """Intent with separate non-mutating validation and terminal broadcast hooks.
 
-    Implement both hooks to participate in the split lifecycle; intents that
-    implement only ``verify`` are dispatched through that legacy combined hook
-    instead. ``validate`` must not settle, reserve, or otherwise consume
-    payment state, so it can back a safe pre-check. ``broadcast`` performs the
-    terminal payment operation and returns its receipt.
+    Implement both hooks to participate in the split lifecycle. ``validate``
+    must not settle, reserve, or otherwise consume payment state, so it can
+    back a safe pre-check. ``broadcast`` performs the terminal payment
+    operation and returns its receipt.
     """
+
+    name: str
 
     async def validate(
         self,
@@ -88,7 +89,7 @@ class SplitIntent(Intent, Protocol):
 
 async def validate_credential(
     *,
-    intent: Intent,
+    intent: Intent | SplitIntent,
     credential: Credential,
     request: dict[str, Any],
 ) -> Validation:
@@ -117,7 +118,7 @@ async def validate_credential(
 
 async def broadcast_credential(
     *,
-    intent: Intent,
+    intent: Intent | SplitIntent,
     credential: Credential,
     request: dict[str, Any],
 ) -> Receipt:
@@ -132,7 +133,11 @@ async def broadcast_credential(
     if isinstance(intent, SplitIntent):
         await validate_credential(intent=intent, credential=credential, request=request)
         return await intent.broadcast(credential, request)
-    return await intent.verify(credential, request)
+    if isinstance(intent, Intent):
+        return await intent.verify(credential, request)
+    raise VerificationFailedError(
+        f"{intent.name} does not support credential verification or broadcast"
+    )
 
 
 class FunctionalIntent:

--- a/src/mpp/server/intent.py
+++ b/src/mpp/server/intent.py
@@ -63,13 +63,13 @@ class Intent(Protocol):
 
 
 @runtime_checkable
-class SplitIntent(Protocol):
+class VerifiableIntent(Protocol):
     """Intent with separate non-mutating validation and terminal broadcast hooks.
 
-    Implement both hooks to participate in the split lifecycle. ``validate``
-    must not settle, reserve, or otherwise consume payment state, so it can
-    back a safe pre-check. ``broadcast`` performs the terminal payment
-    operation and returns its receipt.
+    Implement both hooks to support validation before broadcast. ``validate``
+    must not settle, reserve, or otherwise consume payment state, so it can back
+    a safe pre-check. ``broadcast`` performs the terminal payment operation and
+    returns its receipt.
     """
 
     name: str
@@ -89,7 +89,7 @@ class SplitIntent(Protocol):
 
 async def validate_credential(
     *,
-    intent: Intent | SplitIntent,
+    intent: Intent | VerifiableIntent,
     credential: Credential,
     request: dict[str, Any],
 ) -> Validation:
@@ -106,7 +106,7 @@ async def validate_credential(
         VerificationFailedError: If the intent does not support non-mutating
             validation or returns an invalid validation result.
     """
-    if not isinstance(intent, SplitIntent):
+    if not isinstance(intent, VerifiableIntent):
         raise VerificationFailedError(
             f"{intent.name} does not support non-mutating credential validation"
         )
@@ -118,19 +118,19 @@ async def validate_credential(
 
 async def broadcast_credential(
     *,
-    intent: Intent | SplitIntent,
+    intent: Intent | VerifiableIntent,
     credential: Credential,
     request: dict[str, Any],
 ) -> Receipt:
     """Revalidate and perform the credential's terminal payment operation.
 
-    Split intents run ``validate`` before ``broadcast`` so a credential that
-    is no longer acceptable fails before settlement; legacy intents fall back
-    to their combined ``verify`` hook. Like :func:`validate_credential`, this
-    does not authenticate challenge issuance — use
+    Verifiable intents run ``validate`` before ``broadcast`` so a credential
+    that is no longer acceptable fails before settlement; legacy intents fall
+    back to their combined ``verify`` hook. Like :func:`validate_credential`,
+    this does not authenticate challenge issuance — use
     :meth:`~mpp.server.Mpp.broadcast_credential` for untrusted input.
     """
-    if isinstance(intent, SplitIntent):
+    if isinstance(intent, VerifiableIntent):
         await validate_credential(intent=intent, credential=credential, request=request)
         return await intent.broadcast(credential, request)
     if isinstance(intent, Intent):

--- a/src/mpp/server/intent.py
+++ b/src/mpp/server/intent.py
@@ -7,13 +7,17 @@ and provides verification logic.
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
-from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, cast, runtime_checkable
 
 if TYPE_CHECKING:
     from mpp import Credential, Receipt
 
 
-from mpp.errors import VerificationError as VerificationError  # noqa: F401 — re-export
+from mpp._validation import Validation
+from mpp.errors import (
+    VerificationError as VerificationError,  # noqa: F401 — re-export
+)
+from mpp.errors import VerificationFailedError
 
 
 @runtime_checkable
@@ -56,6 +60,73 @@ class Intent(Protocol):
             VerificationError: If the credential is invalid or payment failed.
         """
         ...
+
+
+@runtime_checkable
+class SplitIntent(Intent, Protocol):
+    """Intent with separate validation and terminal broadcast hooks."""
+
+    async def validate(
+        self,
+        credential: Credential,
+        request: dict[str, Any],
+    ) -> Validation: ...
+
+    async def broadcast(
+        self,
+        credential: Credential,
+        request: dict[str, Any],
+    ) -> Receipt: ...
+
+
+async def validate_credential(
+    *,
+    intent: Intent,
+    credential: Credential,
+    request: dict[str, Any],
+) -> Validation:
+    """Validate a credential without consuming payment state."""
+    validate = cast(
+        "Callable[[Credential, dict[str, Any]], Awaitable[Validation]] | None",
+        getattr(intent, "validate", None),
+    )
+    if not callable(validate):
+        raise VerificationFailedError(
+            f"{intent.name} does not support non-mutating credential validation"
+        )
+    result = await validate(credential, request)
+    if not isinstance(result, Validation):
+        raise VerificationFailedError("Intent returned an invalid validation result")
+    return result
+
+
+async def broadcast_credential(
+    *,
+    intent: Intent,
+    credential: Credential,
+    request: dict[str, Any],
+) -> Receipt:
+    """Revalidate and perform the credential's terminal payment operation."""
+    validate = getattr(intent, "validate", None)
+    broadcast = cast(
+        "Callable[[Credential, dict[str, Any]], Awaitable[Receipt]] | None",
+        getattr(intent, "broadcast", None),
+    )
+    if callable(validate) and callable(broadcast):
+        await validate_credential(intent=intent, credential=credential, request=request)
+    if callable(broadcast):
+        return await broadcast(credential, request)
+    return await intent.verify(credential, request)
+
+
+async def verify_credential(
+    *,
+    intent: Intent,
+    credential: Credential,
+    request: dict[str, Any],
+) -> Receipt:
+    """Backward-compatible alias for :func:`broadcast_credential`."""
+    return await broadcast_credential(intent=intent, credential=credential, request=request)
 
 
 class FunctionalIntent:

--- a/src/mpp/server/intent.py
+++ b/src/mpp/server/intent.py
@@ -124,9 +124,10 @@ async def broadcast_credential(
     """Revalidate and perform the credential's terminal payment operation.
 
     Split intents run ``validate`` before ``broadcast`` so a credential that
-    is no longer acceptable fails before settlement; legacy intents fall back
-    to their combined ``verify`` hook. Like :func:`validate_credential`, this
-    does not authenticate challenge issuance — use
+    is no longer acceptable fails before settlement, matching mppx's
+    ``broadcastCredential`` dispatch; legacy intents fall back to their
+    combined ``verify`` hook. Like :func:`validate_credential`, this does not
+    authenticate challenge issuance — use
     :meth:`~mpp.server.Mpp.broadcast_credential` for untrusted input.
     """
     if isinstance(intent, SplitIntent):

--- a/src/mpp/server/intent.py
+++ b/src/mpp/server/intent.py
@@ -124,10 +124,9 @@ async def broadcast_credential(
     """Revalidate and perform the credential's terminal payment operation.
 
     Split intents run ``validate`` before ``broadcast`` so a credential that
-    is no longer acceptable fails before settlement, matching mppx's
-    ``broadcastCredential`` dispatch; legacy intents fall back to their
-    combined ``verify`` hook. Like :func:`validate_credential`, this does not
-    authenticate challenge issuance — use
+    is no longer acceptable fails before settlement; legacy intents fall back
+    to their combined ``verify`` hook. Like :func:`validate_credential`, this
+    does not authenticate challenge issuance — use
     :meth:`~mpp.server.Mpp.broadcast_credential` for untrusted input.
     """
     if isinstance(intent, SplitIntent):

--- a/src/mpp/server/intent.py
+++ b/src/mpp/server/intent.py
@@ -7,7 +7,7 @@ and provides verification logic.
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
-from typing import TYPE_CHECKING, Any, Protocol, cast, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
     from mpp import Credential, Receipt
@@ -86,15 +86,11 @@ async def validate_credential(
     request: dict[str, Any],
 ) -> Validation:
     """Validate a credential without consuming payment state."""
-    validate = cast(
-        "Callable[[Credential, dict[str, Any]], Awaitable[Validation]] | None",
-        getattr(intent, "validate", None),
-    )
-    if not callable(validate):
+    if not isinstance(intent, SplitIntent):
         raise VerificationFailedError(
             f"{intent.name} does not support non-mutating credential validation"
         )
-    result = await validate(credential, request)
+    result = await intent.validate(credential, request)
     if not isinstance(result, Validation):
         raise VerificationFailedError("Intent returned an invalid validation result")
     return result
@@ -107,26 +103,10 @@ async def broadcast_credential(
     request: dict[str, Any],
 ) -> Receipt:
     """Revalidate and perform the credential's terminal payment operation."""
-    validate = getattr(intent, "validate", None)
-    broadcast = cast(
-        "Callable[[Credential, dict[str, Any]], Awaitable[Receipt]] | None",
-        getattr(intent, "broadcast", None),
-    )
-    if callable(validate) and callable(broadcast):
+    if isinstance(intent, SplitIntent):
         await validate_credential(intent=intent, credential=credential, request=request)
-    if callable(broadcast):
-        return await broadcast(credential, request)
+        return await intent.broadcast(credential, request)
     return await intent.verify(credential, request)
-
-
-async def verify_credential(
-    *,
-    intent: Intent,
-    credential: Credential,
-    request: dict[str, Any],
-) -> Receipt:
-    """Backward-compatible alias for :func:`broadcast_credential`."""
-    return await broadcast_credential(intent=intent, credential=credential, request=request)
 
 
 class FunctionalIntent:

--- a/src/mpp/server/method.py
+++ b/src/mpp/server/method.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from mpp import Challenge, Credential
-    from mpp.server.intent import Intent
+    from mpp.server.intent import Intent, SplitIntent
 
 
 @runtime_checkable
@@ -23,7 +25,7 @@ class Method(Protocol):
             name = "stripe"
 
             @property
-            def intents(self) -> dict[str, Intent]:
+            def intents(self) -> Mapping[str, Intent | SplitIntent]:
                 return {"charge": StripeChargeIntent(self.api_key)}
 
             async def create_credential(self, challenge: Challenge) -> Credential:
@@ -34,7 +36,7 @@ class Method(Protocol):
     name: str
 
     @property
-    def intents(self) -> dict[str, Intent]:
+    def intents(self) -> Mapping[str, Intent | SplitIntent]:
         """Available intents for this method."""
         ...
 

--- a/src/mpp/server/method.py
+++ b/src/mpp/server/method.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
     from collections.abc import Mapping
 
     from mpp import Challenge, Credential
-    from mpp.server.intent import Intent, SplitIntent
+    from mpp.server.intent import Intent, VerifiableIntent
 
 
 @runtime_checkable
@@ -25,7 +25,7 @@ class Method(Protocol):
             name = "stripe"
 
             @property
-            def intents(self) -> Mapping[str, Intent | SplitIntent]:
+            def intents(self) -> Mapping[str, Intent | VerifiableIntent]:
                 return {"charge": StripeChargeIntent(self.api_key)}
 
             async def create_credential(self, challenge: Challenge) -> Credential:
@@ -36,7 +36,7 @@ class Method(Protocol):
     name: str
 
     @property
-    def intents(self) -> Mapping[str, Intent | SplitIntent]:
+    def intents(self) -> Mapping[str, Intent | VerifiableIntent]:
         """Available intents for this method."""
         ...
 

--- a/src/mpp/server/mpp.py
+++ b/src/mpp/server/mpp.py
@@ -38,7 +38,7 @@ from mpp.server.verify import _authenticate_echo, _challenge_from_echo, verify_o
 from mpp.store import Store
 
 if TYPE_CHECKING:
-    from mpp.server.intent import Intent, SplitIntent
+    from mpp.server.intent import Intent, VerifiableIntent
     from mpp.server.method import Method
 
 R = TypeVar("R")
@@ -137,7 +137,7 @@ class Mpp:
         *,
         intent: str | None,
         request: dict[str, Any] | None,
-    ) -> tuple[Credential, Intent | SplitIntent, dict[str, Any], Challenge]:
+    ) -> tuple[Credential, Intent | VerifiableIntent, dict[str, Any], Challenge]:
         """Authenticate and resolve a credential outside an HTTP route."""
         if isinstance(value, Credential):
             credential = value
@@ -244,8 +244,8 @@ class Mpp:
         """Revalidate and perform a bound credential's terminal operation.
 
         Applies the same challenge authentication as
-        :meth:`validate_credential`, then runs the intent's split lifecycle —
-        the non-mutating ``validate`` hook followed by the terminal
+        :meth:`validate_credential`, then runs the intent's validate-then-broadcast
+        lifecycle — the non-mutating ``validate`` hook followed by the terminal
         ``broadcast`` (legacy intents fall back to their combined ``verify``
         hook). Emits the same payment success/failure events as HTTP route
         handlers.

--- a/src/mpp/server/mpp.py
+++ b/src/mpp/server/mpp.py
@@ -38,7 +38,7 @@ from mpp.server.verify import _authenticate_echo, _challenge_from_echo, verify_o
 from mpp.store import Store
 
 if TYPE_CHECKING:
-    from mpp.server.intent import Intent
+    from mpp.server.intent import Intent, SplitIntent
     from mpp.server.method import Method
 
 R = TypeVar("R")
@@ -137,7 +137,7 @@ class Mpp:
         *,
         intent: str | None,
         request: dict[str, Any] | None,
-    ) -> tuple[Credential, Intent, dict[str, Any], Challenge]:
+    ) -> tuple[Credential, Intent | SplitIntent, dict[str, Any], Challenge]:
         """Authenticate and resolve a credential outside an HTTP route."""
         if isinstance(value, Credential):
             credential = value
@@ -288,25 +288,6 @@ class Mpp:
             raise
         await self._events.emit(PAYMENT_SUCCESS, {**context, "receipt": receipt})
         return receipt
-
-    async def verify_credential(
-        self,
-        credential: Credential | str,
-        *,
-        intent: str | None = None,
-        request: dict[str, Any] | None = None,
-    ) -> Receipt:
-        """Terminal alias for :meth:`broadcast_credential` and the intent
-        protocol's combined ``verify`` hook.
-
-        Prefer :meth:`validate_credential` for the non-mutating pre-check and
-        :meth:`broadcast_credential` for settlement.
-        """
-        return await self.broadcast_credential(
-            credential,
-            intent=intent,
-            request=request,
-        )
 
     @classmethod
     def create(

--- a/src/mpp/server/mpp.py
+++ b/src/mpp/server/mpp.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Mapping
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any, TypeVar
 
@@ -125,7 +125,7 @@ class Mpp:
     def _wire_store(self, store: Store) -> None:
         """Inject *store* into intents that have a ``_store`` attribute set to None."""
         intents = getattr(self.method, "intents", None)
-        if not isinstance(intents, dict):
+        if not isinstance(intents, Mapping):
             return
         for intent_obj in intents.values():
             if hasattr(intent_obj, "_store") and intent_obj._store is None:

--- a/src/mpp/server/mpp.py
+++ b/src/mpp/server/mpp.py
@@ -296,8 +296,8 @@ class Mpp:
         intent: str | None = None,
         request: dict[str, Any] | None = None,
     ) -> Receipt:
-        """Terminal alias for :meth:`broadcast_credential`, matching mppx's
-        ``verifyCredential`` and the intent protocol's combined ``verify`` hook.
+        """Terminal alias for :meth:`broadcast_credential` and the intent
+        protocol's combined ``verify`` hook.
 
         Prefer :meth:`validate_credential` for the non-mutating pre-check and
         :meth:`broadcast_credential` for settlement.

--- a/src/mpp/server/mpp.py
+++ b/src/mpp/server/mpp.py
@@ -34,7 +34,12 @@ from mpp.server.intent import Validation
 from mpp.server.intent import broadcast_credential as broadcast_intent_credential
 from mpp.server.intent import validate_credential as validate_intent_credential
 from mpp.server.method import transform_request
-from mpp.server.verify import _authenticate_echo, _challenge_from_echo, verify_or_challenge
+from mpp.server.verify import (
+    _authenticate_echo,
+    _body_digest_error,
+    _challenge_from_echo,
+    verify_or_challenge,
+)
 from mpp.store import Store
 
 if TYPE_CHECKING:
@@ -44,6 +49,14 @@ if TYPE_CHECKING:
 R = TypeVar("R")
 
 DEFAULT_DECIMALS = 6
+
+
+class _ContextUnset:
+    def __repr__(self) -> str:
+        return "<unset>"
+
+
+_CONTEXT_UNSET: Any = _ContextUnset()
 
 
 class Mpp:
@@ -137,6 +150,8 @@ class Mpp:
         *,
         intent: str | None,
         request: dict[str, Any] | None,
+        meta: dict[str, str] | None = _CONTEXT_UNSET,
+        body: str | bytes | dict[str, Any] | None = _CONTEXT_UNSET,
     ) -> tuple[Credential, Intent | VerifiableIntent, dict[str, Any], Challenge]:
         """Authenticate and resolve a credential outside an HTTP route."""
         credential = self._parse_credential(value)
@@ -172,6 +187,14 @@ class Mpp:
             if expected_request != echoed_request:
                 raise InvalidChallengeError(echo.id, "credential request does not match")
 
+        if request is not None or meta is not _CONTEXT_UNSET or body is not _CONTEXT_UNSET:
+            expected_meta = None if meta is _CONTEXT_UNSET else meta
+            expected_body = None if body is _CONTEXT_UNSET else body
+            if echoed_opaque != expected_meta:
+                raise InvalidChallengeError(echo.id, "credential opaque does not match")
+            if digest_error := _body_digest_error(echo.digest, expected_body):
+                raise InvalidChallengeError(echo.id, digest_error)
+
         intent_obj = self.method.intents.get(echo.intent)
         if intent_obj is None:
             raise PaymentMethodUnsupportedError(f"{echo.method}/{echo.intent}")
@@ -194,6 +217,8 @@ class Mpp:
         *,
         intent: str | None = None,
         request: dict[str, Any] | None = None,
+        meta: dict[str, str] | None = _CONTEXT_UNSET,
+        body: str | bytes | dict[str, Any] | None = _CONTEXT_UNSET,
     ) -> Validation:
         """Validate a bound credential without consuming payment state.
 
@@ -212,6 +237,10 @@ class Mpp:
                 this intent name.
             request: If provided, also require the credential's echoed
                 request to match these request parameters.
+            meta: Expected opaque challenge metadata. Supplying any request,
+                meta, or body context checks all three bindings; omitted
+                bindings are treated as absent.
+            body: Expected request body for the challenge's digest binding.
 
         Returns:
             The intent's validation record for the accepted credential.
@@ -230,6 +259,8 @@ class Mpp:
             credential,
             intent=intent,
             request=request,
+            meta=meta,
+            body=body,
         )
         return await validate_intent_credential(
             intent=intent_obj,
@@ -243,6 +274,8 @@ class Mpp:
         *,
         intent: str | None = None,
         request: dict[str, Any] | None = None,
+        meta: dict[str, str] | None = _CONTEXT_UNSET,
+        body: str | bytes | dict[str, Any] | None = _CONTEXT_UNSET,
     ) -> Receipt:
         """Revalidate and perform a bound credential's terminal operation.
 
@@ -259,6 +292,10 @@ class Mpp:
                 this intent name.
             request: If provided, also require the credential's echoed
                 request to match these request parameters.
+            meta: Expected opaque challenge metadata. Supplying any request,
+                meta, or body context checks all three bindings; omitted
+                bindings are treated as absent.
+            body: Expected request body for the challenge's digest binding.
 
         Returns:
             The settlement receipt from the intent's terminal operation.
@@ -274,6 +311,8 @@ class Mpp:
                 parsed,
                 intent=intent,
                 request=request,
+                meta=meta,
+                body=body,
             )
         except Exception as error:
             echo = parsed.challenge

--- a/src/mpp/server/mpp.py
+++ b/src/mpp/server/mpp.py
@@ -192,7 +192,37 @@ class Mpp:
         intent: str | None = None,
         request: dict[str, Any] | None = None,
     ) -> Validation:
-        """Validate a bound credential without consuming payment state."""
+        """Validate a bound credential without consuming payment state.
+
+        Authenticates the credential's echoed challenge against this server's
+        secret key (HMAC challenge ID, realm, method, expiry) before running
+        the intent's non-mutating ``validate`` hook. The result is advisory —
+        it confirms the credential is currently acceptable but does not
+        settle, reserve, or consume the payment — so no payment events are
+        emitted.
+
+        Args:
+            credential: A parsed ``Credential`` or its serialized form (the
+                ``Authorization`` header value, with or without the
+                ``Payment`` scheme prefix).
+            intent: If provided, also require the credential to be bound to
+                this intent name.
+            request: If provided, also require the credential's echoed
+                request to match these request parameters.
+
+        Returns:
+            The intent's validation record for the accepted credential.
+
+        Raises:
+            MalformedCredentialError: If the credential cannot be parsed.
+            InvalidChallengeError: If the challenge was not issued by this
+                server or does not match the requested binding.
+            PaymentExpiredError: If the echoed challenge has expired.
+            PaymentMethodUnsupportedError: If the credential names a method
+                or intent this server does not serve.
+            VerificationFailedError: If the intent does not support
+                non-mutating validation or rejects the credential.
+        """
         prepared, intent_obj, echoed_request, _ = self._prepare_credential(
             credential,
             intent=intent,
@@ -211,7 +241,30 @@ class Mpp:
         intent: str | None = None,
         request: dict[str, Any] | None = None,
     ) -> Receipt:
-        """Revalidate and perform a bound credential's terminal operation."""
+        """Revalidate and perform a bound credential's terminal operation.
+
+        Applies the same challenge authentication as
+        :meth:`validate_credential`, then runs the intent's split lifecycle —
+        the non-mutating ``validate`` hook followed by the terminal
+        ``broadcast`` (legacy intents fall back to their combined ``verify``
+        hook). Emits the same payment success/failure events as HTTP route
+        handlers.
+
+        Args:
+            credential: A parsed ``Credential`` or its serialized form.
+            intent: If provided, also require the credential to be bound to
+                this intent name.
+            request: If provided, also require the credential's echoed
+                request to match these request parameters.
+
+        Returns:
+            The settlement receipt from the intent's terminal operation.
+
+        Raises:
+            The same challenge-authentication errors as
+            :meth:`validate_credential`, or the intent's verification error
+            if validation or settlement fails.
+        """
         prepared, intent_obj, echoed_request, challenge = self._prepare_credential(
             credential,
             intent=intent,
@@ -243,7 +296,11 @@ class Mpp:
         intent: str | None = None,
         request: dict[str, Any] | None = None,
     ) -> Receipt:
-        """Backward-compatible alias for :meth:`broadcast_credential`."""
+        """Backward-compatible alias for :meth:`broadcast_credential`.
+
+        Prefer :meth:`validate_credential` for the non-mutating pre-check and
+        :meth:`broadcast_credential` for settlement.
+        """
         return await self.broadcast_credential(
             credential,
             intent=intent,

--- a/src/mpp/server/mpp.py
+++ b/src/mpp/server/mpp.py
@@ -296,7 +296,8 @@ class Mpp:
         intent: str | None = None,
         request: dict[str, Any] | None = None,
     ) -> Receipt:
-        """Backward-compatible alias for :meth:`broadcast_credential`.
+        """Terminal alias for :meth:`broadcast_credential`, matching mppx's
+        ``verifyCredential`` and the intent protocol's combined ``verify`` hook.
 
         Prefer :meth:`validate_credential` for the non-mutating pre-check and
         :meth:`broadcast_credential` for settlement.

--- a/src/mpp/server/mpp.py
+++ b/src/mpp/server/mpp.py
@@ -6,8 +6,15 @@ from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any, TypeVar
 
-from mpp import Challenge, Credential, Receipt
-from mpp._units import parse_units
+from mpp import Challenge, Credential, Receipt, _constant_time_equal, generate_challenge_id
+from mpp._parsing import ParseError, _b64_decode
+from mpp._units import parse_units, transform_units
+from mpp.errors import (
+    InvalidChallengeError,
+    MalformedCredentialError,
+    PaymentExpiredError,
+    PaymentMethodUnsupportedError,
+)
 from mpp.events import (
     CHALLENGE_CREATED,
     PAYMENT_FAILED,
@@ -23,11 +30,15 @@ from mpp.server.decorator import (
     resolve_body_param,
     wrap_payment_handler,
 )
+from mpp.server.intent import Validation
+from mpp.server.intent import broadcast_credential as broadcast_intent_credential
+from mpp.server.intent import validate_credential as validate_intent_credential
 from mpp.server.method import transform_request
 from mpp.server.verify import verify_or_challenge
 from mpp.store import Store
 
 if TYPE_CHECKING:
+    from mpp.server.intent import Intent
     from mpp.server.method import Method
 
 R = TypeVar("R")
@@ -119,6 +130,125 @@ class Mpp:
         for intent_obj in intents.values():
             if hasattr(intent_obj, "_store") and intent_obj._store is None:
                 intent_obj._store = store
+
+    def _prepare_credential(
+        self,
+        value: Credential | str,
+        *,
+        intent: str | None,
+        request: dict[str, Any] | None,
+    ) -> tuple[Credential, Intent, dict[str, Any]]:
+        """Authenticate and resolve a credential outside an HTTP route."""
+        if isinstance(value, Credential):
+            credential = value
+        else:
+            authorization = value if value.lower().startswith("payment ") else f"Payment {value}"
+            try:
+                credential = Credential.from_authorization(authorization)
+            except ParseError as error:
+                raise MalformedCredentialError(str(error)) from error
+
+        echo = credential.challenge
+        try:
+            echoed_request = _b64_decode(echo.request) if echo.request else {}
+            echoed_opaque = _b64_decode(echo.opaque) if echo.opaque else None
+        except ParseError as error:
+            raise MalformedCredentialError(str(error)) from error
+
+        if echo.realm != self.realm:
+            raise InvalidChallengeError(echo.id, "credential realm does not match")
+        if echo.method != self.method.name:
+            raise PaymentMethodUnsupportedError(echo.method)
+        if intent is not None and echo.intent != intent:
+            raise InvalidChallengeError(echo.id, "credential intent does not match")
+
+        expected_id = generate_challenge_id(
+            secret_key=self.secret_key,
+            realm=echo.realm,
+            method=echo.method,
+            intent=echo.intent,
+            request=echoed_request,
+            expires=echo.expires,
+            digest=echo.digest,
+            opaque=echoed_opaque,
+        )
+        if not _constant_time_equal(echo.id, expected_id):
+            raise InvalidChallengeError(echo.id, "challenge was not issued by this server")
+
+        try:
+            expires = datetime.fromisoformat((echo.expires or "").replace("Z", "+00:00"))
+            if expires.tzinfo is None:
+                raise ValueError
+        except (TypeError, ValueError) as error:
+            raise PaymentExpiredError(echo.expires) from error
+        if expires < datetime.now(UTC):
+            raise PaymentExpiredError(echo.expires)
+
+        if request is not None:
+            expected_request = transform_request(
+                self.method,
+                transform_units(request),
+                credential,
+            )
+            if expected_request != echoed_request:
+                raise InvalidChallengeError(echo.id, "credential request does not match")
+
+        intent_obj = self.method.intents.get(echo.intent)
+        if intent_obj is None:
+            raise PaymentMethodUnsupportedError(f"{echo.method}/{echo.intent}")
+        return credential, intent_obj, echoed_request
+
+    async def validate_credential(
+        self,
+        credential: Credential | str,
+        *,
+        intent: str | None = None,
+        request: dict[str, Any] | None = None,
+    ) -> Validation:
+        """Validate a bound credential without consuming payment state."""
+        prepared, intent_obj, echoed_request = self._prepare_credential(
+            credential,
+            intent=intent,
+            request=request,
+        )
+        return await validate_intent_credential(
+            intent=intent_obj,
+            credential=prepared,
+            request=echoed_request,
+        )
+
+    async def broadcast_credential(
+        self,
+        credential: Credential | str,
+        *,
+        intent: str | None = None,
+        request: dict[str, Any] | None = None,
+    ) -> Receipt:
+        """Revalidate and perform a bound credential's terminal operation."""
+        prepared, intent_obj, echoed_request = self._prepare_credential(
+            credential,
+            intent=intent,
+            request=request,
+        )
+        return await broadcast_intent_credential(
+            intent=intent_obj,
+            credential=prepared,
+            request=echoed_request,
+        )
+
+    async def verify_credential(
+        self,
+        credential: Credential | str,
+        *,
+        intent: str | None = None,
+        request: dict[str, Any] | None = None,
+    ) -> Receipt:
+        """Backward-compatible alias for :meth:`broadcast_credential`."""
+        return await self.broadcast_credential(
+            credential,
+            intent=intent,
+            request=request,
+        )
 
     @classmethod
     def create(

--- a/src/mpp/server/mpp.py
+++ b/src/mpp/server/mpp.py
@@ -6,8 +6,8 @@ from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any, TypeVar
 
-from mpp import Challenge, Credential, Receipt, _constant_time_equal, generate_challenge_id
-from mpp._parsing import ParseError, _b64_decode
+from mpp import Challenge, Credential, Receipt
+from mpp._parsing import ParseError, _parse_timestamp
 from mpp._units import parse_units, transform_units
 from mpp.errors import (
     InvalidChallengeError,
@@ -34,7 +34,7 @@ from mpp.server.intent import Validation
 from mpp.server.intent import broadcast_credential as broadcast_intent_credential
 from mpp.server.intent import validate_credential as validate_intent_credential
 from mpp.server.method import transform_request
-from mpp.server.verify import verify_or_challenge
+from mpp.server.verify import _authenticate_echo, verify_or_challenge
 from mpp.store import Store
 
 if TYPE_CHECKING:
@@ -149,11 +149,7 @@ class Mpp:
                 raise MalformedCredentialError(str(error)) from error
 
         echo = credential.challenge
-        try:
-            echoed_request = _b64_decode(echo.request) if echo.request else {}
-            echoed_opaque = _b64_decode(echo.opaque) if echo.opaque else None
-        except ParseError as error:
-            raise MalformedCredentialError(str(error)) from error
+        echoed_request, _ = _authenticate_echo(credential, secret_key=self.secret_key)
 
         if echo.realm != self.realm:
             raise InvalidChallengeError(echo.id, "credential realm does not match")
@@ -162,26 +158,13 @@ class Mpp:
         if intent is not None and echo.intent != intent:
             raise InvalidChallengeError(echo.id, "credential intent does not match")
 
-        expected_id = generate_challenge_id(
-            secret_key=self.secret_key,
-            realm=echo.realm,
-            method=echo.method,
-            intent=echo.intent,
-            request=echoed_request,
-            expires=echo.expires,
-            digest=echo.digest,
-            opaque=echoed_opaque,
-        )
-        if not _constant_time_equal(echo.id, expected_id):
-            raise InvalidChallengeError(echo.id, "challenge was not issued by this server")
-
+        if not echo.expires:
+            raise PaymentExpiredError(echo.expires)
         try:
-            expires = datetime.fromisoformat((echo.expires or "").replace("Z", "+00:00"))
-            if expires.tzinfo is None:
-                raise ValueError
-        except (TypeError, ValueError) as error:
+            expires = _parse_timestamp(echo.expires)
+        except ParseError as error:
             raise PaymentExpiredError(echo.expires) from error
-        if expires < datetime.now(UTC):
+        if expires.tzinfo is None or expires < datetime.now(UTC):
             raise PaymentExpiredError(echo.expires)
 
         if request is not None:

--- a/src/mpp/server/mpp.py
+++ b/src/mpp/server/mpp.py
@@ -7,7 +7,7 @@ from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any, TypeVar
 
 from mpp import Challenge, Credential, Receipt
-from mpp._parsing import ParseError, _parse_timestamp
+from mpp._parsing import ParseError, _b64_decode, _parse_timestamp
 from mpp._units import parse_units, transform_units
 from mpp.errors import (
     InvalidChallengeError,
@@ -139,14 +139,7 @@ class Mpp:
         request: dict[str, Any] | None,
     ) -> tuple[Credential, Intent | VerifiableIntent, dict[str, Any], Challenge]:
         """Authenticate and resolve a credential outside an HTTP route."""
-        if isinstance(value, Credential):
-            credential = value
-        else:
-            authorization = value if value.lower().startswith("payment ") else f"Payment {value}"
-            try:
-                credential = Credential.from_authorization(authorization)
-            except ParseError as error:
-                raise MalformedCredentialError(str(error)) from error
+        credential = self._parse_credential(value)
 
         echo = credential.challenge
         echoed_request, echoed_opaque = _authenticate_echo(
@@ -184,6 +177,16 @@ class Mpp:
             raise PaymentMethodUnsupportedError(f"{echo.method}/{echo.intent}")
         challenge = _challenge_from_echo(echo, echoed_request, echoed_opaque)
         return credential, intent_obj, echoed_request, challenge
+
+    @staticmethod
+    def _parse_credential(value: Credential | str) -> Credential:
+        if isinstance(value, Credential):
+            return value
+        authorization = value if value.lower().startswith("payment ") else f"Payment {value}"
+        try:
+            return Credential.from_authorization(authorization)
+        except ParseError as error:
+            raise MalformedCredentialError(str(error)) from error
 
     async def validate_credential(
         self,
@@ -265,11 +268,32 @@ class Mpp:
             :meth:`validate_credential`, or the intent's verification error
             if validation or settlement fails.
         """
-        prepared, intent_obj, echoed_request, challenge = self._prepare_credential(
-            credential,
-            intent=intent,
-            request=request,
-        )
+        parsed = self._parse_credential(credential)
+        try:
+            prepared, intent_obj, echoed_request, challenge = self._prepare_credential(
+                parsed,
+                intent=intent,
+                request=request,
+            )
+        except Exception as error:
+            echo = parsed.challenge
+            try:
+                decoded_request = _b64_decode(echo.request) if echo.request else {}
+            except ParseError:
+                decoded_request = {}
+            failed_request = decoded_request if isinstance(decoded_request, dict) else {}
+            await self._events.emit(
+                PAYMENT_FAILED,
+                {
+                    "challenge": _challenge_from_echo(echo, failed_request, None),
+                    "credential": parsed,
+                    "error": error,
+                    "intent": intent or echo.intent,
+                    "method": self.method.name,
+                    "request": failed_request,
+                },
+            )
+            raise
         context = {
             "challenge": challenge,
             "credential": prepared,

--- a/src/mpp/server/mpp.py
+++ b/src/mpp/server/mpp.py
@@ -34,7 +34,7 @@ from mpp.server.intent import Validation
 from mpp.server.intent import broadcast_credential as broadcast_intent_credential
 from mpp.server.intent import validate_credential as validate_intent_credential
 from mpp.server.method import transform_request
-from mpp.server.verify import _authenticate_echo, verify_or_challenge
+from mpp.server.verify import _authenticate_echo, _challenge_from_echo, verify_or_challenge
 from mpp.store import Store
 
 if TYPE_CHECKING:
@@ -137,7 +137,7 @@ class Mpp:
         *,
         intent: str | None,
         request: dict[str, Any] | None,
-    ) -> tuple[Credential, Intent, dict[str, Any]]:
+    ) -> tuple[Credential, Intent, dict[str, Any], Challenge]:
         """Authenticate and resolve a credential outside an HTTP route."""
         if isinstance(value, Credential):
             credential = value
@@ -149,7 +149,10 @@ class Mpp:
                 raise MalformedCredentialError(str(error)) from error
 
         echo = credential.challenge
-        echoed_request, _ = _authenticate_echo(credential, secret_key=self.secret_key)
+        echoed_request, echoed_opaque = _authenticate_echo(
+            credential,
+            secret_key=self.secret_key,
+        )
 
         if echo.realm != self.realm:
             raise InvalidChallengeError(echo.id, "credential realm does not match")
@@ -179,7 +182,8 @@ class Mpp:
         intent_obj = self.method.intents.get(echo.intent)
         if intent_obj is None:
             raise PaymentMethodUnsupportedError(f"{echo.method}/{echo.intent}")
-        return credential, intent_obj, echoed_request
+        challenge = _challenge_from_echo(echo, echoed_request, echoed_opaque)
+        return credential, intent_obj, echoed_request, challenge
 
     async def validate_credential(
         self,
@@ -189,7 +193,7 @@ class Mpp:
         request: dict[str, Any] | None = None,
     ) -> Validation:
         """Validate a bound credential without consuming payment state."""
-        prepared, intent_obj, echoed_request = self._prepare_credential(
+        prepared, intent_obj, echoed_request, _ = self._prepare_credential(
             credential,
             intent=intent,
             request=request,
@@ -208,16 +212,29 @@ class Mpp:
         request: dict[str, Any] | None = None,
     ) -> Receipt:
         """Revalidate and perform a bound credential's terminal operation."""
-        prepared, intent_obj, echoed_request = self._prepare_credential(
+        prepared, intent_obj, echoed_request, challenge = self._prepare_credential(
             credential,
             intent=intent,
             request=request,
         )
-        return await broadcast_intent_credential(
-            intent=intent_obj,
-            credential=prepared,
-            request=echoed_request,
-        )
+        context = {
+            "challenge": challenge,
+            "credential": prepared,
+            "intent": intent_obj.name,
+            "method": self.method.name,
+            "request": echoed_request,
+        }
+        try:
+            receipt = await broadcast_intent_credential(
+                intent=intent_obj,
+                credential=prepared,
+                request=echoed_request,
+            )
+        except Exception as error:
+            await self._events.emit(PAYMENT_FAILED, {**context, "error": error})
+            raise
+        await self._events.emit(PAYMENT_SUCCESS, {**context, "receipt": receipt})
+        return receipt
 
     async def verify_credential(
         self,

--- a/src/mpp/server/verify.py
+++ b/src/mpp/server/verify.py
@@ -20,6 +20,7 @@ from mpp.errors import (
     MalformedCredentialError,
     PaymentError,
     PaymentExpiredError,
+    PaymentOutcomeUnknownError,
 )
 from mpp.events import CHALLENGE_CREATED, PAYMENT_FAILED, PAYMENT_SUCCESS, EventDispatcher
 from mpp.server.intent import broadcast_credential
@@ -208,6 +209,9 @@ async def verify_or_challenge(
             credential=credential,
             request=request,
         )
+    except PaymentOutcomeUnknownError as error:
+        await emit_failure(error, submitted_challenge, credential)
+        raise
     except PaymentError as error:
         error.retry_challenge = await new_challenge()
         await emit_failure(error, submitted_challenge, credential)

--- a/src/mpp/server/verify.py
+++ b/src/mpp/server/verify.py
@@ -123,6 +123,14 @@ async def verify_or_challenge(
         # Preserve the existing challenge-on-failure flow while giving hooks a
         # typed reason for why the submitted credential was rejected.
         challenge = await new_challenge()
+        await emit_failure(error, challenge, credential)
+        return challenge
+
+    async def emit_failure(
+        error: Exception,
+        challenge: Challenge,
+        credential: Credential | None = None,
+    ) -> None:
         if events is not None:
             await events.emit(
                 PAYMENT_FAILED,
@@ -135,7 +143,6 @@ async def verify_or_challenge(
                     "request": request,
                 },
             )
-        return challenge
 
     if authorization is None:
         return await new_challenge()
@@ -194,6 +201,7 @@ async def verify_or_challenge(
     if expires_dt < datetime.now(UTC):
         return await fail(PaymentExpiredError(echo.expires), credential)
 
+    submitted_challenge = _challenge_from_echo(echo, echo_request, echo_opaque)
     try:
         receipt = await broadcast_credential(
             intent=intent,
@@ -201,28 +209,18 @@ async def verify_or_challenge(
             request=request,
         )
     except PaymentError as error:
-        error.retry_challenge = await fail(error, credential)
+        error.retry_challenge = await new_challenge()
+        await emit_failure(error, submitted_challenge, credential)
         raise
     except Exception as error:
-        if events is not None:
-            await events.emit(
-                PAYMENT_FAILED,
-                {
-                    "challenge": _challenge_from_echo(echo, echo_request, echo_opaque),
-                    "credential": credential,
-                    "error": error,
-                    "intent": intent.name,
-                    "method": method_name,
-                    "request": request,
-                },
-            )
+        await emit_failure(error, submitted_challenge, credential)
         raise
 
     if events is not None:
         await events.emit(
             PAYMENT_SUCCESS,
             {
-                "challenge": _challenge_from_echo(echo, echo_request, echo_opaque),
+                "challenge": submitted_challenge,
                 "credential": credential,
                 "intent": intent.name,
                 "method": method_name,

--- a/src/mpp/server/verify.py
+++ b/src/mpp/server/verify.py
@@ -27,13 +27,13 @@ from mpp.server.intent import broadcast_credential
 DEFAULT_EXPIRES_MINUTES = 5
 
 if TYPE_CHECKING:
-    from mpp.server.intent import Intent
+    from mpp.server.intent import Intent, SplitIntent
 
 
 async def verify_or_challenge(
     *,
     authorization: str | None,
-    intent: Intent,
+    intent: Intent | SplitIntent,
     request: dict[str, Any],
     realm: str,
     secret_key: str,

--- a/src/mpp/server/verify.py
+++ b/src/mpp/server/verify.py
@@ -27,13 +27,13 @@ from mpp.server.intent import broadcast_credential
 DEFAULT_EXPIRES_MINUTES = 5
 
 if TYPE_CHECKING:
-    from mpp.server.intent import Intent, SplitIntent
+    from mpp.server.intent import Intent, VerifiableIntent
 
 
 async def verify_or_challenge(
     *,
     authorization: str | None,
-    intent: Intent | SplitIntent,
+    intent: Intent | VerifiableIntent,
     request: dict[str, Any],
     realm: str,
     secret_key: str,

--- a/src/mpp/server/verify.py
+++ b/src/mpp/server/verify.py
@@ -21,6 +21,7 @@ from mpp.errors import (
     PaymentExpiredError,
 )
 from mpp.events import CHALLENGE_CREATED, PAYMENT_FAILED, PAYMENT_SUCCESS, EventDispatcher
+from mpp.server.intent import broadcast_credential
 
 DEFAULT_EXPIRES_MINUTES = 5
 
@@ -210,7 +211,11 @@ async def verify_or_challenge(
         return await fail(PaymentExpiredError(echo.expires), credential)
 
     try:
-        receipt: Receipt = await intent.verify(credential, request)
+        receipt = await broadcast_credential(
+            intent=intent,
+            credential=credential,
+            request=request,
+        )
     except Exception as error:
         if events is not None:
             await events.emit(

--- a/src/mpp/server/verify.py
+++ b/src/mpp/server/verify.py
@@ -152,26 +152,9 @@ async def verify_or_challenge(
     # echoed parameters and compare to the credential's challenge ID.
     echo = credential.challenge
     try:
-        echo_request = _b64_decode(echo.request) if echo.request else {}
-        echo_opaque = _b64_decode(echo.opaque) if echo.opaque else None
-    except ParseError as error:
-        return await fail(MalformedCredentialError(str(error)), credential)
-
-    expected_id = generate_challenge_id(
-        secret_key=secret_key,
-        realm=echo.realm,
-        method=echo.method,
-        intent=echo.intent,
-        request=echo_request,
-        expires=echo.expires,
-        digest=echo.digest,
-        opaque=echo_opaque,
-    )
-    if not _constant_time_equal(echo.id, expected_id):
-        return await fail(
-            InvalidChallengeError(echo.id, "challenge was not issued by this server"),
-            credential,
-        )
+        echo_request, echo_opaque = _authenticate_echo(credential, secret_key=secret_key)
+    except (MalformedCredentialError, InvalidChallengeError) as error:
+        return await fail(error, credential)
 
     # Reject credentials minted for a different realm, method, or intent.
     # This still returns a new Challenge; the only new behavior is the
@@ -245,6 +228,45 @@ async def verify_or_challenge(
         )
 
     return (credential, receipt)
+
+
+def _authenticate_echo(
+    credential: Credential,
+    *,
+    secret_key: str,
+) -> tuple[dict[str, Any], dict[str, Any] | None]:
+    """Authenticate a credential's echoed challenge against the server secret.
+
+    Decodes the echoed request/opaque, recomputes the HMAC-bound challenge ID,
+    and compares it in constant time.
+
+    Returns:
+        The decoded (request, opaque) echoed by the credential.
+
+    Raises:
+        MalformedCredentialError: If the echoed parameters cannot be decoded.
+        InvalidChallengeError: If the challenge ID was not issued by this server.
+    """
+    echo = credential.challenge
+    try:
+        echo_request = _b64_decode(echo.request) if echo.request else {}
+        echo_opaque = _b64_decode(echo.opaque) if echo.opaque else None
+    except ParseError as error:
+        raise MalformedCredentialError(str(error)) from error
+
+    expected_id = generate_challenge_id(
+        secret_key=secret_key,
+        realm=echo.realm,
+        method=echo.method,
+        intent=echo.intent,
+        request=echo_request,
+        expires=echo.expires,
+        digest=echo.digest,
+        opaque=echo_opaque,
+    )
+    if not _constant_time_equal(echo.id, expected_id):
+        raise InvalidChallengeError(echo.id, "challenge was not issued by this server")
+    return echo_request, echo_opaque
 
 
 def _create_challenge(

--- a/src/mpp/server/verify.py
+++ b/src/mpp/server/verify.py
@@ -18,6 +18,7 @@ from mpp._units import transform_units
 from mpp.errors import (
     InvalidChallengeError,
     MalformedCredentialError,
+    PaymentError,
     PaymentExpiredError,
 )
 from mpp.events import CHALLENGE_CREATED, PAYMENT_FAILED, PAYMENT_SUCCESS, EventDispatcher
@@ -199,6 +200,9 @@ async def verify_or_challenge(
             credential=credential,
             request=request,
         )
+    except PaymentError as error:
+        error.retry_challenge = await fail(error, credential)
+        raise
     except Exception as error:
         if events is not None:
             await events.emit(

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -56,6 +56,7 @@ def make_bound_credential(
     source: str | None = None,
     expires: str | None = None,
     digest: str | None = None,
+    meta: dict[str, str] | None = None,
 ) -> Credential:
     """Create a Credential with an HMAC-bound challenge ID for testing.
 
@@ -74,6 +75,7 @@ def make_bound_credential(
         request=request,
         expires=expires,
         digest=digest,
+        meta=meta,
     )
     echo = challenge.to_echo()
     return Credential(challenge=echo, payload=payload, source=source)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -77,3 +77,30 @@ def make_bound_credential(
     )
     echo = challenge.to_echo()
     return Credential(challenge=echo, payload=payload, source=source)
+
+
+class MockRequest:
+    """Mock request object for testing."""
+
+    def __init__(
+        self,
+        authorization: str | None = None,
+        body: bytes | None = None,
+        path: str | None = None,
+        route: str | None = None,
+        query_string: str | None = None,
+    ) -> None:
+        self.headers = {"authorization": authorization} if authorization else {}
+        self.body = body
+        if path is not None:
+            self.path = path
+        if route is not None:
+            self.route = route
+        if query_string is not None:
+            self.query_string = query_string
+
+
+def challenge_from_402(result: Any) -> Challenge:
+    """Extract the challenge from a 402 response (Starlette or plain-dict form)."""
+    headers = result.headers if hasattr(result, "headers") else result["headers"]
+    return Challenge.from_www_authenticate(headers["WWW-Authenticate"])

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -337,7 +337,7 @@ class TestPaymentTransport:
 
     @pytest.mark.asyncio
     async def test_emits_client_payment_events(self) -> None:
-        """Should emit client payment lifecycle events."""
+        """Should emit challenge, credential, and response events in order."""
         events: list[str] = []
         challenge = Challenge(
             id="test-id",

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -337,7 +337,7 @@ class TestPaymentTransport:
 
     @pytest.mark.asyncio
     async def test_emits_client_payment_events(self) -> None:
-        """Should emit mppx-compatible client payment lifecycle events."""
+        """Should emit client payment lifecycle events."""
         events: list[str] = []
         challenge = Challenge(
             id="test-id",

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -1,0 +1,202 @@
+"""Tests for split credential validation and broadcast."""
+
+from dataclasses import replace
+
+import pytest
+
+from mpp import Challenge, Credential, Receipt
+from mpp.errors import InvalidChallengeError, VerificationFailedError
+from mpp.server import (
+    Intent,
+    Mpp,
+    Validation,
+    broadcast_credential,
+    validate_credential,
+    verify_or_challenge,
+)
+from tests import make_bound_credential, make_credential
+
+
+class SplitCharge:
+    name = "charge"
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    async def validate(self, credential: Credential, request: dict) -> Validation:
+        self.calls.append("validate")
+        return Validation(
+            challenge=credential.challenge,
+            credential=credential,
+            details={"mode": "pull"},
+            intent=self.name,
+            method=credential.challenge.method,
+            request=request,
+            source=credential.source,
+        )
+
+    async def broadcast(self, credential: Credential, request: dict) -> Receipt:
+        self.calls.append("broadcast")
+        return Receipt.success("split-reference")
+
+    async def verify(self, credential: Credential, request: dict) -> Receipt:
+        self.calls.append("verify")
+        return Receipt.success("legacy-reference")
+
+
+class FakeMethod:
+    name = "tempo"
+
+    def __init__(self, charge: SplitCharge) -> None:
+        self.intents: dict[str, Intent] = {"charge": charge}
+
+    async def create_credential(self, challenge: Challenge) -> Credential:  # pragma: no cover
+        raise NotImplementedError
+
+
+@pytest.mark.asyncio
+async def test_validation_is_non_mutating() -> None:
+    intent = SplitCharge()
+    result = await validate_credential(
+        intent=intent,
+        credential=make_credential(payload={}),
+        request={"amount": "1000"},
+    )
+
+    assert result.details == {"mode": "pull"}
+    assert intent.calls == ["validate"]
+
+
+@pytest.mark.asyncio
+async def test_broadcast_revalidates_before_terminal_hook() -> None:
+    intent = SplitCharge()
+    receipt = await broadcast_credential(
+        intent=intent,
+        credential=make_credential(payload={}),
+        request={},
+    )
+
+    assert receipt.reference == "split-reference"
+    assert intent.calls == ["validate", "broadcast"]
+
+
+@pytest.mark.asyncio
+async def test_legacy_intent_falls_back_to_verify() -> None:
+    calls: list[str] = []
+
+    class LegacyCharge:
+        name = "charge"
+
+        async def verify(self, credential: Credential, request: dict) -> Receipt:
+            calls.append("verify")
+            return Receipt.success("legacy-reference")
+
+    legacy = LegacyCharge()
+    with pytest.raises(VerificationFailedError, match="non-mutating"):
+        await validate_credential(
+            intent=legacy,
+            credential=make_credential(payload={}),
+            request={},
+        )
+
+    receipt = await broadcast_credential(
+        intent=legacy,
+        credential=make_credential(payload={}),
+        request={},
+    )
+    assert receipt.reference == "legacy-reference"
+    assert calls == ["verify"]
+
+
+@pytest.mark.asyncio
+async def test_route_uses_split_lifecycle() -> None:
+    intent = SplitCharge()
+    request = {"amount": "1000"}
+    credential = make_bound_credential(
+        payload={},
+        request=request,
+        realm="api.example.com",
+        secret_key="test-secret",
+    )
+
+    result = await verify_or_challenge(
+        authorization=credential.to_authorization(),
+        intent=intent,
+        request=request,
+        realm="api.example.com",
+        secret_key="test-secret",
+    )
+
+    assert isinstance(result, tuple)
+    assert result[1].reference == "split-reference"
+    assert intent.calls == ["validate", "broadcast"]
+
+
+@pytest.mark.asyncio
+async def test_mpp_exposes_bound_lifecycle() -> None:
+    intent = SplitCharge()
+    server = Mpp.create(
+        method=FakeMethod(intent),
+        realm="api.example.com",
+        secret_key="test-secret",
+    )
+    request = {"amount": "1000"}
+    credential = make_bound_credential(
+        payload={},
+        request=request,
+        realm=server.realm,
+        secret_key=server.secret_key,
+    )
+
+    validation = await server.validate_credential(credential.to_authorization(), request=request)
+    receipt = await server.broadcast_credential(credential, intent="charge", request=request)
+    alias_receipt = await server.verify_credential(credential)
+
+    assert validation.request == request
+    assert receipt.reference == "split-reference"
+    assert alias_receipt.reference == "split-reference"
+    assert intent.calls == [
+        "validate",
+        "validate",
+        "broadcast",
+        "validate",
+        "broadcast",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_mpp_rejects_tampered_bound_credential() -> None:
+    intent = SplitCharge()
+    server = Mpp.create(
+        method=FakeMethod(intent),
+        realm="api.example.com",
+        secret_key="test-secret",
+    )
+    credential = make_bound_credential(
+        payload={},
+        request={},
+        realm=server.realm,
+        secret_key=server.secret_key,
+    )
+    credential = replace(
+        credential,
+        challenge=replace(credential.challenge, id="tampered"),
+    )
+
+    with pytest.raises(InvalidChallengeError):
+        await server.validate_credential(credential)
+    assert intent.calls == []
+
+
+@pytest.mark.asyncio
+async def test_invalid_validation_result_is_rejected() -> None:
+    class InvalidSplit(SplitCharge):
+        async def validate(self, credential: Credential, request: dict) -> Validation:
+            return {}  # type: ignore[return-value]
+
+    with pytest.raises(VerificationFailedError, match="invalid validation result"):
+        await validate_credential(
+            intent=InvalidSplit(),
+            credential=make_credential(payload={}),
+            request={},
+        )

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -1,4 +1,4 @@
-"""Tests for split credential validation and broadcast."""
+"""Tests for credential validation and broadcast."""
 
 from dataclasses import replace
 from datetime import UTC, datetime, timedelta
@@ -17,8 +17,8 @@ from mpp.errors import (
 from mpp.server import (
     Intent,
     Mpp,
-    SplitIntent,
     Validation,
+    VerifiableIntent,
     broadcast_credential,
     validate_credential,
     verify_or_challenge,
@@ -26,7 +26,7 @@ from mpp.server import (
 from tests import make_bound_credential, make_credential
 
 
-class SplitCharge:
+class VerifiableCharge:
     name = "charge"
 
     def __init__(self) -> None:
@@ -43,22 +43,22 @@ class SplitCharge:
 
     async def broadcast(self, credential: Credential, request: dict) -> Receipt:
         self.calls.append("broadcast")
-        return Receipt.success("split-reference")
+        return Receipt.success("verifiable-reference")
 
 
 class FakeMethod:
     name = "tempo"
 
-    def __init__(self, charge: SplitCharge) -> None:
-        self.intents: dict[str, Intent | SplitIntent] = {"charge": charge}
+    def __init__(self, charge: VerifiableCharge) -> None:
+        self.intents: dict[str, Intent | VerifiableIntent] = {"charge": charge}
 
     async def create_credential(self, challenge: Challenge) -> Credential:  # pragma: no cover
         raise NotImplementedError
 
 
-def _server(intent: SplitCharge | None = None) -> Mpp:
+def _server(intent: VerifiableCharge | None = None) -> Mpp:
     return Mpp.create(
-        method=FakeMethod(intent or SplitCharge()),
+        method=FakeMethod(intent or VerifiableCharge()),
         realm="api.example.com",
         secret_key="test-secret",
     )
@@ -72,7 +72,7 @@ def _bound(request: dict[str, Any] | None = None, **kwargs: Any) -> Credential:
 
 @pytest.mark.asyncio
 async def test_validation_is_non_mutating() -> None:
-    intent = SplitCharge()
+    intent = VerifiableCharge()
     result = await validate_credential(
         intent=intent,
         credential=make_credential(payload={}),
@@ -85,14 +85,14 @@ async def test_validation_is_non_mutating() -> None:
 
 @pytest.mark.asyncio
 async def test_broadcast_revalidates_before_terminal_hook() -> None:
-    intent = SplitCharge()
+    intent = VerifiableCharge()
     receipt = await broadcast_credential(
         intent=intent,
         credential=make_credential(payload={}),
         request={},
     )
 
-    assert receipt.reference == "split-reference"
+    assert receipt.reference == "verifiable-reference"
     assert intent.calls == ["validate", "broadcast"]
 
 
@@ -125,8 +125,8 @@ async def test_legacy_intent_falls_back_to_verify() -> None:
 
 
 @pytest.mark.asyncio
-async def test_route_uses_split_lifecycle() -> None:
-    intent = SplitCharge()
+async def test_route_uses_verifiable_lifecycle() -> None:
+    intent = VerifiableCharge()
     request = {"amount": "1000"}
     credential = _bound(request)
 
@@ -139,13 +139,13 @@ async def test_route_uses_split_lifecycle() -> None:
     )
 
     assert isinstance(result, tuple)
-    assert result[1].reference == "split-reference"
+    assert result[1].reference == "verifiable-reference"
     assert intent.calls == ["validate", "broadcast"]
 
 
 @pytest.mark.asyncio
 async def test_mpp_exposes_bound_lifecycle() -> None:
-    intent = SplitCharge()
+    intent = VerifiableCharge()
     server = _server(intent)
     request = {"amount": "1000"}
     credential = _bound(request)
@@ -154,13 +154,13 @@ async def test_mpp_exposes_bound_lifecycle() -> None:
     receipt = await server.broadcast_credential(credential, intent="charge", request=request)
 
     assert validation.request == request
-    assert receipt.reference == "split-reference"
+    assert receipt.reference == "verifiable-reference"
     assert intent.calls == ["validate", "validate", "broadcast"]
 
 
 @pytest.mark.asyncio
 async def test_bound_broadcast_emits_success_but_validation_is_advisory() -> None:
-    intent = SplitCharge()
+    intent = VerifiableCharge()
     server = _server(intent)
     events: list[tuple[str, dict[str, Any]]] = []
     server.on_payment_success(lambda payload: events.append(("success", payload)))
@@ -186,7 +186,7 @@ async def test_bound_broadcast_emits_success_but_validation_is_advisory() -> Non
 
 @pytest.mark.asyncio
 async def test_bound_broadcast_emits_failures() -> None:
-    class RejectingCharge(SplitCharge):
+    class RejectingCharge(VerifiableCharge):
         async def validate(self, credential: Credential, request: dict) -> Validation:
             self.calls.append("validate")
             raise VerificationFailedError("risk denied")
@@ -228,7 +228,7 @@ async def test_invalid_intent_has_a_typed_failure() -> None:
 @pytest.mark.asyncio
 @pytest.mark.parametrize("field", ["id", "realm", "method", "request", "expires"])
 async def test_mpp_rejects_tampered_bound_credential(field: str) -> None:
-    intent = SplitCharge()
+    intent = VerifiableCharge()
     credential = _bound()
     credential = replace(
         credential,
@@ -302,13 +302,13 @@ async def test_mpp_rejects_missing_or_invalid_expiry(expires: str | None) -> Non
 
 @pytest.mark.asyncio
 async def test_invalid_validation_result_is_rejected() -> None:
-    class InvalidSplit(SplitCharge):
+    class InvalidVerifiable(VerifiableCharge):
         async def validate(self, credential: Credential, request: dict) -> Validation:
             return {}  # type: ignore[return-value]
 
     with pytest.raises(VerificationFailedError, match="invalid validation result"):
         await validate_credential(
-            intent=InvalidSplit(),
+            intent=InvalidVerifiable(),
             credential=make_credential(payload={}),
             request={},
         )

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -17,6 +17,7 @@ from mpp.errors import (
 from mpp.server import (
     Intent,
     Mpp,
+    SplitIntent,
     Validation,
     broadcast_credential,
     validate_credential,
@@ -44,16 +45,12 @@ class SplitCharge:
         self.calls.append("broadcast")
         return Receipt.success("split-reference")
 
-    async def verify(self, credential: Credential, request: dict) -> Receipt:
-        self.calls.append("verify")
-        return Receipt.success("legacy-reference")
-
 
 class FakeMethod:
     name = "tempo"
 
     def __init__(self, charge: SplitCharge) -> None:
-        self.intents: dict[str, Intent] = {"charge": charge}
+        self.intents: dict[str, Intent | SplitIntent] = {"charge": charge}
 
     async def create_credential(self, challenge: Challenge) -> Credential:  # pragma: no cover
         raise NotImplementedError
@@ -155,18 +152,10 @@ async def test_mpp_exposes_bound_lifecycle() -> None:
 
     validation = await server.validate_credential(credential.to_authorization(), request=request)
     receipt = await server.broadcast_credential(credential, intent="charge", request=request)
-    alias_receipt = await server.verify_credential(credential)
 
     assert validation.request == request
     assert receipt.reference == "split-reference"
-    assert alias_receipt.reference == "split-reference"
-    assert intent.calls == [
-        "validate",
-        "validate",
-        "broadcast",
-        "validate",
-        "broadcast",
-    ]
+    assert intent.calls == ["validate", "validate", "broadcast"]
 
 
 @pytest.mark.asyncio
@@ -196,7 +185,7 @@ async def test_bound_broadcast_emits_success_but_validation_is_advisory() -> Non
 
 
 @pytest.mark.asyncio
-async def test_bound_broadcast_and_alias_emit_failures() -> None:
+async def test_bound_broadcast_emits_failures() -> None:
     class RejectingCharge(SplitCharge):
         async def validate(self, credential: Credential, request: dict) -> Validation:
             self.calls.append("validate")
@@ -211,10 +200,8 @@ async def test_bound_broadcast_and_alias_emit_failures() -> None:
 
     with pytest.raises(VerificationFailedError, match="risk denied"):
         await server.broadcast_credential(credential)
-    with pytest.raises(VerificationFailedError, match="risk denied"):
-        await server.verify_credential(credential)
 
-    assert len(failures) == 2
+    assert len(failures) == 1
     for payload in failures:
         assert payload["challenge"].id == credential.challenge.id
         assert payload["credential"] == credential
@@ -222,7 +209,20 @@ async def test_bound_broadcast_and_alias_emit_failures() -> None:
         assert payload["method"] == "tempo"
         assert isinstance(payload["error"], VerificationFailedError)
         assert payload["request"] == request
-    assert intent.calls == ["validate", "validate"]
+    assert intent.calls == ["validate"]
+
+
+@pytest.mark.asyncio
+async def test_invalid_intent_has_a_typed_failure() -> None:
+    class InvalidCharge:
+        name = "charge"
+
+    with pytest.raises(VerificationFailedError, match="verification or broadcast"):
+        await broadcast_credential(
+            intent=InvalidCharge(),  # type: ignore[arg-type]
+            credential=make_credential(payload={}),
+            request={},
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import pytest
 
-from mpp import Challenge, Credential, Receipt
+from mpp import Challenge, Credential, Receipt, _body_digest
 from mpp.errors import (
     InvalidChallengeError,
     MalformedCredentialError,
@@ -291,6 +291,87 @@ async def test_mpp_rejects_request_mismatch() -> None:
 
     with pytest.raises(InvalidChallengeError, match="request does not match"):
         await _server().validate_credential(credential, request={"amount": "2000"})
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ["validate_credential", "broadcast_credential"])
+async def test_mpp_contextless_lifecycle_uses_authenticated_echo(operation: str) -> None:
+    body = {"resource": "bound"}
+    credential = _bound(
+        request={"amount": "1000"},
+        digest=_body_digest.compute(body),
+        meta={"route": "bound"},
+    )
+
+    result = await getattr(_server(), operation)(credential)
+
+    if operation == "validate_credential":
+        assert result.request == {"amount": "1000"}
+    else:
+        assert result.reference == "verifiable-reference"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ["validate_credential", "broadcast_credential"])
+async def test_mpp_accepts_matching_context_bindings(operation: str) -> None:
+    request = {"amount": "1000"}
+    meta = {"route": "bound"}
+    body = {"resource": "bound"}
+    credential = _bound(request, digest=_body_digest.compute(body), meta=meta)
+
+    await getattr(_server(), operation)(credential, request=request, meta=meta, body=body)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ["validate_credential", "broadcast_credential"])
+@pytest.mark.parametrize(
+    ("meta", "body", "reason"),
+    [
+        ({"route": "other"}, {"resource": "bound"}, "opaque"),
+        ({"route": "bound"}, {"resource": "other"}, "body digest mismatch"),
+    ],
+)
+async def test_mpp_rejects_context_binding_mismatch(
+    operation: str,
+    meta: dict[str, str],
+    body: dict[str, Any],
+    reason: str,
+) -> None:
+    request = {"amount": "1000"}
+    expected_meta = {"route": "bound"}
+    expected_body = {"resource": "bound"}
+    credential = _bound(
+        request,
+        digest=_body_digest.compute(expected_body),
+        meta=expected_meta,
+    )
+    intent = VerifiableCharge()
+
+    with pytest.raises(InvalidChallengeError, match=reason):
+        await getattr(_server(intent), operation)(
+            credential,
+            request=request,
+            meta=meta,
+            body=body,
+        )
+    assert intent.calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ["validate_credential", "broadcast_credential"])
+async def test_mpp_rejects_missing_context_bindings(operation: str) -> None:
+    request = {"amount": "1000"}
+    body = {"resource": "bound"}
+    credential = _bound(
+        request,
+        digest=_body_digest.compute(body),
+        meta={"route": "bound"},
+    )
+    intent = VerifiableCharge()
+
+    with pytest.raises(InvalidChallengeError, match="opaque"):
+        await getattr(_server(intent), operation)(credential, request=request)
+    assert intent.calls == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -213,6 +213,31 @@ async def test_bound_broadcast_emits_failures() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("credential", "route_request"),
+    [
+        (_bound(realm="other.example.com"), None),
+        (_bound({"amount": "1000"}), {"amount": "2000"}),
+    ],
+)
+async def test_bound_broadcast_emits_preparation_failures(
+    credential: Credential,
+    route_request: dict[str, Any] | None,
+) -> None:
+    server = _server()
+    failures: list[dict[str, Any]] = []
+    server.on_payment_failed(failures.append)
+
+    with pytest.raises(InvalidChallengeError):
+        await server.broadcast_credential(credential, request=route_request)
+
+    assert len(failures) == 1
+    assert failures[0]["challenge"].id == credential.challenge.id
+    assert failures[0]["credential"] == credential
+    assert isinstance(failures[0]["error"], InvalidChallengeError)
+
+
+@pytest.mark.asyncio
 async def test_invalid_intent_has_a_typed_failure() -> None:
     class InvalidCharge:
         name = "charge"

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -1,12 +1,19 @@
 """Tests for split credential validation and broadcast."""
 
 from dataclasses import replace
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import pytest
 
 from mpp import Challenge, Credential, Receipt
-from mpp.errors import InvalidChallengeError, VerificationFailedError
+from mpp.errors import (
+    InvalidChallengeError,
+    MalformedCredentialError,
+    PaymentExpiredError,
+    PaymentMethodUnsupportedError,
+    VerificationFailedError,
+)
 from mpp.server import (
     Intent,
     Mpp,
@@ -50,6 +57,20 @@ class FakeMethod:
 
     async def create_credential(self, challenge: Challenge) -> Credential:  # pragma: no cover
         raise NotImplementedError
+
+
+def _server(intent: SplitCharge | None = None) -> Mpp:
+    return Mpp.create(
+        method=FakeMethod(intent or SplitCharge()),
+        realm="api.example.com",
+        secret_key="test-secret",
+    )
+
+
+def _bound(request: dict[str, Any] | None = None, **kwargs: Any) -> Credential:
+    kwargs.setdefault("realm", "api.example.com")
+    kwargs.setdefault("secret_key", "test-secret")
+    return make_bound_credential(payload={}, request=request or {}, **kwargs)
 
 
 @pytest.mark.asyncio
@@ -237,27 +258,78 @@ async def test_bound_broadcast_and_alias_emit_failures() -> None:
 
 
 @pytest.mark.asyncio
-async def test_mpp_rejects_tampered_bound_credential() -> None:
+@pytest.mark.parametrize("field", ["id", "realm", "method", "request", "expires"])
+async def test_mpp_rejects_tampered_bound_credential(field: str) -> None:
     intent = SplitCharge()
-    server = Mpp.create(
-        method=FakeMethod(intent),
-        realm="api.example.com",
-        secret_key="test-secret",
-    )
-    credential = make_bound_credential(
-        payload={},
-        request={},
-        realm=server.realm,
-        secret_key=server.secret_key,
-    )
+    credential = _bound()
     credential = replace(
         credential,
-        challenge=replace(credential.challenge, id="tampered"),
+        challenge=replace(credential.challenge, **{field: "tampered"}),
     )
 
-    with pytest.raises(InvalidChallengeError):
-        await server.validate_credential(credential)
+    with pytest.raises((InvalidChallengeError, MalformedCredentialError)):
+        await _server(intent).validate_credential(credential)
     assert intent.calls == []
+
+
+@pytest.mark.asyncio
+async def test_mpp_rejects_credential_bound_to_other_realm_or_method() -> None:
+    server = _server()
+
+    with pytest.raises(InvalidChallengeError, match="realm does not match"):
+        await server.validate_credential(_bound(realm="other.example.com"))
+    with pytest.raises(PaymentMethodUnsupportedError):
+        await server.validate_credential(_bound(method="stripe"))
+
+
+@pytest.mark.asyncio
+async def test_mpp_rejects_intent_mismatches() -> None:
+    server = _server()
+
+    with pytest.raises(InvalidChallengeError, match="intent does not match"):
+        await server.validate_credential(_bound(), intent="refund")
+    with pytest.raises(PaymentMethodUnsupportedError):
+        await server.validate_credential(_bound(intent="refund"))
+
+
+@pytest.mark.asyncio
+async def test_mpp_rejects_request_mismatch() -> None:
+    credential = _bound(request={"amount": "1000"})
+
+    with pytest.raises(InvalidChallengeError, match="request does not match"):
+        await _server().validate_credential(credential, request={"amount": "2000"})
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("value", ["not-a-credential", "Payment ???"])
+async def test_mpp_rejects_malformed_serialized_credential(value: str) -> None:
+    with pytest.raises(MalformedCredentialError):
+        await _server().validate_credential(value)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "expires",
+    [
+        None,
+        "not-a-date",
+        (datetime.now() + timedelta(hours=1)).isoformat(),  # naive: no timezone
+        (datetime.now(UTC) - timedelta(hours=1)).isoformat(),
+    ],
+)
+async def test_mpp_rejects_missing_or_invalid_expiry(expires: str | None) -> None:
+    challenge = Challenge.create(
+        secret_key="test-secret",
+        realm="api.example.com",
+        method="tempo",
+        intent="charge",
+        request={},
+        expires=expires,
+    )
+    credential = Credential(challenge=challenge.to_echo(), payload={})
+
+    with pytest.raises(PaymentExpiredError):
+        await _server().validate_credential(credential)
 
 
 @pytest.mark.asyncio

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -131,12 +131,7 @@ async def test_legacy_intent_falls_back_to_verify() -> None:
 async def test_route_uses_split_lifecycle() -> None:
     intent = SplitCharge()
     request = {"amount": "1000"}
-    credential = make_bound_credential(
-        payload={},
-        request=request,
-        realm="api.example.com",
-        secret_key="test-secret",
-    )
+    credential = _bound(request)
 
     result = await verify_or_challenge(
         authorization=credential.to_authorization(),
@@ -154,18 +149,9 @@ async def test_route_uses_split_lifecycle() -> None:
 @pytest.mark.asyncio
 async def test_mpp_exposes_bound_lifecycle() -> None:
     intent = SplitCharge()
-    server = Mpp.create(
-        method=FakeMethod(intent),
-        realm="api.example.com",
-        secret_key="test-secret",
-    )
+    server = _server(intent)
     request = {"amount": "1000"}
-    credential = make_bound_credential(
-        payload={},
-        request=request,
-        realm=server.realm,
-        secret_key=server.secret_key,
-    )
+    credential = _bound(request)
 
     validation = await server.validate_credential(credential.to_authorization(), request=request)
     receipt = await server.broadcast_credential(credential, intent="charge", request=request)
@@ -186,21 +172,12 @@ async def test_mpp_exposes_bound_lifecycle() -> None:
 @pytest.mark.asyncio
 async def test_bound_broadcast_emits_success_but_validation_is_advisory() -> None:
     intent = SplitCharge()
-    server = Mpp.create(
-        method=FakeMethod(intent),
-        realm="api.example.com",
-        secret_key="test-secret",
-    )
+    server = _server(intent)
     events: list[tuple[str, dict[str, Any]]] = []
     server.on_payment_success(lambda payload: events.append(("success", payload)))
     server.on_payment_failed(lambda payload: events.append(("failed", payload)))
     request = {"amount": "1000"}
-    credential = make_bound_credential(
-        payload={},
-        request=request,
-        realm=server.realm,
-        secret_key=server.secret_key,
-    )
+    credential = _bound(request)
 
     await server.validate_credential(credential)
     assert events == []
@@ -226,20 +203,11 @@ async def test_bound_broadcast_and_alias_emit_failures() -> None:
             raise VerificationFailedError("risk denied")
 
     intent = RejectingCharge()
-    server = Mpp.create(
-        method=FakeMethod(intent),
-        realm="api.example.com",
-        secret_key="test-secret",
-    )
+    server = _server(intent)
     failures: list[dict[str, Any]] = []
     server.on_payment_failed(failures.append)
     request = {"amount": "1000"}
-    credential = make_bound_credential(
-        payload={},
-        request=request,
-        realm=server.realm,
-        secret_key=server.secret_key,
-    )
+    credential = _bound(request)
 
     with pytest.raises(VerificationFailedError, match="risk denied"):
         await server.broadcast_credential(credential)

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -26,13 +26,10 @@ class SplitCharge:
     async def validate(self, credential: Credential, request: dict) -> Validation:
         self.calls.append("validate")
         return Validation(
-            challenge=credential.challenge,
             credential=credential,
             details={"mode": "pull"},
             intent=self.name,
-            method=credential.challenge.method,
             request=request,
-            source=credential.source,
         )
 
     async def broadcast(self, credential: Credential, request: dict) -> Receipt:

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -1,6 +1,7 @@
 """Tests for split credential validation and broadcast."""
 
 from dataclasses import replace
+from typing import Any
 
 import pytest
 
@@ -159,6 +160,80 @@ async def test_mpp_exposes_bound_lifecycle() -> None:
         "validate",
         "broadcast",
     ]
+
+
+@pytest.mark.asyncio
+async def test_bound_broadcast_emits_success_but_validation_is_advisory() -> None:
+    intent = SplitCharge()
+    server = Mpp.create(
+        method=FakeMethod(intent),
+        realm="api.example.com",
+        secret_key="test-secret",
+    )
+    events: list[tuple[str, dict[str, Any]]] = []
+    server.on_payment_success(lambda payload: events.append(("success", payload)))
+    server.on_payment_failed(lambda payload: events.append(("failed", payload)))
+    request = {"amount": "1000"}
+    credential = make_bound_credential(
+        payload={},
+        request=request,
+        realm=server.realm,
+        secret_key=server.secret_key,
+    )
+
+    await server.validate_credential(credential)
+    assert events == []
+
+    receipt = await server.broadcast_credential(credential)
+
+    assert len(events) == 1
+    name, payload = events[0]
+    assert name == "success"
+    assert payload["challenge"].id == credential.challenge.id
+    assert payload["credential"] == credential
+    assert payload["intent"] == "charge"
+    assert payload["method"] == "tempo"
+    assert payload["receipt"] == receipt
+    assert payload["request"] == request
+
+
+@pytest.mark.asyncio
+async def test_bound_broadcast_and_alias_emit_failures() -> None:
+    class RejectingCharge(SplitCharge):
+        async def validate(self, credential: Credential, request: dict) -> Validation:
+            self.calls.append("validate")
+            raise VerificationFailedError("risk denied")
+
+    intent = RejectingCharge()
+    server = Mpp.create(
+        method=FakeMethod(intent),
+        realm="api.example.com",
+        secret_key="test-secret",
+    )
+    failures: list[dict[str, Any]] = []
+    server.on_payment_failed(failures.append)
+    request = {"amount": "1000"}
+    credential = make_bound_credential(
+        payload={},
+        request=request,
+        realm=server.realm,
+        secret_key=server.secret_key,
+    )
+
+    with pytest.raises(VerificationFailedError, match="risk denied"):
+        await server.broadcast_credential(credential)
+    with pytest.raises(VerificationFailedError, match="risk denied"):
+        await server.verify_credential(credential)
+
+    assert len(failures) == 2
+    for payload in failures:
+        assert payload["challenge"].id == credential.challenge.id
+        assert payload["credential"] == credential
+        assert payload["intent"] == "charge"
+        assert payload["method"] == "tempo"
+        assert isinstance(payload["error"], VerificationFailedError)
+        assert payload["request"] == request
+    assert intent.calls == ["validate", "validate"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -7,6 +7,7 @@ from datetime import UTC, datetime, timedelta
 import pytest
 
 from mpp import Challenge, Credential, Receipt, generate_challenge_id
+from mpp.errors import VerificationFailedError
 from mpp.extensions.mcp import (
     CODE_MALFORMED_CREDENTIAL,
     CODE_PAYMENT_REQUIRED,
@@ -734,6 +735,46 @@ class TestVerifyOrChallenge:
             )
 
         assert exc_info.value.detail == "Payment failed"
+
+    async def test_maps_split_payment_error_to_mcp_verification_error(self) -> None:
+        class SplitIntent:
+            name = "charge"
+
+            async def validate(self, credential: object, request: dict) -> object:
+                raise VerificationFailedError(
+                    details={"code": "insufficient_funds"},
+                )
+
+            async def broadcast(self, credential: object, request: dict) -> Receipt:
+                raise AssertionError("broadcast must not run after failed validation")
+
+            async def verify(self, credential: object, request: dict) -> Receipt:
+                raise AssertionError("split intent must not use the legacy hook")
+
+        challenge = _make_bound_mcp_challenge(request={"amount": "1000"})
+        mcp_credential = MCPCredential(
+            challenge=challenge,
+            payload={"type": "transaction", "signature": "0x1234"},
+        )
+
+        with pytest.raises(PaymentVerificationError) as exc_info:
+            await verify_or_challenge(
+                meta=mcp_credential.to_meta(),
+                intent=SplitIntent(),  # type: ignore[arg-type]
+                request={"amount": "1000"},
+                realm="api.example.com",
+                secret_key=MCP_TEST_SECRET,
+            )
+
+        error = exc_info.value.to_jsonrpc_error()
+        retry = error["data"]["challenges"][0]
+        assert error["code"] == CODE_PAYMENT_VERIFICATION_FAILED
+        assert error["data"]["httpStatus"] == 402
+        assert retry["id"] != challenge.id
+        assert error["data"]["failure"] == {
+            "reason": "verification-failed",
+            "detail": "Payment verification failed.",
+        }
 
     async def test_rejects_credential_with_wrong_realm(self) -> None:
         """Credential issued for realm-A should be rejected at realm-B."""

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -748,9 +748,6 @@ class TestVerifyOrChallenge:
             async def broadcast(self, credential: object, request: dict) -> Receipt:
                 raise AssertionError("broadcast must not run after failed validation")
 
-            async def verify(self, credential: object, request: dict) -> Receipt:
-                raise AssertionError("split intent must not use the legacy hook")
-
         challenge = _make_bound_mcp_challenge(request={"amount": "1000"})
         mcp_credential = MCPCredential(
             challenge=challenge,

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -774,6 +774,7 @@ class TestVerifyOrChallenge:
         assert error["data"]["failure"] == {
             "reason": "verification-failed",
             "detail": "Payment verification failed.",
+            "details": {"code": "insufficient_funds"},
         }
 
     async def test_rejects_credential_with_wrong_realm(self) -> None:

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -7,7 +7,7 @@ from datetime import UTC, datetime, timedelta
 import pytest
 
 from mpp import Challenge, Credential, Receipt, generate_challenge_id
-from mpp.errors import VerificationFailedError
+from mpp.errors import PaymentOutcomeUnknownError, VerificationFailedError
 from mpp.extensions.mcp import (
     CODE_MALFORMED_CREDENTIAL,
     CODE_PAYMENT_REQUIRED,
@@ -25,6 +25,7 @@ from mpp.extensions.mcp import (
     payment_capabilities,
     verify_or_challenge,
 )
+from mpp.server import Validation
 from tests import TEST_SECRET
 
 MCP_TEST_SECRET = TEST_SECRET
@@ -773,6 +774,36 @@ class TestVerifyOrChallenge:
             "detail": "Payment verification failed.",
             "details": {"code": "insufficient_funds"},
         }
+
+    async def test_preserves_unknown_payment_outcome_without_fresh_challenge(self) -> None:
+        class VerifiableIntent:
+            name = "charge"
+
+            async def validate(self, credential: Credential, request: dict) -> object:
+                return Validation(
+                    credential=credential,
+                    details={},
+                    intent=self.name,
+                    request=request,
+                )
+
+            async def broadcast(self, credential: Credential, request: dict) -> Receipt:
+                raise PaymentOutcomeUnknownError(credential.challenge, RuntimeError("lost"))
+
+        challenge = _make_bound_mcp_challenge(request={"amount": "1000"})
+        mcp_credential = MCPCredential(
+            challenge=challenge,
+            payload={"type": "transaction", "signature": "0x1234"},
+        )
+
+        with pytest.raises(PaymentOutcomeUnknownError):
+            await verify_or_challenge(
+                meta=mcp_credential.to_meta(),
+                intent=VerifiableIntent(),  # type: ignore[arg-type]
+                request={"amount": "1000"},
+                realm="api.example.com",
+                secret_key=MCP_TEST_SECRET,
+            )
 
     async def test_rejects_credential_with_wrong_realm(self) -> None:
         """Credential issued for realm-A should be rejected at realm-B."""

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -736,8 +736,8 @@ class TestVerifyOrChallenge:
 
         assert exc_info.value.detail == "Payment failed"
 
-    async def test_maps_split_payment_error_to_mcp_verification_error(self) -> None:
-        class SplitIntent:
+    async def test_maps_verifiable_payment_error_to_mcp_verification_error(self) -> None:
+        class VerifiableIntent:
             name = "charge"
 
             async def validate(self, credential: object, request: dict) -> object:
@@ -757,7 +757,7 @@ class TestVerifyOrChallenge:
         with pytest.raises(PaymentVerificationError) as exc_info:
             await verify_or_challenge(
                 meta=mcp_credential.to_meta(),
-                intent=SplitIntent(),  # type: ignore[arg-type]
+                intent=VerifiableIntent(),  # type: ignore[arg-type]
                 request={"amount": "1000"},
                 realm="api.example.com",
                 secret_key=MCP_TEST_SECRET,

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -6,7 +6,7 @@ from mpp import BodyDigest, Challenge, Credential, Receipt
 from mpp.events import EventDispatcher
 from mpp.server import Mpp, intent, pay, verify_or_challenge
 from mpp.server.intent import VerificationError
-from tests import make_bound_credential, make_credential
+from tests import MockRequest, challenge_from_402, make_bound_credential, make_credential
 
 try:
     from starlette.responses import Response as StarletteResponse
@@ -633,37 +633,11 @@ class TestCrossEndpointReplay:
         assert result.intent == "charge"
 
 
-class MockRequest:
-    """Mock request object for testing."""
-
-    def __init__(
-        self,
-        authorization: str | None = None,
-        body: bytes | None = None,
-        path: str | None = None,
-        route: str | None = None,
-        query_string: str | None = None,
-    ) -> None:
-        self.headers = {"authorization": authorization} if authorization else {}
-        self.body = body
-        if path is not None:
-            self.path = path
-        if route is not None:
-            self.route = route
-        if query_string is not None:
-            self.query_string = query_string
-
-
 class DjangoStyleRequest:
     """Mock Django-style request object for testing."""
 
     def __init__(self, authorization: str | None = None) -> None:
         self.META = {"HTTP_AUTHORIZATION": authorization} if authorization else {}
-
-
-def challenge_from_402(result) -> Challenge:
-    headers = result.headers if HAS_STARLETTE else result["headers"]
-    return Challenge.from_www_authenticate(headers["WWW-Authenticate"])
 
 
 class TestWrapPaymentHandler:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -797,7 +797,7 @@ class TestPay:
             challenge = Challenge.from_www_authenticate(
                 challenge_response.headers["WWW-Authenticate"]
             )
-            assert challenge.request["_mpp_scope"] == {
+            assert challenge.request["_mppx_scope"] == {
                 "route": "/paid/{id}",
                 "resource": "/paid/one",
                 "query": "view=full",
@@ -835,7 +835,7 @@ class TestPay:
             MockRequest(path="/paid/one", route="/paid/{id}", query_string="view=full")
         )
         challenge = challenge_from_402(challenge_result)
-        assert challenge.request["_mpp_scope"] == {
+        assert challenge.request["_mppx_scope"] == {
             "route": "/paid/{id}",
             "resource": "/paid/one",
             "query": "view=full",
@@ -1154,7 +1154,7 @@ class TestMppPay:
 
     @pytest.mark.asyncio
     async def test_exposes_server_event_helpers(self) -> None:
-        """Mpp should expose server event helper methods."""
+        """Mpp should expose challenge and payment event helpers."""
         events: list[str] = []
 
         @intent(name="charge")
@@ -1246,7 +1246,7 @@ class TestMppPay:
             MockRequest(path="/paid/one", route="/paid/{id}", query_string="view=full")
         )
         challenge = challenge_from_402(challenge_result)
-        assert challenge.request["_mpp_scope"] == {
+        assert challenge.request["_mppx_scope"] == {
             "route": "/paid/{id}",
             "resource": "/paid/one",
             "query": "view=full",

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3,6 +3,7 @@
 import pytest
 
 from mpp import BodyDigest, Challenge, Credential, Receipt
+from mpp.errors import VerificationFailedError
 from mpp.events import EventDispatcher
 from mpp.server import Mpp, intent, pay, verify_or_challenge
 from mpp.server.intent import VerificationError
@@ -450,6 +451,42 @@ class TestVerificationError:
             )
 
         assert events == [f"failed:{credential.challenge.id}:VerificationError"]
+
+    @pytest.mark.asyncio
+    async def test_payment_error_event_uses_submitted_challenge(self) -> None:
+        """Payment failures should identify the attempted, not retry, challenge."""
+        failed_challenge_ids: list[str] = []
+        dispatcher = EventDispatcher()
+        dispatcher.on(
+            "payment.failed",
+            lambda payload: failed_challenge_ids.append(payload["challenge"].id),
+        )
+
+        @intent(name="charge")
+        async def failing_intent(credential: Credential, request: dict) -> Receipt:
+            raise VerificationFailedError("Payment verification failed")
+
+        credential = make_bound_credential(
+            payload={},
+            request={"amount": "1000"},
+            realm="api.example.com",
+            secret_key="test-secret",
+        )
+
+        with pytest.raises(VerificationFailedError) as raised:
+            await verify_or_challenge(
+                authorization=credential.to_authorization(),
+                intent=failing_intent,
+                request={"amount": "1000"},
+                realm="api.example.com",
+                secret_key="test-secret",
+                events=dispatcher,
+            )
+
+        retry = raised.value.retry_challenge
+        assert isinstance(retry, Challenge)
+        assert failed_challenge_ids == [credential.challenge.id]
+        assert retry.id != credential.challenge.id
 
     @pytest.mark.asyncio
     async def test_returns_receipt_for_success(self) -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -797,7 +797,7 @@ class TestPay:
             challenge = Challenge.from_www_authenticate(
                 challenge_response.headers["WWW-Authenticate"]
             )
-            assert challenge.request["_mppx_scope"] == {
+            assert challenge.request["_mpp_scope"] == {
                 "route": "/paid/{id}",
                 "resource": "/paid/one",
                 "query": "view=full",
@@ -835,7 +835,7 @@ class TestPay:
             MockRequest(path="/paid/one", route="/paid/{id}", query_string="view=full")
         )
         challenge = challenge_from_402(challenge_result)
-        assert challenge.request["_mppx_scope"] == {
+        assert challenge.request["_mpp_scope"] == {
             "route": "/paid/{id}",
             "resource": "/paid/one",
             "query": "view=full",
@@ -1154,7 +1154,7 @@ class TestMppPay:
 
     @pytest.mark.asyncio
     async def test_exposes_server_event_helpers(self) -> None:
-        """Mpp should expose mppx-compatible server event helper methods."""
+        """Mpp should expose server event helper methods."""
         events: list[str] = []
 
         @intent(name="charge")
@@ -1246,7 +1246,7 @@ class TestMppPay:
             MockRequest(path="/paid/one", route="/paid/{id}", query_string="view=full")
         )
         challenge = challenge_from_402(challenge_result)
-        assert challenge.request["_mppx_scope"] == {
+        assert challenge.request["_mpp_scope"] == {
             "route": "/paid/{id}",
             "resource": "/paid/one",
             "query": "view=full",

--- a/tests/test_stores_wiring.py
+++ b/tests/test_stores_wiring.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+from types import MappingProxyType
+
 import pytest
 
-from mpp import Challenge
+from mpp import Challenge, Credential
 from mpp.methods.tempo import tempo
 from mpp.methods.tempo.intents import ChargeIntent
 from mpp.server import Mpp
@@ -24,6 +26,27 @@ class TestMppStoreWiring:
                 recipient="0x742d35Cc6634c0532925a3b844bC9e7595F8fE00",
                 intents={"charge": intent},
             ),
+            realm="test.com",
+            secret_key="test-secret",
+            store=store,
+        )
+
+        assert intent._store is store
+
+    def test_store_wired_into_read_only_intent_mapping(self) -> None:
+        """Mpp should wire stores into any mapping accepted by Method."""
+        store = MemoryStore()
+        intent = ChargeIntent()
+
+        class ReadOnlyMethod:
+            name = "tempo"
+            intents = MappingProxyType({"charge": intent})
+
+            async def create_credential(self, challenge: Challenge) -> Credential:
+                raise NotImplementedError
+
+        Mpp.create(
+            method=ReadOnlyMethod(),
             realm="test.com",
             secret_key="test-secret",
             store=store,

--- a/tests/test_stripe.py
+++ b/tests/test_stripe.py
@@ -653,7 +653,7 @@ class TestChargeIntent:
 
     @pytest.mark.asyncio
     async def test_idempotency_key(self):
-        """Verify idempotency keys use the pympp namespace."""
+        """Verify idempotency key format matches mppx."""
         captured: list[tuple[tuple, dict]] = []
 
         class CapturingIntents:
@@ -669,7 +669,7 @@ class TestChargeIntent:
         await intent.verify(credential, SAMPLE_REQUEST)
 
         options = captured[0][1]["options"]
-        assert options["idempotency_key"] == "pympp_test-challenge-id_spt_test_xyz"
+        assert options["idempotency_key"] == "mppx_test-challenge-id_spt_test_xyz"
 
     @pytest.mark.asyncio
     async def test_client_request_body_is_first_positional_arg(self):
@@ -757,7 +757,7 @@ class TestChargeIntentRawHttp:
         headers = call_kwargs.kwargs["headers"]
         expected_auth = base64.b64encode(b"sk_test_raw:").decode()
         assert headers["Authorization"] == f"Basic {expected_auth}"
-        assert headers["Idempotency-Key"] == "pympp_test-challenge-id_spt_test_abc"
+        assert headers["Idempotency-Key"] == "mppx_test-challenge-id_spt_test_abc"
 
         data = call_kwargs.kwargs["data"]
         assert data["amount"] == "150"

--- a/tests/test_stripe.py
+++ b/tests/test_stripe.py
@@ -186,7 +186,7 @@ class TestStripeMethod:
 
     @pytest.mark.asyncio
     async def test_create_credential_missing_network_id_raises(self):
-        """networkId is required in challenge.methodDetails (mppx parity)."""
+        """networkId is required in challenge.methodDetails."""
 
         async def fake_create_token(params: OnChallengeParameters) -> str:
             return "spt_test_abc"
@@ -235,7 +235,7 @@ class TestStripeMethod:
 
     @pytest.mark.asyncio
     async def test_create_credential_rejects_metadata_external_id(self):
-        """metadata.externalId is reserved (mppx parity)."""
+        """metadata.externalId is reserved."""
 
         async def fake_create_token(params: OnChallengeParameters) -> str:
             return "spt_test_abc"
@@ -653,7 +653,7 @@ class TestChargeIntent:
 
     @pytest.mark.asyncio
     async def test_idempotency_key(self):
-        """Verify idempotency key format matches mppx."""
+        """Verify idempotency keys use the pympp namespace."""
         captured: list[tuple[tuple, dict]] = []
 
         class CapturingIntents:
@@ -669,7 +669,7 @@ class TestChargeIntent:
         await intent.verify(credential, SAMPLE_REQUEST)
 
         options = captured[0][1]["options"]
-        assert options["idempotency_key"] == "mppx_test-challenge-id_spt_test_xyz"
+        assert options["idempotency_key"] == "pympp_test-challenge-id_spt_test_xyz"
 
     @pytest.mark.asyncio
     async def test_client_request_body_is_first_positional_arg(self):
@@ -757,7 +757,7 @@ class TestChargeIntentRawHttp:
         headers = call_kwargs.kwargs["headers"]
         expected_auth = base64.b64encode(b"sk_test_raw:").decode()
         assert headers["Authorization"] == f"Basic {expected_auth}"
-        assert headers["Idempotency-Key"] == "mppx_test-challenge-id_spt_test_abc"
+        assert headers["Idempotency-Key"] == "pympp_test-challenge-id_spt_test_abc"
 
         data = call_kwargs.kwargs["data"]
         assert data["amount"] == "150"

--- a/tests/test_tempo.py
+++ b/tests/test_tempo.py
@@ -23,6 +23,7 @@ from mpp.methods.tempo import (
 )
 from mpp.methods.tempo._attribution import encode as encode_attribution
 from mpp.methods.tempo._defaults import CHAIN_RPC_URLS
+from mpp.methods.tempo._rpc import _tip20_balance
 from mpp.methods.tempo.client import TempoMethod
 from mpp.methods.tempo.fee_payer_envelope import decode_fee_payer_envelope
 from mpp.methods.tempo.fee_payer_policy import get_policy
@@ -65,6 +66,37 @@ def mock_response(status_code: int = 200, json: dict | None = None) -> httpx.Res
 
 def amount_data(amount: int) -> str:
     return "0x" + hex(amount)[2:].zfill(64)
+
+
+@pytest.mark.asyncio
+async def test_tip20_balance() -> None:
+    client = AsyncMock()
+    client.post.return_value = mock_response(json={"result": "0x2a"})
+    address = "0x742d35Cc6634c0532925a3b844bC9e7595F8fE00"
+
+    balance = await _tip20_balance(
+        "https://rpc.test",
+        "0x20c0000000000000000000000000000000000000",
+        address,
+        client=client,
+    )
+
+    assert balance == 42
+    client.post.assert_awaited_once_with(
+        "https://rpc.test",
+        json={
+            "jsonrpc": "2.0",
+            "method": "eth_call",
+            "params": [
+                {
+                    "to": "0x20c0000000000000000000000000000000000000",
+                    "data": "0x70a08231" + "0" * 24 + address[2:].lower(),
+                },
+                "latest",
+            ],
+            "id": 1,
+        },
+    )
 
 
 class TestTempoAccount:

--- a/tests/test_tempo_relay.py
+++ b/tests/test_tempo_relay.py
@@ -1,6 +1,8 @@
 """Tests for the Tempo API relay adapter."""
 
 import json
+from collections.abc import AsyncIterator, Callable
+from contextlib import asynccontextmanager
 from datetime import UTC, datetime, timedelta
 from typing import Any
 from unittest.mock import AsyncMock, patch
@@ -11,10 +13,10 @@ from eth_hash.auto import keccak
 
 from mpp import Challenge, Credential, Receipt
 from mpp.errors import PaymentExpiredError, VerificationFailedError
-from mpp.methods.tempo import ChargeIntent, Relay, tempo
+from mpp.methods.tempo import ChargeIntent, Relay, TempoMethod, tempo
 from mpp.server import broadcast_credential, pay
 from mpp.store import MemoryStore
-from tests import make_bound_credential, make_credential
+from tests import MockRequest, challenge_from_402, make_bound_credential, make_credential
 
 
 def credential(payload: dict | None = None) -> Credential:
@@ -27,6 +29,20 @@ def credential(payload: dict | None = None) -> Credential:
 
 def response(body: dict, status: int = 200) -> httpx.Response:
     return httpx.Response(status, json=body)
+
+
+@asynccontextmanager
+async def relay_method(
+    handler: Callable[[httpx.Request], httpx.Response],
+    **relay_kwargs: Any,
+) -> AsyncIterator[TempoMethod]:
+    """Yield a tempo method whose charge intent is served by a mock relay."""
+    relay_kwargs.setdefault("api_key", "key")
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        yield tempo(
+            intents={"charge": ChargeIntent()},
+            relay=Relay(http_client=client, **relay_kwargs),
+        )
 
 
 @pytest.mark.asyncio
@@ -48,15 +64,11 @@ async def test_relay_validates_then_broadcasts_with_idempotency() -> None:
             }
         )
 
-    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
-        method = tempo(
-            intents={"charge": ChargeIntent()},
-            relay=Relay(
-                api_key="tempo:sk:test",
-                api_base_url="https://relay.example/mpp",
-                http_client=client,
-            ),
-        )
+    async with relay_method(
+        handler,
+        api_key="tempo:sk:test",
+        api_base_url="https://relay.example/mpp",
+    ) as method:
         result = await broadcast_credential(
             intent=method.intents["charge"],
             credential=credential(),
@@ -69,7 +81,7 @@ async def test_relay_validates_then_broadcasts_with_idempotency() -> None:
         "/mpp/v1/mpp/broadcast",
     ]
     assert calls[0].headers["tempo-api-key"] == "tempo:sk:test"
-    expected_key = "pympp_0x" + keccak(bytes.fromhex("1234")).hex()
+    expected_key = "mppx_0x" + keccak(bytes.fromhex("1234")).hex()
     assert calls[1].headers["idempotency-key"] == expected_key
     body = json.loads(calls[0].content)
     assert body["challenge"]["request"] == {"amount": "1000"}
@@ -95,11 +107,7 @@ async def test_relay_finalizes_pushed_hash_credential() -> None:
             }
         )
 
-    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
-        method = tempo(
-            intents={"charge": ChargeIntent()},
-            relay=Relay(api_key="key", http_client=client),
-        )
+    async with relay_method(handler) as method:
         result = await broadcast_credential(
             intent=method.intents["charge"],
             credential=credential({"type": "hash", "hash": "0xpushed"}),
@@ -108,6 +116,23 @@ async def test_relay_finalizes_pushed_hash_credential() -> None:
 
     assert result.reference == "0xpushed"
     assert paths == ["/v1/mpp/validate", "/v1/mpp/broadcast"]
+
+
+@pytest.mark.asyncio
+async def test_relay_validate_posts_to_validate_endpoint() -> None:
+    paths: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        paths.append(request.url.path)
+        return response({"success": True})
+
+    async with relay_method(handler) as method:
+        validation = await method.intents["charge"].validate(  # type: ignore[attr-defined]
+            credential(), {"amount": "1000"}
+        )
+
+    assert paths == ["/v1/mpp/validate"]
+    assert validation.request == {"amount": "1000"}
 
 
 @pytest.mark.asyncio
@@ -125,11 +150,7 @@ async def test_relay_exposes_only_safe_error_details(code: str, details: dict) -
     def handler(request: httpx.Request) -> httpx.Response:
         return response({"success": False, "error": {"code": code, "message": "private"}})
 
-    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
-        method = tempo(
-            intents={"charge": ChargeIntent()},
-            relay=Relay(api_key="key", http_client=client),
-        )
+    async with relay_method(handler) as method:
         with pytest.raises(VerificationFailedError) as raised:
             await method.intents["charge"].validate(credential(), {"amount": "1000"})  # type: ignore[attr-defined]
 
@@ -148,11 +169,7 @@ async def test_relay_hides_policy_errors() -> None:
             }
         )
 
-    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
-        method = tempo(
-            intents={"charge": ChargeIntent()},
-            relay=Relay(api_key="key", http_client=client),
-        )
+    async with relay_method(handler) as method:
         with pytest.raises(VerificationFailedError) as raised:
             await method.intents["charge"].validate(credential(), {})  # type: ignore[attr-defined]
 
@@ -170,15 +187,7 @@ async def test_relay_rejection_returns_retryable_http_challenge() -> None:
             }
         )
 
-    class Request:
-        def __init__(self, authorization: str | None = None) -> None:
-            self.headers = {"Authorization": authorization} if authorization else {}
-
-    async with httpx.AsyncClient(transport=httpx.MockTransport(relay_handler)) as client:
-        method = tempo(
-            intents={"charge": ChargeIntent()},
-            relay=Relay(api_key="key", http_client=client),
-        )
+    async with relay_method(relay_handler) as method:
 
         @pay(
             intent=method.intents["charge"],
@@ -187,17 +196,16 @@ async def test_relay_rejection_returns_retryable_http_challenge() -> None:
             secret_key="test-secret",
         )
         async def handler(
-            request: Request,
+            request: MockRequest,
             credential: Credential,
             receipt: Receipt,
         ) -> dict[str, bool]:
             return {"paid": True}
 
-        initial: Any = await handler(Request())
-        initial_headers = initial.headers if hasattr(initial, "headers") else initial["headers"]
-        challenge = Challenge.from_www_authenticate(initial_headers["WWW-Authenticate"])
+        initial: Any = await handler(MockRequest())
+        challenge = challenge_from_402(initial)
         rejected: Any = await handler(
-            Request(
+            MockRequest(
                 Credential(
                     challenge=challenge.to_echo(),
                     payload={"type": "transaction", "signature": "0x1234"},
@@ -230,11 +238,7 @@ async def test_relay_maps_expired_error() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         return response({"success": False, "error": {"code": "expired"}})
 
-    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
-        method = tempo(
-            intents={"charge": ChargeIntent()},
-            relay=Relay(api_key="key", http_client=client),
-        )
+    async with relay_method(handler) as method:
         with pytest.raises(PaymentExpiredError):
             await method.intents["charge"].validate(credential(), {})  # type: ignore[attr-defined]
 
@@ -246,11 +250,7 @@ async def test_relay_rejects_invalid_receipt() -> None:
             return response({"success": True})
         return response({"success": True, "receipt": {"method": "stripe"}})
 
-    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
-        method = tempo(
-            intents={"charge": ChargeIntent()},
-            relay=Relay(api_key="key", http_client=client),
-        )
+    async with relay_method(handler) as method:
         with pytest.raises(VerificationFailedError):
             await broadcast_credential(
                 intent=method.intents["charge"],

--- a/tests/test_tempo_relay.py
+++ b/tests/test_tempo_relay.py
@@ -12,7 +12,7 @@ import pytest
 from eth_hash.auto import keccak
 
 from mpp import Challenge, Credential, Receipt
-from mpp.errors import PaymentExpiredError, VerificationFailedError
+from mpp.errors import PaymentExpiredError, VerificationError, VerificationFailedError
 from mpp.methods.tempo import ChargeIntent, Relay, TempoMethod, tempo
 from mpp.server import broadcast_credential, pay
 from mpp.store import MemoryStore
@@ -140,6 +140,23 @@ async def test_relay_validate_posts_to_validate_endpoint() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("hook_name", ["validate", "broadcast"])
+async def test_relay_rejects_mismatched_request(hook_name: str) -> None:
+    calls: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(request)
+        return response({"success": True})
+
+    async with relay_method(handler) as method:
+        hook = getattr(method.intents["charge"], hook_name)
+        with pytest.raises(VerificationFailedError):
+            await hook(credential(), {"amount": "2000"})
+
+    assert calls == []
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("code", "details"),
     [
@@ -175,7 +192,9 @@ async def test_relay_hides_policy_errors() -> None:
 
     async with relay_method(handler) as method:
         with pytest.raises(VerificationFailedError) as raised:
-            await method.intents["charge"].validate(credential(), {})  # type: ignore[attr-defined]
+            await method.intents["charge"].validate(  # type: ignore[attr-defined]
+                credential(), {"amount": "1000"}
+            )
 
     assert raised.value.details is None
     assert "policy" not in str(raised.value)
@@ -244,7 +263,9 @@ async def test_relay_maps_expired_error() -> None:
 
     async with relay_method(handler) as method:
         with pytest.raises(PaymentExpiredError):
-            await method.intents["charge"].validate(credential(), {})  # type: ignore[attr-defined]
+            await method.intents["charge"].validate(  # type: ignore[attr-defined]
+                credential(), {"amount": "1000"}
+            )
 
 
 @pytest.mark.asyncio
@@ -259,7 +280,7 @@ async def test_relay_rejects_invalid_receipt() -> None:
             await broadcast_credential(
                 intent=method.intents["charge"],
                 credential=credential(),
-                request={},
+                request={"amount": "1000"},
             )
 
 
@@ -293,6 +314,32 @@ async def test_charge_validation_does_not_consume_hash() -> None:
 
     assert result.details == {"mode": "push"}
     assert await store.get("mpp:charge:0xabc") is None
+
+
+@pytest.mark.asyncio
+async def test_charge_validation_rejects_consumed_hash() -> None:
+    store = MemoryStore()
+    await store.put("mpp:charge:0xabc", "0xabc")
+    intent = ChargeIntent(rpc_url="https://rpc.test", store=store)
+    payment = make_credential(
+        payload={"type": "hash", "hash": "0xabc"},
+        expires=(datetime.now(UTC) + timedelta(hours=1)).isoformat(),
+    )
+
+    with (
+        patch.object(intent, "_validate_hash", AsyncMock()) as validate_hash,
+        pytest.raises(VerificationError, match="Transaction hash already used"),
+    ):
+        await intent.validate(
+            payment,
+            {
+                "amount": "1000",
+                "currency": "0x1234567890123456789012345678901234567890",
+                "recipient": "0x4567890123456789012345678901234567890123",
+            },
+        )
+
+    validate_hash.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/test_tempo_relay.py
+++ b/tests/test_tempo_relay.py
@@ -81,7 +81,7 @@ async def test_relay_validates_then_broadcasts_with_idempotency() -> None:
         "/mpp/v1/mpp/broadcast",
     ]
     assert calls[0].headers["tempo-api-key"] == "tempo:sk:test"
-    expected_key = "mppx_0x" + keccak(bytes.fromhex("1234")).hex()
+    expected_key = "pympp_0x" + keccak(bytes.fromhex("1234")).hex()
     assert calls[1].headers["idempotency-key"] == expected_key
     body = json.loads(calls[0].content)
     assert body["challenge"]["request"] == {"amount": "1000"}
@@ -90,10 +90,10 @@ async def test_relay_validates_then_broadcasts_with_idempotency() -> None:
 
 @pytest.mark.asyncio
 async def test_relay_finalizes_pushed_hash_credential() -> None:
-    paths: list[str] = []
+    calls: list[httpx.Request] = []
 
     def handler(request: httpx.Request) -> httpx.Response:
-        paths.append(request.url.path)
+        calls.append(request)
         if request.url.path.endswith("/validate"):
             return response({"success": True})
         return response(
@@ -115,7 +115,11 @@ async def test_relay_finalizes_pushed_hash_credential() -> None:
         )
 
     assert result.reference == "0xpushed"
-    assert paths == ["/v1/mpp/validate", "/v1/mpp/broadcast"]
+    assert [call.url.path for call in calls] == [
+        "/v1/mpp/validate",
+        "/v1/mpp/broadcast",
+    ]
+    assert calls[1].headers["idempotency-key"].startswith("pympp_0x")
 
 
 @pytest.mark.asyncio
@@ -289,3 +293,25 @@ async def test_charge_validation_does_not_consume_hash() -> None:
 
     assert result.details == {"mode": "push"}
     assert await store.get("mpp:charge:0xabc") is None
+
+
+@pytest.mark.asyncio
+async def test_charge_validation_uses_python_field_names() -> None:
+    intent = ChargeIntent(rpc_url="https://rpc.test")
+    payment = make_credential(
+        payload={"type": "transaction", "signature": "0x1234"},
+        expires=(datetime.now(UTC) + timedelta(hours=1)).isoformat(),
+    )
+    request = {
+        "amount": "1000",
+        "currency": "0x1234567890123456789012345678901234567890",
+        "recipient": "0x4567890123456789012345678901234567890123",
+    }
+
+    with patch.object(intent, "_validate_transaction_payload"):
+        result = await intent.validate(payment, request)
+
+    assert result.details == {
+        "mode": "pull",
+        "serialized_transaction": "0x1234",
+    }

--- a/tests/test_tempo_relay.py
+++ b/tests/test_tempo_relay.py
@@ -1,0 +1,225 @@
+"""Tests for the Tempo API relay adapter."""
+
+import json
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+from eth_hash.auto import keccak
+
+from mpp import Credential, Receipt
+from mpp.errors import PaymentExpiredError, VerificationFailedError
+from mpp.methods.tempo import ChargeIntent, Relay, tempo
+from mpp.server import broadcast_credential
+from mpp.store import MemoryStore
+from tests import make_bound_credential, make_credential
+
+
+def credential(payload: dict | None = None) -> Credential:
+    return make_bound_credential(
+        payload=payload or {"type": "transaction", "signature": "0x1234"},
+        request={"amount": "1000"},
+        source="did:pkh:eip155:42431:0x1234567890123456789012345678901234567890",
+    )
+
+
+def response(body: dict, status: int = 200) -> httpx.Response:
+    return httpx.Response(status, json=body)
+
+
+@pytest.mark.asyncio
+async def test_relay_validates_then_broadcasts_with_idempotency() -> None:
+    calls: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(request)
+        if request.url.path.endswith("/validate"):
+            return response({"success": True})
+        return response(
+            {
+                "success": True,
+                "receipt": {
+                    "method": "tempo",
+                    "reference": "0xabc",
+                    "timestamp": "2026-08-05T12:00:00Z",
+                },
+            }
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        method = tempo(
+            intents={"charge": ChargeIntent()},
+            relay=Relay(
+                api_key="tempo:sk:test",
+                api_base_url="https://relay.example/mpp",
+                http_client=client,
+            ),
+        )
+        result = await broadcast_credential(
+            intent=method.intents["charge"],
+            credential=credential(),
+            request={"amount": "1000"},
+        )
+
+    assert result.reference == "0xabc"
+    assert [call.url.path for call in calls] == [
+        "/mpp/v1/mpp/validate",
+        "/mpp/v1/mpp/broadcast",
+    ]
+    assert calls[0].headers["tempo-api-key"] == "tempo:sk:test"
+    expected_key = "pympp_0x" + keccak(bytes.fromhex("1234")).hex()
+    assert calls[1].headers["idempotency-key"] == expected_key
+    body = json.loads(calls[0].content)
+    assert body["challenge"]["request"] == {"amount": "1000"}
+    assert body["payload"] == {"type": "transaction", "signature": "0x1234"}
+
+
+@pytest.mark.asyncio
+async def test_relay_finalizes_pushed_hash_credential() -> None:
+    paths: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        paths.append(request.url.path)
+        if request.url.path.endswith("/validate"):
+            return response({"success": True})
+        return response(
+            {
+                "success": True,
+                "receipt": {
+                    "method": "tempo",
+                    "reference": "0xpushed",
+                    "timestamp": "2026-08-05T12:00:00+00:00",
+                },
+            }
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        method = tempo(
+            intents={"charge": ChargeIntent()},
+            relay=Relay(api_key="key", http_client=client),
+        )
+        result = await broadcast_credential(
+            intent=method.intents["charge"],
+            credential=credential({"type": "hash", "hash": "0xpushed"}),
+            request={"amount": "1000"},
+        )
+
+    assert result.reference == "0xpushed"
+    assert paths == ["/v1/mpp/validate", "/v1/mpp/broadcast"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("code", "details"),
+    [
+        ("already_used", {"code": "already_used"}),
+        (
+            "temporarily_unavailable",
+            {"code": "temporarily_unavailable", "retry": "same_credential"},
+        ),
+    ],
+)
+async def test_relay_exposes_only_safe_error_details(code: str, details: dict) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return response({"success": False, "error": {"code": code, "message": "private"}})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        method = tempo(
+            intents={"charge": ChargeIntent()},
+            relay=Relay(api_key="key", http_client=client),
+        )
+        with pytest.raises(VerificationFailedError) as raised:
+            await method.intents["charge"].validate(credential(), {"amount": "1000"})  # type: ignore[attr-defined]
+
+    assert raised.value.details == details
+    assert raised.value.to_problem_details()["details"] == details
+    assert "private" not in str(raised.value)
+
+
+@pytest.mark.asyncio
+async def test_relay_hides_policy_errors() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return response(
+            {
+                "success": False,
+                "error": {"code": "policy_denied", "message": "private policy detail"},
+            }
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        method = tempo(
+            intents={"charge": ChargeIntent()},
+            relay=Relay(api_key="key", http_client=client),
+        )
+        with pytest.raises(VerificationFailedError) as raised:
+            await method.intents["charge"].validate(credential(), {})  # type: ignore[attr-defined]
+
+    assert raised.value.details is None
+    assert "policy" not in str(raised.value)
+
+
+@pytest.mark.asyncio
+async def test_relay_maps_expired_error() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return response({"success": False, "error": {"code": "expired"}})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        method = tempo(
+            intents={"charge": ChargeIntent()},
+            relay=Relay(api_key="key", http_client=client),
+        )
+        with pytest.raises(PaymentExpiredError):
+            await method.intents["charge"].validate(credential(), {})  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_relay_rejects_invalid_receipt() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/validate"):
+            return response({"success": True})
+        return response({"success": True, "receipt": {"method": "stripe"}})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        method = tempo(
+            intents={"charge": ChargeIntent()},
+            relay=Relay(api_key="key", http_client=client),
+        )
+        with pytest.raises(VerificationFailedError):
+            await broadcast_credential(
+                intent=method.intents["charge"],
+                credential=credential(),
+                request={},
+            )
+
+
+def test_relay_requires_charge_intent() -> None:
+    with pytest.raises(ValueError, match="charge intent"):
+        tempo(intents={}, relay=Relay(api_key="key"))
+
+
+@pytest.mark.asyncio
+async def test_charge_validation_does_not_consume_hash() -> None:
+    store = MemoryStore()
+    intent = ChargeIntent(rpc_url="https://rpc.test", store=store)
+    payment = make_credential(
+        payload={"type": "hash", "hash": "0xabc"},
+        expires=(datetime.now(UTC) + timedelta(hours=1)).isoformat(),
+    )
+
+    with patch.object(
+        intent,
+        "_validate_hash",
+        AsyncMock(return_value=Receipt.success("0xabc")),
+    ):
+        result = await intent.validate(
+            payment,
+            {
+                "amount": "1000",
+                "currency": "0x1234567890123456789012345678901234567890",
+                "recipient": "0x4567890123456789012345678901234567890123",
+            },
+        )
+
+    assert result.details == {"mode": "push"}
+    assert await store.get("mpp:charge:0xabc") is None

--- a/tests/test_tempo_relay.py
+++ b/tests/test_tempo_relay.py
@@ -12,7 +12,12 @@ import pytest
 from eth_hash.auto import keccak
 
 from mpp import Challenge, Credential, Receipt
-from mpp.errors import PaymentExpiredError, VerificationError, VerificationFailedError
+from mpp.errors import (
+    PaymentExpiredError,
+    PaymentOutcomeUnknownError,
+    VerificationError,
+    VerificationFailedError,
+)
 from mpp.methods.tempo import ChargeIntent, Relay, TempoMethod, tempo
 from mpp.server import broadcast_credential, pay
 from mpp.store import MemoryStore
@@ -254,6 +259,50 @@ async def test_relay_rejection_returns_retryable_http_challenge() -> None:
     assert body["challengeId"] == retry.id
     assert body["details"] == {"code": "insufficient_funds"}
     assert "private balance" not in json.dumps(body)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure", ["transport", "json"])
+async def test_ambiguous_broadcast_does_not_issue_fresh_challenge(failure: str) -> None:
+    paths: list[str] = []
+
+    def relay_handler(request: httpx.Request) -> httpx.Response:
+        paths.append(request.url.path)
+        if request.url.path.endswith("/validate"):
+            return response({"success": True})
+        if failure == "transport":
+            raise httpx.ReadError("response lost", request=request)
+        return httpx.Response(200, content=b"not-json")
+
+    async with relay_method(relay_handler) as method:
+
+        @pay(
+            intent=method.intents["charge"],
+            request={"amount": "1000"},
+            realm="api.example.com",
+            secret_key="test-secret",
+        )
+        async def handler(
+            request: MockRequest,
+            credential: Credential,
+            receipt: Receipt,
+        ) -> dict[str, bool]:
+            return {"paid": True}
+
+        initial: Any = await handler(MockRequest())
+        challenge = challenge_from_402(initial)
+        payment = Credential(
+            challenge=challenge.to_echo(),
+            payload={"type": "transaction", "signature": "0x1234"},
+        )
+        with pytest.raises(PaymentOutcomeUnknownError) as raised:
+            await handler(MockRequest(payment.to_authorization()))
+
+    assert paths == ["/v1/mpp/validate", "/v1/mpp/broadcast"]
+    assert raised.value.challenge.id == challenge.id
+    assert raised.value.credential == payment
+    assert raised.value.request == {"amount": "1000"}
+    assert raised.value.retry_challenge is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_tempo_relay.py
+++ b/tests/test_tempo_relay.py
@@ -411,3 +411,23 @@ async def test_charge_validation_uses_python_field_names() -> None:
         "mode": "pull",
         "serialized_transaction": "0x1234",
     }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("signature", ["0x1234", "0x76ff"])
+async def test_charge_validation_rejects_undecodable_transactions(signature: str) -> None:
+    intent = ChargeIntent(rpc_url="https://rpc.test")
+    payment = make_credential(
+        payload={"type": "transaction", "signature": signature},
+        expires=(datetime.now(UTC) + timedelta(hours=1)).isoformat(),
+    )
+
+    with pytest.raises(VerificationError):
+        await intent.validate(
+            payment,
+            {
+                "amount": "1000",
+                "currency": "0x1234567890123456789012345678901234567890",
+                "recipient": "0x4567890123456789012345678901234567890123",
+            },
+        )

--- a/tests/test_tempo_relay.py
+++ b/tests/test_tempo_relay.py
@@ -2,16 +2,17 @@
 
 import json
 from datetime import UTC, datetime, timedelta
+from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import httpx
 import pytest
 from eth_hash.auto import keccak
 
-from mpp import Credential, Receipt
+from mpp import Challenge, Credential, Receipt
 from mpp.errors import PaymentExpiredError, VerificationFailedError
 from mpp.methods.tempo import ChargeIntent, Relay, tempo
-from mpp.server import broadcast_credential
+from mpp.server import broadcast_credential, pay
 from mpp.store import MemoryStore
 from tests import make_bound_credential, make_credential
 
@@ -157,6 +158,71 @@ async def test_relay_hides_policy_errors() -> None:
 
     assert raised.value.details is None
     assert "policy" not in str(raised.value)
+
+
+@pytest.mark.asyncio
+async def test_relay_rejection_returns_retryable_http_challenge() -> None:
+    def relay_handler(request: httpx.Request) -> httpx.Response:
+        return response(
+            {
+                "success": False,
+                "error": {"code": "insufficient_funds", "message": "private balance"},
+            }
+        )
+
+    class Request:
+        def __init__(self, authorization: str | None = None) -> None:
+            self.headers = {"Authorization": authorization} if authorization else {}
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(relay_handler)) as client:
+        method = tempo(
+            intents={"charge": ChargeIntent()},
+            relay=Relay(api_key="key", http_client=client),
+        )
+
+        @pay(
+            intent=method.intents["charge"],
+            request={"amount": "1000"},
+            realm="api.example.com",
+            secret_key="test-secret",
+        )
+        async def handler(
+            request: Request,
+            credential: Credential,
+            receipt: Receipt,
+        ) -> dict[str, bool]:
+            return {"paid": True}
+
+        initial: Any = await handler(Request())
+        initial_headers = initial.headers if hasattr(initial, "headers") else initial["headers"]
+        challenge = Challenge.from_www_authenticate(initial_headers["WWW-Authenticate"])
+        rejected: Any = await handler(
+            Request(
+                Credential(
+                    challenge=challenge.to_echo(),
+                    payload={"type": "transaction", "signature": "0x1234"},
+                ).to_authorization()
+            )
+        )
+
+    if hasattr(rejected, "status_code"):
+        status = rejected.status_code
+        headers = rejected.headers
+        body = json.loads(rejected.body)
+    else:
+        status = rejected["status"]
+        headers = rejected["headers"]
+        body = json.loads(rejected["body"])
+
+    retry = Challenge.from_www_authenticate(headers["WWW-Authenticate"])
+    assert status == 402
+    assert headers["Content-Type"] == "application/problem+json"
+    assert retry.id != challenge.id
+    assert body["type"].endswith("/verification-failed")
+    assert body["status"] == 402
+    assert body["challengeId"] == retry.id
+    assert body["details"] == {"code": "insufficient_funds"}
+    assert "private balance" not in json.dumps(body)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Why

pympp servers need to delegate Tempo charge validation and settlement to the Tempo API without local RPC or replay infrastructure. This requires non-mutating validation before terminal broadcast while preserving existing verify-only intents.

## What

- Add the `VerifiableIntent` protocol with `validate` and `broadcast`, plus bound credential lifecycle APIs for HTTP and MCP.
- Add the Tempo `Relay` adapter, safe relay failure mapping, and deterministic `pympp_` broadcast idempotency keys.
- Preserve legacy `Intent.verify` behavior and existing Stripe idempotency behavior.
- Add a runnable FastAPI example and lifecycle, relay, binding, and replay coverage.