### PR TITLE
fix: preserve release changelog attribution

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          fetch-depth: 0
           persist-credentials: true
 
       - uses: tempoxyz/changelogs@a19f62e3fdbd6d07b8900eb0568ed09b868bf84d # OIDC trusted publishing


### PR DESCRIPTION
## Why

The release workflow checks out only one commit, so `changelogs` cannot find the commit that introduced each pending entry. Regenerating `v0.10.2` after #218 therefore rewrote its attribution from #216 to #218.

## What

- Fetch full Git history before running the pinned `changelogs` action.
- Leave package and release contents unchanged.
