### PR TITLE
fix(server): reject timezone-naive expires instead of raising

### DIFF
--- a/.changelog/quiet-heron-verify.md
+++ b/.changelog/quiet-heron-verify.md
@@ -1,0 +1,5 @@
+---
+pympp: patch
+---
+
+Fixed `verify_or_challenge` raising `TypeError` when a challenge carried a timezone-naive `expires`. Such a value parsed but could not be compared to an aware `now`, so an expired credential surfaced as a server error instead of a fail-closed rejection; it is now rejected like any other unusable `expires`.

--- a/src/mpp/server/verify.py
+++ b/src/mpp/server/verify.py
@@ -206,6 +206,11 @@ async def verify_or_challenge(
         expires_dt = datetime.fromisoformat(echo.expires.replace("Z", "+00:00"))
     except ValueError:
         return await fail(InvalidChallengeError(echo.id, "invalid expires"), credential)
+    if expires_dt.tzinfo is None:
+        # A timestamp without an offset does not name an instant, and comparing
+        # it to an aware "now" raises TypeError. Reject it like any other
+        # unparseable value so the route still fails closed.
+        return await fail(InvalidChallengeError(echo.id, "invalid expires"), credential)
     if expires_dt < datetime.now(UTC):
         return await fail(PaymentExpiredError(echo.expires), credential)
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -596,6 +596,42 @@ class TestChallengeExpiryEnforcement:
 
         assert isinstance(result, Challenge)
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "expires",
+        ["2099-01-01T00:00:00", "2000-01-01T00:00:00"],
+        ids=["future", "past"],
+    )
+    async def test_rejects_timezone_naive_expires(self, expires: str) -> None:
+        """Should reject an expires without an offset instead of raising.
+
+        A naive timestamp parses, so it reached the comparison against an
+        aware ``now`` and raised TypeError — turning an expired credential
+        into a server error rather than a fail-closed rejection.
+        """
+
+        @intent(name="charge")
+        async def test_intent(credential: Credential, request: dict) -> Receipt:
+            return Receipt.success("0x123")
+
+        credential = make_bound_credential(
+            payload={"hash": "0xabc"},
+            request={"amount": "1000"},
+            realm="api.example.com",
+            secret_key="test-secret",
+            expires=expires,
+        )
+
+        result = await verify_or_challenge(
+            authorization=credential.to_authorization(),
+            intent=test_intent,
+            request={"amount": "1000"},
+            realm="api.example.com",
+            secret_key="test-secret",
+        )
+
+        assert isinstance(result, Challenge)
+
 
 class TestCrossEndpointReplay:
     @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

`verify_or_challenge` parses the echoed `expires` and compares it to `datetime.now(UTC)`:

```python
try:
    expires_dt = datetime.fromisoformat(echo.expires.replace("Z", "+00:00"))
except ValueError:
    return await fail(InvalidChallengeError(echo.id, "invalid expires"), credential)
if expires_dt < datetime.now(UTC):
```

A timestamp without an offset parses successfully, so it never reaches the `except`, and the comparison then raises:

```
TypeError: can't compare offset-naive and offset-aware datetimes
```

The comment directly above this block states the intent — "Credentials without an expires field or with an unparseable value are rejected outright" — but a naive value *is* parseable, so it escapes the fail-closed path. An expired credential surfaces as a server error instead of a rejection, and because the value is fixed for the route, every subsequent request fails the same way.

## Reachability

`expires` is covered by the challenge-id HMAC, so a client cannot inject a naive value into someone else's challenge; forging one fails the id check earlier. It is reachable when an application supplies its own `expires` to `verify_or_challenge`, for example `datetime.now().isoformat()` instead of `datetime.now(UTC)`. The existing runtime guard in `_create_challenge` only checks that `expires` is a `str`, not that it names an instant.

So this is a robustness / fail-closed-contract bug rather than a way for a payer to bypass expiry — I did not want to overstate it.

Reproduced against `main` with `make_bound_credential(..., expires="2000-01-01T00:00:00")`: `TypeError` at `verify.py:209`, where a `Challenge` rejection is expected.

## Fix

Reject a naive `expires` the same way an unparseable one is rejected, so the route still fails closed instead of erroring.

## Tests

Parametrized over a future and a past naive timestamp — the past case is the one that should have been a clean expiry rejection. Both fail on `main` with the `TypeError` above and pass here.

`uv run pytest` → 802 passed, 41 skipped. `ruff check` and `ruff format --check` clean.

## Open question

Should `_create_challenge` also validate an application-supplied `expires` at issue time, so a naive value is caught when the challenge is minted rather than when a credential comes back? That would fail earlier and more visibly, but it changes the challenge-creation contract, so I kept this PR to the crash itself. Happy to follow up if you want that guard.

Disclosure: I used an AI assistant while investigating and preparing this change; the analysis and conclusions are my own to defend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
