### PR TITLE
fix(units): scale amounts with exact integer arithmetic

### DIFF
--- a/.changelog/steady-otter-count.md
+++ b/.changelog/steady-otter-count.md
@@ -1,0 +1,5 @@
+---
+pympp: patch
+---
+
+Fixed `parse_units` silently returning a rounded amount for values with more than 28 significant digits. Scaling ran through the active decimal context, so a long amount was rounded to a different integral value and returned without error; it is now scaled with exact integer arithmetic.

--- a/src/mpp/_units.py
+++ b/src/mpp/_units.py
@@ -44,14 +44,24 @@ def parse_units(value: str, decimals: int) -> int:
     if d < 0:
         raise ValueError("amount must be non-negative")
 
-    result = d * (10**decimals)
+    # Scale with integer arithmetic. ``d * (10**decimals)`` is evaluated in the
+    # active decimal context, whose default precision is 28 significant digits,
+    # so amounts longer than that would be rounded into a different — and still
+    # integral — value and returned as a silently wrong base-unit amount.
+    _sign, digits, exponent = d.as_tuple()
+    unscaled = int("".join(str(digit) for digit in digits))
+    scale = int(exponent) + decimals
 
-    if result != int(result):
+    if scale >= 0:
+        return unscaled * 10**scale
+
+    divisor = 10**-scale
+    if unscaled % divisor:
         raise ValueError(
             f"Amount {value!r} with {decimals} decimals produces fractional base units"
         )
 
-    return int(result)
+    return unscaled // divisor
 
 
 def transform_units(request: dict[str, Any]) -> dict[str, Any]:

--- a/src/mpp/_units.py
+++ b/src/mpp/_units.py
@@ -52,16 +52,24 @@ def parse_units(value: str, decimals: int) -> int:
     unscaled = int("".join(str(digit) for digit in digits))
     scale = int(exponent) + decimals
 
+    if unscaled == 0:
+        return 0
+
     if scale >= 0:
         return unscaled * 10**scale
 
-    divisor = 10**-scale
-    if unscaled % divisor:
+    # ``unscaled`` has exactly ``len(digits)`` digits, so a divisor carrying at
+    # least that many zeros cannot divide it. Testing the exponent before
+    # building the divisor short-circuits values such as ``"1e-10000000"``,
+    # which would otherwise materialize a ten-million-digit integer only to be
+    # rejected.
+    divisor_zeros = -scale
+    if divisor_zeros >= len(digits) or unscaled % 10**divisor_zeros:
         raise ValueError(
             f"Amount {value!r} with {decimals} decimals produces fractional base units"
         )
 
-    return unscaled // divisor
+    return unscaled // 10**divisor_zeros
 
 
 def transform_units(request: dict[str, Any]) -> dict[str, Any]:

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -113,3 +113,19 @@ class TestParseUnitsEdgeCases:
 
     def test_whitespace_stripped(self) -> None:
         assert parse_units(" 1.5 ", 6) == 1_500_000
+
+    def test_amount_longer_than_decimal_context_precision_is_exact(self) -> None:
+        """Amounts past 28 significant digits must not be rounded.
+
+        Scaling through the active decimal context would round these to a
+        different, still-integral value and return a silently wrong amount.
+        """
+        assert parse_units("999999999999999999999999999999", 0) == 999999999999999999999999999999
+        assert (
+            parse_units("12345678901234567890.123456789012345678", 18)
+            == 12345678901234567890123456789012345678
+        )
+
+    def test_fractional_base_units_still_rejected_for_long_amounts(self) -> None:
+        with pytest.raises(ValueError, match="fractional base units"):
+            parse_units("0.1234567890123456789012345678901", 6)

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -129,3 +129,23 @@ class TestParseUnitsEdgeCases:
     def test_fractional_base_units_still_rejected_for_long_amounts(self) -> None:
         with pytest.raises(ValueError, match="fractional base units"):
             parse_units("0.1234567890123456789012345678901", 6)
+
+    def test_extreme_negative_exponent_is_rejected_without_building_a_divisor(
+        self,
+    ) -> None:
+        """A tiny exponent must be rejected from the exponent alone.
+
+        The scaled divisor for these values has millions of digits. Deciding
+        divisibility by comparing the exponent to the digit count avoids
+        materializing it, so this stays immediate instead of spending seconds
+        and megabytes on a value that is rejected either way.
+        """
+        with pytest.raises(ValueError, match="fractional base units"):
+            parse_units("1e-10000000", 6)
+
+        with pytest.raises(ValueError, match="fractional base units"):
+            parse_units("1e-1000000000", 6)
+
+    def test_zero_is_zero_at_any_scale(self) -> None:
+        assert parse_units("0.000", 6) == 0
+        assert parse_units("0e-10000000", 6) == 0


### PR DESCRIPTION
## Problem

`parse_units` scales with `d * (10**decimals)`. That multiplication is evaluated in the active decimal context, whose default precision is 28 significant digits, so an amount longer than that is rounded *before* the integrality check runs. The rounded value is itself integral, so `result != int(result)` does not fire and a silently wrong base-unit amount is returned.

```python
>>> from mpp._units import parse_units
>>> parse_units("999999999999999999999999999999", 0)
1000000000000000000000000000000          # exact: 999999999999999999999999999999

>>> parse_units("12345678901234567890.123456789012345678", 18)
12345678901234567890123456790000000000   # exact: 12345678901234567890123456789012345678
```

The second case overstates the amount by 987,654,322 base units. No exception is raised in either case, so a caller cannot detect it.

The threshold is 28 significant digits in total, not 28 decimal places, so it is reachable from ordinary inputs: an 18-decimal token needs only 10 integer digits before the value crosses the limit.

## Fix

Scale from the decimal's own digit tuple with integer arithmetic, which is exact at any length. `10**decimals` is still applied, but never through the rounding context.

Everything else is unchanged on purpose:

- the `fractional base units` error keeps its condition and message
- validation of empty / non-string / non-finite / negative input is untouched
- exponent-form input (`"1e5"`) keeps its current behavior — see the question below

## Tests

Two cases added to `TestParseUnitsEdgeCases`, both verified to fail on `main` and pass here:

- amounts past the context precision scale exactly
- a long amount that genuinely produces fractional base units still raises

`uv run pytest` → 802 passed, 41 skipped. `ruff check` and `ruff format --check` clean.

## One question, deliberately left out of this PR

`parse_units("1e5", 6)` currently returns `100000000000`. The module docstring says the function matches "the parseUnits behavior in the TypeScript SDK (viem's parseUnits)", and viem validates its input against a plain decimal pattern that rejects exponent notation. If that divergence is real, it is a separate cross-SDK conformance question and I did not want to change two behaviors in one PR — happy to open a follow-up if you want it aligned.

Disclosure: I used an AI assistant while investigating and preparing this change; the analysis and conclusions are my own to defend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
