### PR TITLE
ci: open the release PR via github-sts

### DIFF
--- a/.github/sts/release-pr.sts.yaml
+++ b/.github/sts/release-pr.sts.yaml
@@ -1,0 +1,14 @@
+# Allow the release workflow (push to main) to mint a short-lived token that
+# opens and updates the changelog-release version PR through the
+# tempoxyz/changelogs action, and pushes its branch, tags, and GitHub
+# releases. Replaces the built-in GITHUB_TOKEN so the org can turn off
+# "Allow GitHub Actions to create and approve pull requests".
+# The release job runs inside the release GitHub Environment, so
+# that is what its OIDC subject carries; the job_workflow_ref claim check
+# pins minting to this workflow as it exists on main.
+subject: repo:tempoxyz@211589300/pympp@1141403862:environment:release
+claim_pattern:
+  job_workflow_ref: tempoxyz/pympp/\.github/workflows/publish\.yml@refs/heads/main
+permissions:
+  contents: write
+  pull_requests: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - name: Fetch GitHub token via STS
         id: app-token
-        uses: tempoxyz/gh-actions/actions/github-sts@183a02178c660ce295e9a262edc5857cb7135f06 # main
+        uses: tempoxyz/gh-actions/actions/github-sts@183a02178c660ce295e9a262edc5857cb7135f06
         with:
           policy: release-pr
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,13 +13,23 @@ jobs:
     name: Version
     runs-on: ubuntu-latest
     environment: release
+    # The changelog-release version PR, branch, tags, and GitHub releases are
+    # created with a short-lived GitHub App token minted via the github-sts
+    # action (authorized by .github/sts/release-pr.sts.yaml); the built-in
+    # GITHUB_TOKEN is not allowed to create pull requests.
     permissions:
-      contents: write
-      pull-requests: write
-      id-token: write   # required for PyPI Trusted Publishing (OIDC)
+      contents: read
+      id-token: write # PyPI Trusted Publishing (OIDC) and the STS exchange
     steps:
+      - name: Fetch GitHub token via STS
+        id: app-token
+        uses: tempoxyz/gh-actions/actions/github-sts@183a02178c660ce295e9a262edc5857cb7135f06 # main
+        with:
+          policy: release-pr
+
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
           persist-credentials: true
 
@@ -28,5 +38,4 @@ jobs:
           ecosystem: python
           python-version: '3.12'
           conventional-commit: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Motivation

We are disabling the org-level **"Allow GitHub Actions to create and approve pull requests"** setting, after which the built-in `GITHUB_TOKEN` can no longer open or approve pull requests. This repo's `tempoxyz/changelogs` step opens and updates the changelog-release version PR with the built-in token, so it would stop working.

## Changes

- Mint a short-lived GitHub App token via the `tempoxyz/gh-actions/actions/github-sts` action (SHA-pinned) and pass it to `tempoxyz/changelogs` via its `github-token` input (and to checkout where credentials persist), following the pattern `tempo` and `wallet-rs` already use. The version PR, branch, tags, and GitHub releases are all created with that token.
- Drop the job's built-in token to `contents: read` and grant `id-token: write` (the OIDC exchange; also used by registry trusted publishing where applicable).
- Add `.github/sts/release-pr.sts.yaml` granting `contents: write` + `pull_requests: write`, with a `job_workflow_ref` claim check pinning minting to this workflow on `main`.

## Notes

- Bonus: version PRs opened by the STS App trigger `pull_request` workflows normally, so CI runs on them (built-in-token PRs never got checks).
- Requires the Tempo GitHub STS App to be installed on this repository.
- Verify on the next push to `main` with pending changelogs.
