### PR TITLE
test: use bootstrapped Tempo localnet

### DIFF
--- a/.changelog/tempo-localnet-integration.md
+++ b/.changelog/tempo-localnet-integration.md
@@ -1,0 +1,5 @@
+---
+pympp: patch
+---
+
+Use the bootstrapped Tempo localnet image for reproducible integration tests.

--- a/.changelog/tempo-localnet-integration.md
+++ b/.changelog/tempo-localnet-integration.md
@@ -1,5 +1,0 @@
----
-pympp: patch
----
-
-Use the bootstrapped Tempo localnet image for reproducible integration tests.

--- a/.changelog/ugly-fish-wash.md
+++ b/.changelog/ugly-fish-wash.md
@@ -1,0 +1,5 @@
+---
+pympp: patch
+---
+
+Used the bootstrapped Tempo localnet image for reproducible integration tests, replacing the dynamic `latest` tag pull-and-cache approach with a pinned `tempo-localnet` image digest. Removed the dev-key-based account funding fallback in favour of exclusively using the localnet faucet via `tempo_fundAddress`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,8 +93,6 @@ jobs:
   integration:
     name: Integration Test
     runs-on: ubuntu-latest
-    env:
-      TEMPO_TAG: latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -112,30 +110,7 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-extras --dev
 
-      - name: Resolve Tempo image digest
-        id: tempo-digest
-        run: |
-          digest=$(docker buildx imagetools inspect "ghcr.io/tempoxyz/tempo:${TEMPO_TAG}" --raw | sha256sum | cut -d' ' -f1)
-          echo "digest=${digest}" >> "$GITHUB_OUTPUT"
-
-      - name: Cache Tempo Docker image
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        id: docker-cache
-        with:
-          path: /tmp/tempo-image.tar
-          key: tempo-image-${{ steps.tempo-digest.outputs.digest }}
-
-      - name: Load cached Tempo image
-        if: steps.docker-cache.outputs.cache-hit == 'true'
-        run: docker load -i /tmp/tempo-image.tar
-
-      - name: Pull and cache Tempo image
-        if: steps.docker-cache.outputs.cache-hit != 'true'
-        run: |
-          docker pull "ghcr.io/tempoxyz/tempo:${TEMPO_TAG}"
-          docker save "ghcr.io/tempoxyz/tempo:${TEMPO_TAG}" -o /tmp/tempo-image.tar
-
-      - name: Start Tempo devnet and Redis
+      - name: Start Tempo localnet and Redis
         run: docker compose up -d --wait
 
       - name: Run integration tests

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,29 +10,8 @@ services:
       retries: 10
 
   tempo:
-    image: ghcr.io/tempoxyz/tempo:${TEMPO_TAG:-latest}
+    image: ${TEMPO_LOCALNET_IMAGE:-ghcr.io/tempoxyz/tempo-localnet@sha256:86f199f161be85d3610d990e5bc2653ece29de3ee9c91e8c8e768cf2b8c05c3b}
+    command: ["--block-time", "1ms"]
     ports:
-      - "8545:8545"
-    command: >
-      node
-      --dev
-      --dev.block-time 200ms
-      --http
-      --http.addr 0.0.0.0
-      --http.port 8545
-      --http.api all
-      --http.corsdomain '*'
-      --engine.legacy-state-root
-      --engine.disable-precompile-cache
-      --faucet.enabled
-      --faucet.private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
-      --faucet.amount 1000000000
-      --faucet.address 0x20c0000000000000000000000000000000000000
-      --faucet.address 0x20c0000000000000000000000000000000000001
-      --faucet.address 0x20c0000000000000000000000000000000000002
-      --faucet.address 0x20c0000000000000000000000000000000000003
-    healthcheck:
-      test: ["CMD-SHELL", "bash -c 'echo >/dev/tcp/localhost/8545' 2>/dev/null || exit 1"]
-      interval: 2s
-      timeout: 5s
-      retries: 30
+      - "127.0.0.1:8545:8545"
+    stop_grace_period: 10s

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,9 +10,6 @@ from mpp.methods.tempo import TempoAccount
 from mpp.methods.tempo._defaults import PATH_USD
 from mpp.methods.tempo.intents import ChargeIntent
 
-# Standard dev key pre-funded on --dev nodes
-DEV_PRIVATE_KEY = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
-
 
 @pytest.fixture(scope="session")
 def rpc_url():
@@ -60,89 +57,8 @@ def _tip20_balance(rpc_url: str, token: str, address: str, client: httpx.Client)
     return int(resp.json()["result"], 16)
 
 
-def _fund_account_via_dev_key(rpc_url: str, address: str, currency: str, amount: int) -> None:
-    """Fund an account by sending tokens from the pre-funded dev account."""
-    from pytempo import Call, TempoTransaction
-
-    dev_account = TempoAccount.from_key(DEV_PRIVATE_KEY)
-
-    with httpx.Client(timeout=30) as client:
-        chain_id_hex = client.post(
-            rpc_url,
-            json={"jsonrpc": "2.0", "method": "eth_chainId", "params": [], "id": 1},
-        ).json()["result"]
-        nonce_hex = client.post(
-            rpc_url,
-            json={
-                "jsonrpc": "2.0",
-                "method": "eth_getTransactionCount",
-                "params": [dev_account.address, "pending"],
-                "id": 1,
-            },
-        ).json()["result"]
-        gas_hex = client.post(
-            rpc_url,
-            json={"jsonrpc": "2.0", "method": "eth_gasPrice", "params": [], "id": 1},
-        ).json()["result"]
-
-    cid = int(chain_id_hex, 16)
-    nonce = int(nonce_hex, 16)
-    gas_price = int(gas_hex, 16)
-
-    selector = "a9059cbb"
-    to_padded = address[2:].lower().zfill(64)
-    amount_padded = hex(amount)[2:].zfill(64)
-    data = f"0x{selector}{to_padded}{amount_padded}"
-
-    tx = TempoTransaction.create(
-        chain_id=cid,
-        gas_limit=5_000_000,
-        max_fee_per_gas=gas_price,
-        max_priority_fee_per_gas=gas_price,
-        nonce=nonce,
-        nonce_key=0,
-        fee_token=currency,
-        calls=(Call.create(to=currency, value=0, data=data),),
-    )
-    signed = tx.sign(dev_account.private_key)
-    raw_tx = "0x" + signed.encode().hex()
-
-    with httpx.Client(timeout=30) as client:
-        resp = client.post(
-            rpc_url,
-            json={
-                "jsonrpc": "2.0",
-                "method": "eth_sendRawTransaction",
-                "params": [raw_tx],
-                "id": 1,
-            },
-        )
-        result = resp.json()
-        if "error" in result:
-            raise RuntimeError(f"Fund transfer failed: {result['error']}")
-        tx_hash = result["result"]
-
-        for _ in range(120):
-            resp = client.post(
-                rpc_url,
-                json={
-                    "jsonrpc": "2.0",
-                    "method": "eth_getTransactionReceipt",
-                    "params": [tx_hash],
-                    "id": 1,
-                },
-            )
-            receipt = resp.json().get("result")
-            if receipt is not None:
-                if receipt.get("status") != "0x1":
-                    raise RuntimeError(f"Fund transfer reverted: {tx_hash}")
-                return
-            time.sleep(0.5)
-    raise RuntimeError(f"Fund transfer receipt not found: {tx_hash}")
-
-
 def _fund_account(rpc_url: str, address: str, currency: str) -> None:
-    """Fund an account using tempo_fundAddress if available, else dev key transfer."""
+    """Fund an account using the localnet faucet."""
     with httpx.Client(timeout=30) as client:
         resp = client.post(
             rpc_url,
@@ -154,22 +70,15 @@ def _fund_account(rpc_url: str, address: str, currency: str) -> None:
             },
         )
         result = resp.json()
-        if "error" not in result:
-            for _ in range(100):
-                if _tip20_balance(rpc_url, currency, address, client) > 0:
-                    return
-                time.sleep(0.2)
-            raise RuntimeError(f"Account {address} not funded after tempo_fundAddress")
-
-    # Fallback: transfer from dev account
-    _fund_account_via_dev_key(rpc_url, address, currency, 100_000_000_000)
-
-    with httpx.Client(timeout=30) as client:
+        if "error" in result:
+            raise RuntimeError(f"tempo_fundAddress failed: {result['error']}")
+        if not result.get("result"):
+            raise RuntimeError("tempo_fundAddress returned no transaction hashes")
         for _ in range(100):
             if _tip20_balance(rpc_url, currency, address, client) > 0:
                 return
             time.sleep(0.2)
-    raise RuntimeError(f"Account {address} not funded after 100 attempts")
+    raise RuntimeError(f"Account {address} not funded after tempo_fundAddress")
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_tempo_integration.py
+++ b/tests/test_tempo_integration.py
@@ -297,8 +297,7 @@ class TestChargeIntegration:
         )
         expires = _future_expires()
         request_dict = {
-            # The dev faucet funds exactly 1_000_000_000 units, and gas is paid
-            # in the same token. Leave headroom so the payment can settle.
+            # Gas is paid in the same token, so leave headroom for settlement.
             "amount": premium_amount,
             "currency": currency,
             "recipient": funded_recipient.address,


### PR DESCRIPTION
## Motivation

The Python SDK integration suite should use Tempo’s canonical deterministic faucet setup instead of maintaining raw node flags and a private-key funding fallback.

## Summary

- replace the hand-configured Tempo node with the digest-pinned localnet image
- simplify account funding around the canonical localnet faucet
- remove redundant CI image caching and node setup

## Key design considerations

- keep Redis and Tempo readiness coordinated through Docker Compose
- preserve TEMPO_LOCALNET_IMAGE overrides and use a 1 ms block interval for reliable bootstrap
