### PR TITLE
feat: add Tempo relay and split credential lifecycle (simplified)

### DIFF
--- a/.changelog/dry-wolves-write.md
+++ b/.changelog/dry-wolves-write.md
@@ -1,0 +1,5 @@
+---
+pympp: minor
+---
+
+Added split credential validation and broadcast APIs (`validate_credential`, `broadcast_credential`) alongside a new `SplitIntent` protocol to separate advisory and terminal charge phases. Introduced a `Relay` class that delegates Tempo charge validation and finalization to the Tempo API relay, and added a `charge-relay` example demonstrating FastAPI route protection settled through the relay.

--- a/.changelog/old-cats-chirp.md
+++ b/.changelog/old-cats-chirp.md
@@ -1,0 +1,5 @@
+---
+pympp: minor
+---
+
+Added split credential validation and broadcast APIs (`validate_credential`, `broadcast_credential`) alongside a new `SplitIntent` protocol to separate advisory and terminal charge phases. Introduced a `Relay` class that delegates Tempo charge validation and finalization to the Tempo API relay, and added a `charge-relay` example demonstrating FastAPI route protection settled through the relay.

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,6 +6,7 @@ Code examples for using the Machine Payments Protocol (pympp).
 
 | Example | Description |
 |---------|-------------|
+| [charge-relay/](charge-relay/) | FastAPI charge settled through the Tempo API relay |
 | [fetch/](fetch/) | CLI tool for fetching URLs with automatic payment handling |
 | [mcp-server/](mcp-server/) | MCP server with payment-protected tools |
 | [stripe/](stripe/) | Stripe SPT payment flow (server + headless client) |

--- a/examples/charge-relay/README.md
+++ b/examples/charge-relay/README.md
@@ -1,0 +1,36 @@
+# Tempo API charge relay
+
+This example protects a FastAPI route with a 0.01 pathUSD charge on Tempo
+Moderato. pympp authenticates the challenge while Tempo API validates and
+finalizes the submitted credential.
+
+Start the server:
+
+```bash
+export TEMPO_API_KEY=tempo:sk:...
+export MPP_SECRET_KEY=$(openssl rand -base64 32)
+uv sync
+uv run server.py
+```
+
+Then run the included payer in another terminal:
+
+```bash
+uv run client.py
+```
+
+The client creates and funds a disposable Moderato account, handles the initial
+402 challenge, pays it, and prints the decoded `Payment-Receipt`. Set
+`TEMPO_PRIVATE_KEY` to reuse a test account or `PAYMENT_URL` to call another
+deployment.
+
+The server flow is:
+
+1. Issue a bound `tempo/charge` challenge.
+2. Call `POST /v1/mpp/validate` without consuming the credential.
+3. Call `POST /v1/mpp/broadcast` with a deterministic idempotency key.
+4. Return the relay receipt in `Payment-Receipt`.
+
+`Mpp.validate_credential()` exposes the advisory phase independently;
+`Mpp.broadcast_credential()` revalidates before the terminal phase.
+`Mpp.verify_credential()` remains a terminal alias.

--- a/examples/charge-relay/client.py
+++ b/examples/charge-relay/client.py
@@ -1,0 +1,81 @@
+"""Fund a disposable Moderato account and call the paid example route."""
+
+import asyncio
+import json
+import os
+import secrets
+from typing import Any
+
+import httpx
+
+from mpp import Receipt
+from mpp.client import Client
+from mpp.methods.tempo import ChargeIntent, TempoAccount, tempo
+from mpp.methods.tempo._defaults import PATH_USD, TESTNET_CHAIN_ID, TESTNET_RPC_URL
+
+
+async def rpc(client: httpx.AsyncClient, method: str, params: list[Any]) -> Any:
+    response = await client.post(
+        TESTNET_RPC_URL,
+        json={"jsonrpc": "2.0", "id": 1, "method": method, "params": params},
+    )
+    response.raise_for_status()
+    result = response.json()
+    if "error" in result:
+        raise RuntimeError(str(result["error"]))
+    return result["result"]
+
+
+async def fund(account: TempoAccount) -> None:
+    balance_call = "0x70a08231" + "0" * 24 + account.address[2:].lower()
+    async with httpx.AsyncClient(timeout=30) as client:
+        await rpc(client, "tempo_fundAddress", [account.address])
+        for _ in range(60):
+            balance = await rpc(
+                client,
+                "eth_call",
+                [{"to": PATH_USD, "data": balance_call}, "latest"],
+            )
+            if int(balance, 16) > 0:
+                return
+            await asyncio.sleep(0.5)
+    raise RuntimeError("Moderato funding was not visible after 30 seconds")
+
+
+async def main() -> None:
+    account = TempoAccount.from_key(
+        os.environ.get("TEMPO_PRIVATE_KEY", "0x" + secrets.token_hex(32))
+    )
+    await fund(account)
+
+    method = tempo(
+        account=account,
+        chain_id=TESTNET_CHAIN_ID,
+        rpc_url=TESTNET_RPC_URL,
+        intents={"charge": ChargeIntent()},
+    )
+    async with Client(methods=[method]) as client:
+        response = await client.get(os.environ.get("PAYMENT_URL", "http://127.0.0.1:5173/photo"))
+    response.raise_for_status()
+
+    receipt = Receipt.from_payment_receipt(response.headers["Payment-Receipt"])
+    print(
+        json.dumps(
+            {
+                "payer": account.address,
+                "response": response.json(),
+                "status": response.status_code,
+                "receipt": {
+                    "method": receipt.method,
+                    "reference": receipt.reference,
+                    "status": receipt.status,
+                    "timestamp": receipt.timestamp.isoformat(),
+                },
+            },
+            indent=2,
+        )
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/charge-relay/pyproject.toml
+++ b/examples/charge-relay/pyproject.toml
@@ -1,0 +1,8 @@
+[project]
+name = "pympp-charge-relay-example"
+version = "0.1.0"
+requires-python = ">=3.12"
+dependencies = ["pympp[server,tempo]", "fastapi", "uvicorn"]
+
+[tool.uv.sources]
+pympp = { path = "../.." }

--- a/examples/charge-relay/server.py
+++ b/examples/charge-relay/server.py
@@ -1,0 +1,78 @@
+"""Payment-gated FastAPI route settled by the Tempo API relay."""
+
+import os
+import secrets
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+
+from mpp import Challenge
+from mpp.methods.tempo import ChargeIntent, Relay, TempoAccount, tempo
+from mpp.methods.tempo._defaults import PATH_USD, TESTNET_CHAIN_ID
+from mpp.server import Mpp
+
+api_key = os.environ.get("TEMPO_API_KEY")
+if api_key is None:
+    raise RuntimeError("TEMPO_API_KEY is required")
+
+recipient = os.environ.get("PAYMENT_DESTINATION")
+if recipient is None:
+    recipient = TempoAccount.from_key("0x" + secrets.token_hex(32)).address
+
+relay = Relay(
+    api_key=api_key,
+    api_base_url=os.environ.get("TEMPO_API_URL", "https://api.tempo.xyz"),
+)
+payments = Mpp.create(
+    method=tempo(
+        chain_id=TESTNET_CHAIN_ID,
+        currency=PATH_USD,
+        recipient=recipient,
+        intents={"charge": ChargeIntent()},
+        relay=relay,
+    ),
+    secret_key=os.environ.get("MPP_SECRET_KEY", "local-relay-example-secret"),
+)
+
+
+@asynccontextmanager
+async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
+    yield
+    await relay.aclose()
+
+
+app = FastAPI(lifespan=lifespan)
+
+
+@app.get("/health")
+async def health() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.get("/photo")
+async def photo(request: Request):
+    payment = await payments.charge(
+        authorization=request.headers.get("Authorization"),
+        amount="0.01",
+        description="Random photo",
+    )
+    if isinstance(payment, Challenge):
+        return JSONResponse(
+            {"error": "Payment required"},
+            status_code=402,
+            headers={"WWW-Authenticate": payment.to_www_authenticate(payments.realm)},
+        )
+
+    _, receipt = payment
+    return JSONResponse(
+        {"url": "https://picsum.photos/1024/1024"},
+        headers={"Payment-Receipt": receipt.to_payment_receipt()},
+    )
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="127.0.0.1", port=5173)

--- a/src/mpp/_validation.py
+++ b/src/mpp/_validation.py
@@ -1,0 +1,22 @@
+"""Dependency-neutral credential validation result."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from mpp import ChallengeEcho, Credential
+
+
+@dataclass(frozen=True, slots=True)
+class Validation:
+    """Result of non-mutating credential validation."""
+
+    challenge: ChallengeEcho
+    credential: Credential
+    details: Any
+    intent: str
+    method: str
+    request: dict[str, Any]
+    source: str | None = None

--- a/src/mpp/_validation.py
+++ b/src/mpp/_validation.py
@@ -13,10 +13,19 @@ if TYPE_CHECKING:
 class Validation:
     """Result of non-mutating credential validation."""
 
-    challenge: ChallengeEcho
     credential: Credential
     details: Any
     intent: str
-    method: str
     request: dict[str, Any]
-    source: str | None = None
+
+    @property
+    def challenge(self) -> ChallengeEcho:
+        return self.credential.challenge
+
+    @property
+    def method(self) -> str:
+        return self.credential.challenge.method
+
+    @property
+    def source(self) -> str | None:
+        return self.credential.source

--- a/src/mpp/errors.py
+++ b/src/mpp/errors.py
@@ -56,6 +56,10 @@ class PaymentError(Exception):
 
     type: str = f"{_BASE_URI}/payment-error"
 
+    def __init__(self, message: str, *, details: dict[str, Any] | None = None) -> None:
+        super().__init__(message)
+        self.details = details
+
     def to_problem_details(self, challenge_id: str | None = None) -> dict[str, Any]:
         """Convert to RFC 9457 Problem Details format."""
         details: dict[str, Any] = {
@@ -68,6 +72,8 @@ class PaymentError(Exception):
             details["challengeId"] = challenge_id
         if self.hint is not None:
             details["hint"] = self.hint
+        if self.details is not None:
+            details["details"] = self.details
         return details
 
 
@@ -128,11 +134,16 @@ class InvalidChallengeError(PaymentError):
 class VerificationFailedError(PaymentError):
     """Payment proof is invalid or verification failed."""
 
-    def __init__(self, reason: str | None = None) -> None:
+    def __init__(
+        self,
+        reason: str | None = None,
+        *,
+        details: dict[str, Any] | None = None,
+    ) -> None:
         msg = (
             f"Payment verification failed: {reason}." if reason else "Payment verification failed."
         )
-        super().__init__(msg)
+        super().__init__(msg, details=details)
 
 
 class PaymentExpiredError(PaymentError):

--- a/src/mpp/errors.py
+++ b/src/mpp/errors.py
@@ -46,6 +46,7 @@ class PaymentError(Exception):
     status: int = 402
     title: str = "Payment Error"
     hint: str | None = None
+    details: dict[str, Any] | None = None
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)
@@ -55,10 +56,6 @@ class PaymentError(Exception):
             cls.title = _to_title(cls.__name__)
 
     type: str = f"{_BASE_URI}/payment-error"
-
-    def __init__(self, message: str, *, details: dict[str, Any] | None = None) -> None:
-        super().__init__(message)
-        self.details = details
 
     def to_problem_details(self, challenge_id: str | None = None) -> dict[str, Any]:
         """Convert to RFC 9457 Problem Details format."""
@@ -143,7 +140,8 @@ class VerificationFailedError(PaymentError):
         msg = (
             f"Payment verification failed: {reason}." if reason else "Payment verification failed."
         )
-        super().__init__(msg, details=details)
+        super().__init__(msg)
+        self.details = details
 
 
 class PaymentExpiredError(PaymentError):

--- a/src/mpp/extensions/mcp/verify.py
+++ b/src/mpp/extensions/mcp/verify.py
@@ -194,12 +194,16 @@ async def verify_or_challenge(
     if expires_dt < datetime.now(UTC):
         return new_challenge()
 
-    from mpp.server.intent import VerificationError
+    from mpp.server.intent import VerificationError, broadcast_credential
 
     core_credential = mcp_credential.to_core()
 
     try:
-        core_receipt = await intent.verify(core_credential, request)
+        core_receipt = await broadcast_credential(
+            intent=intent,
+            credential=core_credential,
+            request=request,
+        )
     except VerificationError as e:
         raise PaymentVerificationError(
             challenges=[new_challenge()],

--- a/src/mpp/methods/tempo/__init__.py
+++ b/src/mpp/methods/tempo/__init__.py
@@ -50,6 +50,7 @@ _LAZY_EXPORTS = {
         "ValidateSender",
         "get_transfers",
     ),
+    "mpp.methods.tempo.relay": ("Relay", "RelayErrorCode"),
     "mpp.methods.tempo.schemas": ("Split",),
 }
 

--- a/src/mpp/methods/tempo/__init__.pyi
+++ b/src/mpp/methods/tempo/__init__.pyi
@@ -14,6 +14,8 @@ from mpp.methods.tempo.intents import SenderValidation as _SenderValidation
 from mpp.methods.tempo.intents import Transfer as _Transfer
 from mpp.methods.tempo.intents import ValidateSender as _ValidateSender
 from mpp.methods.tempo.intents import get_transfers as _get_transfers
+from mpp.methods.tempo.relay import Relay as _Relay
+from mpp.methods.tempo.relay import RelayErrorCode as _RelayErrorCode
 from mpp.methods.tempo.schemas import Split as _Split
 
 CHAIN_ID = _CHAIN_ID
@@ -32,4 +34,6 @@ SenderValidation = _SenderValidation
 Transfer = _Transfer
 ValidateSender = _ValidateSender
 get_transfers = _get_transfers
+Relay = _Relay
+RelayErrorCode = _RelayErrorCode
 Split = _Split

--- a/src/mpp/methods/tempo/client.py
+++ b/src/mpp/methods/tempo/client.py
@@ -23,6 +23,7 @@ from mpp.methods.tempo.fee_payer_policy import get_policy
 
 if TYPE_CHECKING:
     from mpp.methods.tempo.account import TempoAccount
+    from mpp.methods.tempo.relay import Relay
     from mpp.server.intent import Intent
 
 
@@ -393,6 +394,7 @@ def tempo(
     recipient: str | None = None,
     decimals: int = 6,
     client_id: str | None = None,
+    relay: Relay | None = None,
 ) -> TempoMethod:
     """Create a Tempo payment method.
 
@@ -414,6 +416,7 @@ def tempo(
         recipient: Default recipient address for charges.
         decimals: Token decimal places for amount conversion (default: 6).
         client_id: Optional client identity for attribution memos.
+        relay: Optional server-side Tempo API relay for the charge intent.
 
     Returns:
         A configured TempoMethod instance.
@@ -468,5 +471,11 @@ def tempo(
             intent.rpc_url = rpc_url  # type: ignore[union-attr]
         if hasattr(intent, "_method"):
             intent._method = method  # type: ignore[union-attr]
-    method._intents = dict(intents)
+    configured_intents = dict(intents)
+    if relay is not None:
+        charge = configured_intents.get("charge")
+        if charge is None:
+            raise ValueError("relay requires a charge intent")
+        configured_intents["charge"] = relay.configure(charge)
+    method._intents = configured_intents
     return method

--- a/src/mpp/methods/tempo/intents.py
+++ b/src/mpp/methods/tempo/intents.py
@@ -18,6 +18,7 @@ from eth_abi.exceptions import DecodingError
 
 from mpp import Credential, Receipt
 from mpp._defaults import DEFAULT_TIMEOUT
+from mpp._validation import Validation
 from mpp.errors import VerificationError
 from mpp.methods.tempo._defaults import PATH_USD, rpc_url_for_chain
 from mpp.methods.tempo.fee_payer_policy import get_policy
@@ -547,23 +548,12 @@ class ChargeIntent:
             self._http_client = httpx.AsyncClient(timeout=self._timeout)
         return self._http_client
 
-    async def verify(
+    def _prepare_credential(
         self,
         credential: Credential,
         request: dict[str, Any],
-    ) -> Receipt:
-        """Verify a charge credential.
-
-        Args:
-            credential: The payment credential from the client.
-            request: The original payment request parameters.
-
-        Returns:
-            A receipt indicating success or failure.
-
-        Raises:
-            VerificationError: If verification fails.
-        """
+    ) -> tuple[ChargeRequest, CredentialPayload]:
+        """Parse the charge request and credential payload."""
         req = ChargeRequest.model_validate(request)
 
         # Expiry is conveyed via the challenge-level expires auth-param,
@@ -587,21 +577,83 @@ class ChargeIntent:
         else:
             raise VerificationError(f"Invalid credential type: {payload_data['type']}")
 
+        return req, payload
+
+    async def validate(
+        self,
+        credential: Credential,
+        request: dict[str, Any],
+    ) -> Validation:
+        """Validate a charge credential without consuming or broadcasting it."""
+        req, payload = self._prepare_credential(credential, request)
+
         if isinstance(payload, HashCredentialPayload):
-            return await self._verify_hash(
+            await self._validate_hash(
                 payload,
                 req,
                 challenge_id=credential.challenge.id,
                 realm=credential.challenge.realm,
                 source=credential.source,
             )
+            details: dict[str, Any] = {"mode": "push"}
         else:
-            return await self._verify_transaction(
-                payload,
-                req,
-                challenge_id=credential.challenge.id,
-                realm=credential.challenge.realm,
-            )
+            self._validate_transaction_payload(payload.signature, req)
+            details = {"mode": "pull", "serializedTransaction": payload.signature}
+
+        return Validation(
+            challenge=credential.challenge,
+            credential=credential,
+            details=details,
+            intent=self.name,
+            method=credential.challenge.method,
+            request=dict(request),
+            source=credential.source,
+        )
+
+    async def broadcast(
+        self,
+        credential: Credential,
+        request: dict[str, Any],
+    ) -> Receipt:
+        """Perform the terminal charge operation."""
+        req, payload = self._prepare_credential(credential, request)
+
+        if isinstance(payload, HashCredentialPayload):
+            store_key = await self._reserve_hash(payload.hash)
+            try:
+                return await self._validate_hash(
+                    payload,
+                    req,
+                    challenge_id=credential.challenge.id,
+                    realm=credential.challenge.realm,
+                    source=credential.source,
+                )
+            except Exception:
+                if store_key is not None and self._store is not None:
+                    await self._store.delete(store_key)
+                raise
+        return await self._broadcast_transaction(
+            payload,
+            req,
+            challenge_id=credential.challenge.id,
+            realm=credential.challenge.realm,
+        )
+
+    async def verify(
+        self,
+        credential: Credential,
+        request: dict[str, Any],
+    ) -> Receipt:
+        """Backward-compatible terminal charge hook."""
+        return await self.broadcast(credential, request)
+
+    async def _reserve_hash(self, tx_hash: str) -> str | None:
+        if self._store is None:
+            return None
+        store_key = f"mpp:charge:{tx_hash.lower()}"
+        if not await self._store.put_if_absent(store_key, tx_hash):
+            raise VerificationError("Transaction hash already used")
+        return store_key
 
     def _parse_hash_credential_source(
         self, source: str | None, expected_chain_id: int
@@ -644,7 +696,7 @@ class ChargeIntent:
             )
         )
 
-    async def _verify_hash(
+    async def _validate_hash(
         self,
         payload: HashCredentialPayload,
         request: ChargeRequest,
@@ -652,33 +704,20 @@ class ChargeIntent:
         realm: str,
         source: str | None = None,
     ) -> Receipt:
-        """Verify a credential with a transaction hash."""
-        # Validate the source before reserving the hash.
+        """Validate a transaction hash without consuming its replay key."""
         source_address = self._parse_hash_credential_source(source, request.methodDetails.chainId)
 
         client = await self._get_client()
-
-        store_key: str | None = None
-        if self._store is not None:
-            store_key = f"mpp:charge:{payload.hash.lower()}"
-            if not await self._store.put_if_absent(store_key, payload.hash):
-                raise VerificationError("Transaction hash already used")
-
-        try:
-            receipt_data = await self._fetch_transaction_receipt(client, payload.hash)
-            self._verify_receipt_transfers(
-                receipt_data,
-                request,
-                challenge_id=challenge_id,
-                realm=realm,
-                source=source,
-                source_address=source_address,
-                validate_sender=self._validate_sender,
-            )
-        except Exception:
-            if self._store is not None and store_key is not None:
-                await self._store.delete(store_key)
-            raise
+        receipt_data = await self._fetch_transaction_receipt(client, payload.hash)
+        self._verify_receipt_transfers(
+            receipt_data,
+            request,
+            challenge_id=challenge_id,
+            realm=realm,
+            source=source,
+            source_address=source_address,
+            validate_sender=self._validate_sender,
+        )
 
         return Receipt.success(payload.hash)
 
@@ -951,7 +990,7 @@ class ChargeIntent:
 
         return all_matches
 
-    async def _verify_transaction(
+    async def _broadcast_transaction(
         self,
         payload: TransactionCredentialPayload,
         request: ChargeRequest,

--- a/src/mpp/methods/tempo/intents.py
+++ b/src/mpp/methods/tempo/intents.py
@@ -601,13 +601,10 @@ class ChargeIntent:
             details = {"mode": "pull", "serializedTransaction": payload.signature}
 
         return Validation(
-            challenge=credential.challenge,
             credential=credential,
             details=details,
             intent=self.name,
-            method=credential.challenge.method,
             request=dict(request),
-            source=credential.source,
         )
 
     async def broadcast(

--- a/src/mpp/methods/tempo/relay.py
+++ b/src/mpp/methods/tempo/relay.py
@@ -5,14 +5,13 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
-from datetime import datetime
-from typing import TYPE_CHECKING, Any, Literal, get_args
+from typing import TYPE_CHECKING, Any, Literal
 
 from mpp import Credential, Receipt
 from mpp._defaults import DEFAULT_TIMEOUT
-from mpp._parsing import ParseError, _b64_decode
+from mpp._parsing import ParseError, _b64_decode, _parse_timestamp
 from mpp._validation import Validation
-from mpp.errors import PaymentExpiredError, VerificationFailedError
+from mpp.errors import PaymentExpiredError, VerificationError, VerificationFailedError
 
 if TYPE_CHECKING:
     import httpx
@@ -37,7 +36,6 @@ RelayErrorCode = Literal[
     "unknown",
 ]
 
-_ERROR_CODES = frozenset(get_args(RelayErrorCode))
 _SAFE_ERROR_CODES = frozenset(
     {
         "already_used",
@@ -103,7 +101,7 @@ class Relay:
         body: dict[str, Any],
         *,
         idempotency_key: str | None = None,
-    ) -> Any:
+    ) -> dict[str, Any]:
         headers = {
             "Accept": "application/json",
             "content-type": "application/json",
@@ -119,18 +117,15 @@ class Relay:
                 json=body,
                 headers=headers,
             )
-            if not response.is_success:
-                raise _failure()
-            return response.json()
-        except (PaymentExpiredError, VerificationFailedError):
-            raise
+            result = response.json() if response.is_success else None
         except Exception:
             raise _failure() from None
-
-    async def _validate(self, body: dict[str, Any]) -> None:
-        result = await self._post("v1/mpp/validate", body)
         if not isinstance(result, dict) or result.get("success") is not True:
             raise _failure(result)
+        return result
+
+    async def _validate(self, body: dict[str, Any]) -> None:
+        await self._post("v1/mpp/validate", body)
 
     async def _broadcast(self, body: dict[str, Any]) -> Receipt:
         result = await self._post(
@@ -138,8 +133,6 @@ class Relay:
             body,
             idempotency_key=_idempotency_key(body),
         )
-        if not isinstance(result, dict) or result.get("success") is not True:
-            raise _failure(result)
         return _receipt(result.get("receipt"))
 
 
@@ -157,13 +150,10 @@ class _RelayCharge:
         body = _relay_input(credential)
         await self._relay._validate(body)
         return Validation(
-            challenge=credential.challenge,
             credential=credential,
             details={},
             intent=self.name,
-            method=credential.challenge.method,
             request=dict(request),
-            source=credential.source,
         )
 
     async def broadcast(self, credential: Credential, request: dict[str, Any]) -> Receipt:
@@ -203,14 +193,12 @@ def _idempotency_key(body: dict[str, Any]) -> str:
     if isinstance(payload, dict):
         signature = payload.get("signature")
         if payload.get("type") == "transaction" and isinstance(signature, str):
-            try:
-                raw = bytes.fromhex(signature.removeprefix("0x"))
-            except ValueError:
-                pass
-            else:
-                from eth_hash.auto import keccak
+            from mpp.methods.tempo.intents import _raw_transaction_hash
 
-                return f"pympp_0x{keccak(raw).hex()}"
+            try:
+                return f"pympp_{_raw_transaction_hash(signature)}"
+            except VerificationError:
+                pass
 
     canonical = json.dumps(body, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
     return f"pympp_0x{hashlib.sha256(canonical.encode()).hexdigest()}"
@@ -231,8 +219,8 @@ def _receipt(value: Any) -> Receipt:
     ):
         raise _failure()
     try:
-        parsed_timestamp = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
-    except ValueError:
+        parsed_timestamp = _parse_timestamp(timestamp)
+    except ParseError:
         raise _failure() from None
     if parsed_timestamp.tzinfo is None:
         raise _failure()
@@ -260,4 +248,4 @@ def _error_code(value: Any) -> str | None:
     if not isinstance(value, dict) or not isinstance(value.get("error"), dict):
         return None
     code = value["error"].get("code")
-    return code if isinstance(code, str) and code in _ERROR_CODES else None
+    return code if isinstance(code, str) else None

--- a/src/mpp/methods/tempo/relay.py
+++ b/src/mpp/methods/tempo/relay.py
@@ -1,0 +1,263 @@
+"""Tempo API relay adapter for server-side charges."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from datetime import datetime
+from typing import TYPE_CHECKING, Any, Literal, get_args
+
+from mpp import Credential, Receipt
+from mpp._defaults import DEFAULT_TIMEOUT
+from mpp._parsing import ParseError, _b64_decode
+from mpp._validation import Validation
+from mpp.errors import PaymentExpiredError, VerificationFailedError
+
+if TYPE_CHECKING:
+    import httpx
+
+    from mpp.server.intent import Intent, SplitIntent
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_API_BASE_URL = "https://api.tempo.xyz"
+
+RelayErrorCode = Literal[
+    "already_used",
+    "broadcast_failed",
+    "expired",
+    "invalid_payment",
+    "insufficient_funds",
+    "policy_denied",
+    "screen_rejected",
+    "simulation_failed",
+    "temporarily_unavailable",
+    "unsupported",
+    "unknown",
+]
+
+_ERROR_CODES = frozenset(get_args(RelayErrorCode))
+_SAFE_ERROR_CODES = frozenset(
+    {
+        "already_used",
+        "broadcast_failed",
+        "invalid_payment",
+        "insufficient_funds",
+        "simulation_failed",
+        "temporarily_unavailable",
+        "unsupported",
+    }
+)
+
+
+class Relay:
+    """Delegate Tempo charge validation and finalization to an MPP relay."""
+
+    def __init__(
+        self,
+        api_key: str,
+        api_base_url: str = DEFAULT_API_BASE_URL,
+        http_client: httpx.AsyncClient | None = None,
+        timeout: float = DEFAULT_TIMEOUT,
+    ) -> None:
+        if not api_key:
+            raise ValueError("api_key is required")
+        if not api_base_url:
+            raise ValueError("api_base_url is required")
+        self.api_key = api_key
+        self.api_base_url = api_base_url.rstrip("/") + "/"
+        self._client = http_client
+        self._owns_client = http_client is None
+        self._timeout = timeout
+
+    def configure(self, intent: Intent) -> SplitIntent:
+        """Replace a charge intent's lifecycle hooks with relay calls."""
+        if intent.name != "charge":
+            raise ValueError("Relay can only configure a charge intent")
+        return _RelayCharge(self)
+
+    async def __aenter__(self) -> Relay:
+        await self._get_client()
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        await self.aclose()
+
+    async def aclose(self) -> None:
+        """Close the internally owned HTTP client."""
+        if self._owns_client and self._client is not None:
+            await self._client.aclose()
+            self._client = None
+
+    async def _get_client(self) -> httpx.AsyncClient:
+        if self._client is None:
+            import httpx
+
+            self._client = httpx.AsyncClient(timeout=self._timeout)
+        return self._client
+
+    async def _post(
+        self,
+        path: str,
+        body: dict[str, Any],
+        *,
+        idempotency_key: str | None = None,
+    ) -> Any:
+        headers = {
+            "Accept": "application/json",
+            "content-type": "application/json",
+            "tempo-api-key": self.api_key,
+        }
+        if idempotency_key is not None:
+            headers["idempotency-key"] = idempotency_key
+
+        logger.debug("relay request method=POST path=/%s", path)
+        try:
+            response = await (await self._get_client()).post(
+                self.api_base_url + path,
+                json=body,
+                headers=headers,
+            )
+            if not response.is_success:
+                raise _failure()
+            return response.json()
+        except (PaymentExpiredError, VerificationFailedError):
+            raise
+        except Exception:
+            raise _failure() from None
+
+    async def _validate(self, body: dict[str, Any]) -> None:
+        result = await self._post("v1/mpp/validate", body)
+        if not isinstance(result, dict) or result.get("success") is not True:
+            raise _failure(result)
+
+    async def _broadcast(self, body: dict[str, Any]) -> Receipt:
+        result = await self._post(
+            "v1/mpp/broadcast",
+            body,
+            idempotency_key=_idempotency_key(body),
+        )
+        if not isinstance(result, dict) or result.get("success") is not True:
+            raise _failure(result)
+        return _receipt(result.get("receipt"))
+
+
+class _RelayCharge:
+    name = "charge"
+
+    def __init__(self, relay: Relay) -> None:
+        self._relay = relay
+
+    async def validate(
+        self,
+        credential: Credential,
+        request: dict[str, Any],
+    ) -> Validation:
+        body = _relay_input(credential)
+        await self._relay._validate(body)
+        return Validation(
+            challenge=credential.challenge,
+            credential=credential,
+            details={},
+            intent=self.name,
+            method=credential.challenge.method,
+            request=dict(request),
+            source=credential.source,
+        )
+
+    async def broadcast(self, credential: Credential, request: dict[str, Any]) -> Receipt:
+        return await self._relay._broadcast(_relay_input(credential))
+
+    async def verify(self, credential: Credential, request: dict[str, Any]) -> Receipt:
+        await self.validate(credential, request)
+        return await self.broadcast(credential, request)
+
+
+def _relay_input(credential: Credential) -> dict[str, Any]:
+    try:
+        request = _b64_decode(credential.challenge.request)
+    except ParseError:
+        raise _failure() from None
+
+    echo = credential.challenge
+    challenge: dict[str, Any] = {
+        "id": echo.id,
+        "realm": echo.realm,
+        "method": echo.method,
+        "intent": echo.intent,
+        "request": request,
+    }
+    for name in ("expires", "digest", "opaque"):
+        if (value := getattr(echo, name)) is not None:
+            challenge[name] = value
+
+    result: dict[str, Any] = {"challenge": challenge, "payload": credential.payload}
+    if credential.source:
+        result["source"] = credential.source
+    return result
+
+
+def _idempotency_key(body: dict[str, Any]) -> str:
+    payload = body.get("payload")
+    if isinstance(payload, dict):
+        signature = payload.get("signature")
+        if payload.get("type") == "transaction" and isinstance(signature, str):
+            try:
+                raw = bytes.fromhex(signature.removeprefix("0x"))
+            except ValueError:
+                pass
+            else:
+                from eth_hash.auto import keccak
+
+                return f"pympp_0x{keccak(raw).hex()}"
+
+    canonical = json.dumps(body, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+    return f"pympp_0x{hashlib.sha256(canonical.encode()).hexdigest()}"
+
+
+def _receipt(value: Any) -> Receipt:
+    if not isinstance(value, dict):
+        raise _failure()
+    method = value.get("method")
+    reference = value.get("reference")
+    timestamp = value.get("timestamp")
+    external_id = value.get("externalId")
+    if (
+        method != "tempo"
+        or not isinstance(reference, str)
+        or not isinstance(timestamp, str)
+        or (external_id is not None and not isinstance(external_id, str))
+    ):
+        raise _failure()
+    try:
+        parsed_timestamp = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+    except ValueError:
+        raise _failure() from None
+    if parsed_timestamp.tzinfo is None:
+        raise _failure()
+    return Receipt.success(
+        reference,
+        timestamp=parsed_timestamp,
+        method=method,
+        external_id=external_id,
+    )
+
+
+def _failure(value: Any = None) -> VerificationFailedError | PaymentExpiredError:
+    code = _error_code(value)
+    if code == "expired":
+        return PaymentExpiredError()
+    if code in _SAFE_ERROR_CODES:
+        details = {"code": code}
+        if code == "temporarily_unavailable":
+            details["retry"] = "same_credential"
+        return VerificationFailedError(details=details)
+    return VerificationFailedError()
+
+
+def _error_code(value: Any) -> str | None:
+    if not isinstance(value, dict) or not isinstance(value.get("error"), dict):
+        return None
+    code = value["error"].get("code")
+    return code if isinstance(code, str) and code in _ERROR_CODES else None

--- a/src/mpp/server/__init__.py
+++ b/src/mpp/server/__init__.py
@@ -49,7 +49,6 @@ from mpp.server.intent import (
     broadcast_credential,
     intent,
     validate_credential,
-    verify_credential,
 )
 from mpp.server.method import Method, transform_request
 from mpp.server.mpp import Mpp

--- a/src/mpp/server/__init__.py
+++ b/src/mpp/server/__init__.py
@@ -41,7 +41,16 @@ from mpp.events import (
     PaymentEventName,
 )
 from mpp.server.decorator import pay
-from mpp.server.intent import Intent, VerificationError, intent
+from mpp.server.intent import (
+    Intent,
+    SplitIntent,
+    Validation,
+    VerificationError,
+    broadcast_credential,
+    intent,
+    validate_credential,
+    verify_credential,
+)
 from mpp.server.method import Method, transform_request
 from mpp.server.mpp import Mpp
 from mpp.server.verify import verify_or_challenge

--- a/src/mpp/server/intent.py
+++ b/src/mpp/server/intent.py
@@ -7,13 +7,17 @@ and provides verification logic.
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
-from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, cast, runtime_checkable
 
 if TYPE_CHECKING:
     from mpp import Credential, Receipt
 
 
-from mpp.errors import VerificationError as VerificationError  # noqa: F401 — re-export
+from mpp._validation import Validation
+from mpp.errors import (
+    VerificationError as VerificationError,  # noqa: F401 — re-export
+)
+from mpp.errors import VerificationFailedError
 
 
 @runtime_checkable
@@ -56,6 +60,73 @@ class Intent(Protocol):
             VerificationError: If the credential is invalid or payment failed.
         """
         ...
+
+
+@runtime_checkable
+class SplitIntent(Intent, Protocol):
+    """Intent with separate validation and terminal broadcast hooks."""
+
+    async def validate(
+        self,
+        credential: Credential,
+        request: dict[str, Any],
+    ) -> Validation: ...
+
+    async def broadcast(
+        self,
+        credential: Credential,
+        request: dict[str, Any],
+    ) -> Receipt: ...
+
+
+async def validate_credential(
+    *,
+    intent: Intent,
+    credential: Credential,
+    request: dict[str, Any],
+) -> Validation:
+    """Validate a credential without consuming payment state."""
+    validate = cast(
+        "Callable[[Credential, dict[str, Any]], Awaitable[Validation]] | None",
+        getattr(intent, "validate", None),
+    )
+    if not callable(validate):
+        raise VerificationFailedError(
+            f"{intent.name} does not support non-mutating credential validation"
+        )
+    result = await validate(credential, request)
+    if not isinstance(result, Validation):
+        raise VerificationFailedError("Intent returned an invalid validation result")
+    return result
+
+
+async def broadcast_credential(
+    *,
+    intent: Intent,
+    credential: Credential,
+    request: dict[str, Any],
+) -> Receipt:
+    """Revalidate and perform the credential's terminal payment operation."""
+    validate = getattr(intent, "validate", None)
+    broadcast = cast(
+        "Callable[[Credential, dict[str, Any]], Awaitable[Receipt]] | None",
+        getattr(intent, "broadcast", None),
+    )
+    if callable(validate) and callable(broadcast):
+        await validate_credential(intent=intent, credential=credential, request=request)
+    if callable(broadcast):
+        return await broadcast(credential, request)
+    return await intent.verify(credential, request)
+
+
+async def verify_credential(
+    *,
+    intent: Intent,
+    credential: Credential,
+    request: dict[str, Any],
+) -> Receipt:
+    """Backward-compatible alias for :func:`broadcast_credential`."""
+    return await broadcast_credential(intent=intent, credential=credential, request=request)
 
 
 class FunctionalIntent:

--- a/src/mpp/server/intent.py
+++ b/src/mpp/server/intent.py
@@ -7,7 +7,7 @@ and provides verification logic.
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
-from typing import TYPE_CHECKING, Any, Protocol, cast, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
     from mpp import Credential, Receipt
@@ -86,15 +86,11 @@ async def validate_credential(
     request: dict[str, Any],
 ) -> Validation:
     """Validate a credential without consuming payment state."""
-    validate = cast(
-        "Callable[[Credential, dict[str, Any]], Awaitable[Validation]] | None",
-        getattr(intent, "validate", None),
-    )
-    if not callable(validate):
+    if not isinstance(intent, SplitIntent):
         raise VerificationFailedError(
             f"{intent.name} does not support non-mutating credential validation"
         )
-    result = await validate(credential, request)
+    result = await intent.validate(credential, request)
     if not isinstance(result, Validation):
         raise VerificationFailedError("Intent returned an invalid validation result")
     return result
@@ -107,26 +103,10 @@ async def broadcast_credential(
     request: dict[str, Any],
 ) -> Receipt:
     """Revalidate and perform the credential's terminal payment operation."""
-    validate = getattr(intent, "validate", None)
-    broadcast = cast(
-        "Callable[[Credential, dict[str, Any]], Awaitable[Receipt]] | None",
-        getattr(intent, "broadcast", None),
-    )
-    if callable(validate) and callable(broadcast):
+    if isinstance(intent, SplitIntent):
         await validate_credential(intent=intent, credential=credential, request=request)
-    if callable(broadcast):
-        return await broadcast(credential, request)
+        return await intent.broadcast(credential, request)
     return await intent.verify(credential, request)
-
-
-async def verify_credential(
-    *,
-    intent: Intent,
-    credential: Credential,
-    request: dict[str, Any],
-) -> Receipt:
-    """Backward-compatible alias for :func:`broadcast_credential`."""
-    return await broadcast_credential(intent=intent, credential=credential, request=request)
 
 
 class FunctionalIntent:

--- a/src/mpp/server/mpp.py
+++ b/src/mpp/server/mpp.py
@@ -6,8 +6,15 @@ from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any, TypeVar
 
-from mpp import Challenge, Credential, Receipt
-from mpp._units import parse_units
+from mpp import Challenge, Credential, Receipt, _constant_time_equal, generate_challenge_id
+from mpp._parsing import ParseError, _b64_decode
+from mpp._units import parse_units, transform_units
+from mpp.errors import (
+    InvalidChallengeError,
+    MalformedCredentialError,
+    PaymentExpiredError,
+    PaymentMethodUnsupportedError,
+)
 from mpp.events import (
     CHALLENGE_CREATED,
     PAYMENT_FAILED,
@@ -23,11 +30,15 @@ from mpp.server.decorator import (
     resolve_body_param,
     wrap_payment_handler,
 )
+from mpp.server.intent import Validation
+from mpp.server.intent import broadcast_credential as broadcast_intent_credential
+from mpp.server.intent import validate_credential as validate_intent_credential
 from mpp.server.method import transform_request
 from mpp.server.verify import verify_or_challenge
 from mpp.store import Store
 
 if TYPE_CHECKING:
+    from mpp.server.intent import Intent
     from mpp.server.method import Method
 
 R = TypeVar("R")
@@ -119,6 +130,125 @@ class Mpp:
         for intent_obj in intents.values():
             if hasattr(intent_obj, "_store") and intent_obj._store is None:
                 intent_obj._store = store
+
+    def _prepare_credential(
+        self,
+        value: Credential | str,
+        *,
+        intent: str | None,
+        request: dict[str, Any] | None,
+    ) -> tuple[Credential, Intent, dict[str, Any]]:
+        """Authenticate and resolve a credential outside an HTTP route."""
+        if isinstance(value, Credential):
+            credential = value
+        else:
+            authorization = value if value.lower().startswith("payment ") else f"Payment {value}"
+            try:
+                credential = Credential.from_authorization(authorization)
+            except ParseError as error:
+                raise MalformedCredentialError(str(error)) from error
+
+        echo = credential.challenge
+        try:
+            echoed_request = _b64_decode(echo.request) if echo.request else {}
+            echoed_opaque = _b64_decode(echo.opaque) if echo.opaque else None
+        except ParseError as error:
+            raise MalformedCredentialError(str(error)) from error
+
+        if echo.realm != self.realm:
+            raise InvalidChallengeError(echo.id, "credential realm does not match")
+        if echo.method != self.method.name:
+            raise PaymentMethodUnsupportedError(echo.method)
+        if intent is not None and echo.intent != intent:
+            raise InvalidChallengeError(echo.id, "credential intent does not match")
+
+        expected_id = generate_challenge_id(
+            secret_key=self.secret_key,
+            realm=echo.realm,
+            method=echo.method,
+            intent=echo.intent,
+            request=echoed_request,
+            expires=echo.expires,
+            digest=echo.digest,
+            opaque=echoed_opaque,
+        )
+        if not _constant_time_equal(echo.id, expected_id):
+            raise InvalidChallengeError(echo.id, "challenge was not issued by this server")
+
+        try:
+            expires = datetime.fromisoformat((echo.expires or "").replace("Z", "+00:00"))
+            if expires.tzinfo is None:
+                raise ValueError
+        except (TypeError, ValueError) as error:
+            raise PaymentExpiredError(echo.expires) from error
+        if expires < datetime.now(UTC):
+            raise PaymentExpiredError(echo.expires)
+
+        if request is not None:
+            expected_request = transform_request(
+                self.method,
+                transform_units(request),
+                credential,
+            )
+            if expected_request != echoed_request:
+                raise InvalidChallengeError(echo.id, "credential request does not match")
+
+        intent_obj = self.method.intents.get(echo.intent)
+        if intent_obj is None:
+            raise PaymentMethodUnsupportedError(f"{echo.method}/{echo.intent}")
+        return credential, intent_obj, echoed_request
+
+    async def validate_credential(
+        self,
+        credential: Credential | str,
+        *,
+        intent: str | None = None,
+        request: dict[str, Any] | None = None,
+    ) -> Validation:
+        """Validate a bound credential without consuming payment state."""
+        prepared, intent_obj, echoed_request = self._prepare_credential(
+            credential,
+            intent=intent,
+            request=request,
+        )
+        return await validate_intent_credential(
+            intent=intent_obj,
+            credential=prepared,
+            request=echoed_request,
+        )
+
+    async def broadcast_credential(
+        self,
+        credential: Credential | str,
+        *,
+        intent: str | None = None,
+        request: dict[str, Any] | None = None,
+    ) -> Receipt:
+        """Revalidate and perform a bound credential's terminal operation."""
+        prepared, intent_obj, echoed_request = self._prepare_credential(
+            credential,
+            intent=intent,
+            request=request,
+        )
+        return await broadcast_intent_credential(
+            intent=intent_obj,
+            credential=prepared,
+            request=echoed_request,
+        )
+
+    async def verify_credential(
+        self,
+        credential: Credential | str,
+        *,
+        intent: str | None = None,
+        request: dict[str, Any] | None = None,
+    ) -> Receipt:
+        """Backward-compatible alias for :meth:`broadcast_credential`."""
+        return await self.broadcast_credential(
+            credential,
+            intent=intent,
+            request=request,
+        )
 
     @classmethod
     def create(

--- a/src/mpp/server/mpp.py
+++ b/src/mpp/server/mpp.py
@@ -6,8 +6,8 @@ from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any, TypeVar
 
-from mpp import Challenge, Credential, Receipt, _constant_time_equal, generate_challenge_id
-from mpp._parsing import ParseError, _b64_decode
+from mpp import Challenge, Credential, Receipt
+from mpp._parsing import ParseError, _parse_timestamp
 from mpp._units import parse_units, transform_units
 from mpp.errors import (
     InvalidChallengeError,
@@ -34,7 +34,7 @@ from mpp.server.intent import Validation
 from mpp.server.intent import broadcast_credential as broadcast_intent_credential
 from mpp.server.intent import validate_credential as validate_intent_credential
 from mpp.server.method import transform_request
-from mpp.server.verify import verify_or_challenge
+from mpp.server.verify import _authenticate_echo, verify_or_challenge
 from mpp.store import Store
 
 if TYPE_CHECKING:
@@ -149,11 +149,7 @@ class Mpp:
                 raise MalformedCredentialError(str(error)) from error
 
         echo = credential.challenge
-        try:
-            echoed_request = _b64_decode(echo.request) if echo.request else {}
-            echoed_opaque = _b64_decode(echo.opaque) if echo.opaque else None
-        except ParseError as error:
-            raise MalformedCredentialError(str(error)) from error
+        echoed_request, _ = _authenticate_echo(credential, secret_key=self.secret_key)
 
         if echo.realm != self.realm:
             raise InvalidChallengeError(echo.id, "credential realm does not match")
@@ -162,26 +158,13 @@ class Mpp:
         if intent is not None and echo.intent != intent:
             raise InvalidChallengeError(echo.id, "credential intent does not match")
 
-        expected_id = generate_challenge_id(
-            secret_key=self.secret_key,
-            realm=echo.realm,
-            method=echo.method,
-            intent=echo.intent,
-            request=echoed_request,
-            expires=echo.expires,
-            digest=echo.digest,
-            opaque=echoed_opaque,
-        )
-        if not _constant_time_equal(echo.id, expected_id):
-            raise InvalidChallengeError(echo.id, "challenge was not issued by this server")
-
+        if not echo.expires:
+            raise PaymentExpiredError(echo.expires)
         try:
-            expires = datetime.fromisoformat((echo.expires or "").replace("Z", "+00:00"))
-            if expires.tzinfo is None:
-                raise ValueError
-        except (TypeError, ValueError) as error:
+            expires = _parse_timestamp(echo.expires)
+        except ParseError as error:
             raise PaymentExpiredError(echo.expires) from error
-        if expires < datetime.now(UTC):
+        if expires.tzinfo is None or expires < datetime.now(UTC):
             raise PaymentExpiredError(echo.expires)
 
         if request is not None:

--- a/src/mpp/server/verify.py
+++ b/src/mpp/server/verify.py
@@ -21,6 +21,7 @@ from mpp.errors import (
     PaymentExpiredError,
 )
 from mpp.events import CHALLENGE_CREATED, PAYMENT_FAILED, PAYMENT_SUCCESS, EventDispatcher
+from mpp.server.intent import broadcast_credential
 
 DEFAULT_EXPIRES_MINUTES = 5
 
@@ -210,7 +211,11 @@ async def verify_or_challenge(
         return await fail(PaymentExpiredError(echo.expires), credential)
 
     try:
-        receipt: Receipt = await intent.verify(credential, request)
+        receipt = await broadcast_credential(
+            intent=intent,
+            credential=credential,
+            request=request,
+        )
     except Exception as error:
         if events is not None:
             await events.emit(

--- a/src/mpp/server/verify.py
+++ b/src/mpp/server/verify.py
@@ -152,26 +152,9 @@ async def verify_or_challenge(
     # echoed parameters and compare to the credential's challenge ID.
     echo = credential.challenge
     try:
-        echo_request = _b64_decode(echo.request) if echo.request else {}
-        echo_opaque = _b64_decode(echo.opaque) if echo.opaque else None
-    except ParseError as error:
-        return await fail(MalformedCredentialError(str(error)), credential)
-
-    expected_id = generate_challenge_id(
-        secret_key=secret_key,
-        realm=echo.realm,
-        method=echo.method,
-        intent=echo.intent,
-        request=echo_request,
-        expires=echo.expires,
-        digest=echo.digest,
-        opaque=echo_opaque,
-    )
-    if not _constant_time_equal(echo.id, expected_id):
-        return await fail(
-            InvalidChallengeError(echo.id, "challenge was not issued by this server"),
-            credential,
-        )
+        echo_request, echo_opaque = _authenticate_echo(credential, secret_key=secret_key)
+    except (MalformedCredentialError, InvalidChallengeError) as error:
+        return await fail(error, credential)
 
     # Reject credentials minted for a different realm, method, or intent.
     # This still returns a new Challenge; the only new behavior is the
@@ -245,6 +228,45 @@ async def verify_or_challenge(
         )
 
     return (credential, receipt)
+
+
+def _authenticate_echo(
+    credential: Credential,
+    *,
+    secret_key: str,
+) -> tuple[dict[str, Any], dict[str, Any] | None]:
+    """Authenticate a credential's echoed challenge against the server secret.
+
+    Decodes the echoed request/opaque, recomputes the HMAC-bound challenge ID,
+    and compares it in constant time.
+
+    Returns:
+        The decoded (request, opaque) echoed by the credential.
+
+    Raises:
+        MalformedCredentialError: If the echoed parameters cannot be decoded.
+        InvalidChallengeError: If the challenge ID was not issued by this server.
+    """
+    echo = credential.challenge
+    try:
+        echo_request = _b64_decode(echo.request) if echo.request else {}
+        echo_opaque = _b64_decode(echo.opaque) if echo.opaque else None
+    except ParseError as error:
+        raise MalformedCredentialError(str(error)) from error
+
+    expected_id = generate_challenge_id(
+        secret_key=secret_key,
+        realm=echo.realm,
+        method=echo.method,
+        intent=echo.intent,
+        request=echo_request,
+        expires=echo.expires,
+        digest=echo.digest,
+        opaque=echo_opaque,
+    )
+    if not _constant_time_equal(echo.id, expected_id):
+        raise InvalidChallengeError(echo.id, "challenge was not issued by this server")
+    return echo_request, echo_opaque
 
 
 def _create_challenge(

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -1,0 +1,202 @@
+"""Tests for split credential validation and broadcast."""
+
+from dataclasses import replace
+
+import pytest
+
+from mpp import Challenge, Credential, Receipt
+from mpp.errors import InvalidChallengeError, VerificationFailedError
+from mpp.server import (
+    Intent,
+    Mpp,
+    Validation,
+    broadcast_credential,
+    validate_credential,
+    verify_or_challenge,
+)
+from tests import make_bound_credential, make_credential
+
+
+class SplitCharge:
+    name = "charge"
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    async def validate(self, credential: Credential, request: dict) -> Validation:
+        self.calls.append("validate")
+        return Validation(
+            challenge=credential.challenge,
+            credential=credential,
+            details={"mode": "pull"},
+            intent=self.name,
+            method=credential.challenge.method,
+            request=request,
+            source=credential.source,
+        )
+
+    async def broadcast(self, credential: Credential, request: dict) -> Receipt:
+        self.calls.append("broadcast")
+        return Receipt.success("split-reference")
+
+    async def verify(self, credential: Credential, request: dict) -> Receipt:
+        self.calls.append("verify")
+        return Receipt.success("legacy-reference")
+
+
+class FakeMethod:
+    name = "tempo"
+
+    def __init__(self, charge: SplitCharge) -> None:
+        self.intents: dict[str, Intent] = {"charge": charge}
+
+    async def create_credential(self, challenge: Challenge) -> Credential:  # pragma: no cover
+        raise NotImplementedError
+
+
+@pytest.mark.asyncio
+async def test_validation_is_non_mutating() -> None:
+    intent = SplitCharge()
+    result = await validate_credential(
+        intent=intent,
+        credential=make_credential(payload={}),
+        request={"amount": "1000"},
+    )
+
+    assert result.details == {"mode": "pull"}
+    assert intent.calls == ["validate"]
+
+
+@pytest.mark.asyncio
+async def test_broadcast_revalidates_before_terminal_hook() -> None:
+    intent = SplitCharge()
+    receipt = await broadcast_credential(
+        intent=intent,
+        credential=make_credential(payload={}),
+        request={},
+    )
+
+    assert receipt.reference == "split-reference"
+    assert intent.calls == ["validate", "broadcast"]
+
+
+@pytest.mark.asyncio
+async def test_legacy_intent_falls_back_to_verify() -> None:
+    calls: list[str] = []
+
+    class LegacyCharge:
+        name = "charge"
+
+        async def verify(self, credential: Credential, request: dict) -> Receipt:
+            calls.append("verify")
+            return Receipt.success("legacy-reference")
+
+    legacy = LegacyCharge()
+    with pytest.raises(VerificationFailedError, match="non-mutating"):
+        await validate_credential(
+            intent=legacy,
+            credential=make_credential(payload={}),
+            request={},
+        )
+
+    receipt = await broadcast_credential(
+        intent=legacy,
+        credential=make_credential(payload={}),
+        request={},
+    )
+    assert receipt.reference == "legacy-reference"
+    assert calls == ["verify"]
+
+
+@pytest.mark.asyncio
+async def test_route_uses_split_lifecycle() -> None:
+    intent = SplitCharge()
+    request = {"amount": "1000"}
+    credential = make_bound_credential(
+        payload={},
+        request=request,
+        realm="api.example.com",
+        secret_key="test-secret",
+    )
+
+    result = await verify_or_challenge(
+        authorization=credential.to_authorization(),
+        intent=intent,
+        request=request,
+        realm="api.example.com",
+        secret_key="test-secret",
+    )
+
+    assert isinstance(result, tuple)
+    assert result[1].reference == "split-reference"
+    assert intent.calls == ["validate", "broadcast"]
+
+
+@pytest.mark.asyncio
+async def test_mpp_exposes_bound_lifecycle() -> None:
+    intent = SplitCharge()
+    server = Mpp.create(
+        method=FakeMethod(intent),
+        realm="api.example.com",
+        secret_key="test-secret",
+    )
+    request = {"amount": "1000"}
+    credential = make_bound_credential(
+        payload={},
+        request=request,
+        realm=server.realm,
+        secret_key=server.secret_key,
+    )
+
+    validation = await server.validate_credential(credential.to_authorization(), request=request)
+    receipt = await server.broadcast_credential(credential, intent="charge", request=request)
+    alias_receipt = await server.verify_credential(credential)
+
+    assert validation.request == request
+    assert receipt.reference == "split-reference"
+    assert alias_receipt.reference == "split-reference"
+    assert intent.calls == [
+        "validate",
+        "validate",
+        "broadcast",
+        "validate",
+        "broadcast",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_mpp_rejects_tampered_bound_credential() -> None:
+    intent = SplitCharge()
+    server = Mpp.create(
+        method=FakeMethod(intent),
+        realm="api.example.com",
+        secret_key="test-secret",
+    )
+    credential = make_bound_credential(
+        payload={},
+        request={},
+        realm=server.realm,
+        secret_key=server.secret_key,
+    )
+    credential = replace(
+        credential,
+        challenge=replace(credential.challenge, id="tampered"),
+    )
+
+    with pytest.raises(InvalidChallengeError):
+        await server.validate_credential(credential)
+    assert intent.calls == []
+
+
+@pytest.mark.asyncio
+async def test_invalid_validation_result_is_rejected() -> None:
+    class InvalidSplit(SplitCharge):
+        async def validate(self, credential: Credential, request: dict) -> Validation:
+            return {}  # type: ignore[return-value]
+
+    with pytest.raises(VerificationFailedError, match="invalid validation result"):
+        await validate_credential(
+            intent=InvalidSplit(),
+            credential=make_credential(payload={}),
+            request={},
+        )

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -26,13 +26,10 @@ class SplitCharge:
     async def validate(self, credential: Credential, request: dict) -> Validation:
         self.calls.append("validate")
         return Validation(
-            challenge=credential.challenge,
             credential=credential,
             details={"mode": "pull"},
             intent=self.name,
-            method=credential.challenge.method,
             request=request,
-            source=credential.source,
         )
 
     async def broadcast(self, credential: Credential, request: dict) -> Receipt:

--- a/tests/test_tempo_relay.py
+++ b/tests/test_tempo_relay.py
@@ -1,0 +1,225 @@
+"""Tests for the Tempo API relay adapter."""
+
+import json
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+from eth_hash.auto import keccak
+
+from mpp import Credential, Receipt
+from mpp.errors import PaymentExpiredError, VerificationFailedError
+from mpp.methods.tempo import ChargeIntent, Relay, tempo
+from mpp.server import broadcast_credential
+from mpp.store import MemoryStore
+from tests import make_bound_credential, make_credential
+
+
+def credential(payload: dict | None = None) -> Credential:
+    return make_bound_credential(
+        payload=payload or {"type": "transaction", "signature": "0x1234"},
+        request={"amount": "1000"},
+        source="did:pkh:eip155:42431:0x1234567890123456789012345678901234567890",
+    )
+
+
+def response(body: dict, status: int = 200) -> httpx.Response:
+    return httpx.Response(status, json=body)
+
+
+@pytest.mark.asyncio
+async def test_relay_validates_then_broadcasts_with_idempotency() -> None:
+    calls: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(request)
+        if request.url.path.endswith("/validate"):
+            return response({"success": True})
+        return response(
+            {
+                "success": True,
+                "receipt": {
+                    "method": "tempo",
+                    "reference": "0xabc",
+                    "timestamp": "2026-08-05T12:00:00Z",
+                },
+            }
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        method = tempo(
+            intents={"charge": ChargeIntent()},
+            relay=Relay(
+                api_key="tempo:sk:test",
+                api_base_url="https://relay.example/mpp",
+                http_client=client,
+            ),
+        )
+        result = await broadcast_credential(
+            intent=method.intents["charge"],
+            credential=credential(),
+            request={"amount": "1000"},
+        )
+
+    assert result.reference == "0xabc"
+    assert [call.url.path for call in calls] == [
+        "/mpp/v1/mpp/validate",
+        "/mpp/v1/mpp/broadcast",
+    ]
+    assert calls[0].headers["tempo-api-key"] == "tempo:sk:test"
+    expected_key = "pympp_0x" + keccak(bytes.fromhex("1234")).hex()
+    assert calls[1].headers["idempotency-key"] == expected_key
+    body = json.loads(calls[0].content)
+    assert body["challenge"]["request"] == {"amount": "1000"}
+    assert body["payload"] == {"type": "transaction", "signature": "0x1234"}
+
+
+@pytest.mark.asyncio
+async def test_relay_finalizes_pushed_hash_credential() -> None:
+    paths: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        paths.append(request.url.path)
+        if request.url.path.endswith("/validate"):
+            return response({"success": True})
+        return response(
+            {
+                "success": True,
+                "receipt": {
+                    "method": "tempo",
+                    "reference": "0xpushed",
+                    "timestamp": "2026-08-05T12:00:00+00:00",
+                },
+            }
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        method = tempo(
+            intents={"charge": ChargeIntent()},
+            relay=Relay(api_key="key", http_client=client),
+        )
+        result = await broadcast_credential(
+            intent=method.intents["charge"],
+            credential=credential({"type": "hash", "hash": "0xpushed"}),
+            request={"amount": "1000"},
+        )
+
+    assert result.reference == "0xpushed"
+    assert paths == ["/v1/mpp/validate", "/v1/mpp/broadcast"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("code", "details"),
+    [
+        ("already_used", {"code": "already_used"}),
+        (
+            "temporarily_unavailable",
+            {"code": "temporarily_unavailable", "retry": "same_credential"},
+        ),
+    ],
+)
+async def test_relay_exposes_only_safe_error_details(code: str, details: dict) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return response({"success": False, "error": {"code": code, "message": "private"}})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        method = tempo(
+            intents={"charge": ChargeIntent()},
+            relay=Relay(api_key="key", http_client=client),
+        )
+        with pytest.raises(VerificationFailedError) as raised:
+            await method.intents["charge"].validate(credential(), {"amount": "1000"})  # type: ignore[attr-defined]
+
+    assert raised.value.details == details
+    assert raised.value.to_problem_details()["details"] == details
+    assert "private" not in str(raised.value)
+
+
+@pytest.mark.asyncio
+async def test_relay_hides_policy_errors() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return response(
+            {
+                "success": False,
+                "error": {"code": "policy_denied", "message": "private policy detail"},
+            }
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        method = tempo(
+            intents={"charge": ChargeIntent()},
+            relay=Relay(api_key="key", http_client=client),
+        )
+        with pytest.raises(VerificationFailedError) as raised:
+            await method.intents["charge"].validate(credential(), {})  # type: ignore[attr-defined]
+
+    assert raised.value.details is None
+    assert "policy" not in str(raised.value)
+
+
+@pytest.mark.asyncio
+async def test_relay_maps_expired_error() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return response({"success": False, "error": {"code": "expired"}})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        method = tempo(
+            intents={"charge": ChargeIntent()},
+            relay=Relay(api_key="key", http_client=client),
+        )
+        with pytest.raises(PaymentExpiredError):
+            await method.intents["charge"].validate(credential(), {})  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_relay_rejects_invalid_receipt() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/validate"):
+            return response({"success": True})
+        return response({"success": True, "receipt": {"method": "stripe"}})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        method = tempo(
+            intents={"charge": ChargeIntent()},
+            relay=Relay(api_key="key", http_client=client),
+        )
+        with pytest.raises(VerificationFailedError):
+            await broadcast_credential(
+                intent=method.intents["charge"],
+                credential=credential(),
+                request={},
+            )
+
+
+def test_relay_requires_charge_intent() -> None:
+    with pytest.raises(ValueError, match="charge intent"):
+        tempo(intents={}, relay=Relay(api_key="key"))
+
+
+@pytest.mark.asyncio
+async def test_charge_validation_does_not_consume_hash() -> None:
+    store = MemoryStore()
+    intent = ChargeIntent(rpc_url="https://rpc.test", store=store)
+    payment = make_credential(
+        payload={"type": "hash", "hash": "0xabc"},
+        expires=(datetime.now(UTC) + timedelta(hours=1)).isoformat(),
+    )
+
+    with patch.object(
+        intent,
+        "_validate_hash",
+        AsyncMock(return_value=Receipt.success("0xabc")),
+    ):
+        result = await intent.validate(
+            payment,
+            {
+                "amount": "1000",
+                "currency": "0x1234567890123456789012345678901234567890",
+                "recipient": "0x4567890123456789012345678901234567890123",
+            },
+        )
+
+    assert result.details == {"mode": "push"}
+    assert await store.get("mpp:charge:0xabc") is None


### PR DESCRIPTION
Simplified variant of #204 — same feature and behavior (816 tests pass identically), with a cleanup pass applied as a second commit.

## Why

pympp needs a non-mutating credential preflight and a separate terminal phase so Tempo charge servers can delegate payment finalization to the Tempo API relay safely.

## What

- add split `validate` and `broadcast` lifecycle hooks while preserving `verify` as the terminal compatibility path
- add bound and low-level credential lifecycle APIs with challenge authentication and revalidation
- add Tempo API relay configuration with deterministic idempotency, safe errors, and push/pull finalization
- split local Tempo charge validation from broadcast without weakening replay protection
- add focused coverage and a runnable FastAPI Moderato example with a payer client

## Simplifications vs #204

- **Single challenge-authentication core.** `Mpp._prepare_credential` re-implemented the echo decode → HMAC recompute → constant-time compare sequence that `verify_or_challenge` already performs. Both now call a shared `_authenticate_echo` in `server/verify.py`, so the security-critical binding logic exists once. (The copies had already drifted: one enforced tz-aware expiry, the other didn't.)
- **`Validation` stores only what isn't derivable.** `challenge`, `method`, and `source` were copies of what `credential` already carries and had to be echoed by every `SplitIntent` implementation; they are now read-only properties, and construction shrinks from 7 kwargs to 4 at every site.
- **Dispatch on the `SplitIntent` protocol.** `validate_credential`/`broadcast_credential` probed hooks with `getattr` + `callable` + `cast`, admitting untested half-shapes (broadcast-without-validate, validate-without-broadcast). They now use `isinstance(intent, SplitIntent)` — the protocol this PR defines becomes the mechanism instead of documentation.
- **Reuse existing helpers.** `relay._receipt` and `Mpp._prepare_credential` re-inlined the Z-suffix timestamp parsing that `_parsing._parse_timestamp` provides; `_idempotency_key` re-implemented the raw-tx keccak that `_raw_transaction_hash` provides. Both now call the existing helpers, so the idempotency key can't silently diverge from the tx hash used elsewhere.
- **Flatter relay error flow.** `Relay._post` raised inside its own `try`, forcing a re-raise allowlist, and both callers repeated the same success-envelope check. The envelope check now lives in `_post` after the transport `try`; `_validate` collapses to one line.
- **Dropped inert code.** The `_ERROR_CODES` membership filter changed no behavior (codes outside `_SAFE_ERROR_CODES` map to a bare failure either way). The module-level `verify_credential` free function aliased a name that never existed before this PR and had no callers; `Mpp.verify_credential()` (documented in the example) stays.
- **`PaymentError.details` follows the `hint` idiom** — a class attribute with default instead of a base `__init__` override; `VerificationFailedError` (the only raiser that sets it) assigns the instance attribute.

Net: −27 lines against #204 with behavior preserved.

## Flagged but intentionally not changed

Review findings that touch documented design decisions, left for discussion:

- **`broadcast_credential` revalidates before every broadcast** while both shipped `broadcast` implementations also validate internally. On the standard `verify_or_challenge` path this means a hash credential fetches its tx receipt over RPC twice per payment (main did once), and a relay charge makes an extra HTTPS round trip. Kept because the revalidate-before-terminal contract is explicit (README, test); if the terminal hooks are instead declared the sole owners of their safety, the pre-validate could be dropped or made opt-in.
- **`tempo(relay=...)` requires and then discards a `ChargeIntent`** — configuration on it (`store`, `validate_sender`, `rpc_url`) silently vanishes. An alternative is letting the relay mint its intent directly (e.g. `intents={"charge": relay.charge()}`).
- **`Mpp.validate_credential`/`broadcast_credential` bypass the event dispatcher** — `on_payment_success`/`on_payment_failed` handlers never fire for payments settled through the new lifecycle methods, only for `Mpp.charge()`.
- **The two `verify` compat shims disagree**: `ChargeIntent.verify` = broadcast only; `_RelayCharge.verify` = validate then broadcast. Harmless today (the framework path preempts both), but direct callers get per-method semantics.
