### PR TITLE
feat(server): compose payment handlers

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   conformance-policy:
-    uses: tempoxyz/mpp-tools/.github/workflows/sdk-conformance-policy.yml@29fee62deba0aa3982d3860b40c5e72c8aa27957
+    uses: tempoxyz/mpp-tools/.github/workflows/sdk-conformance-policy.yml@c5dde8faa684b79e2df665143cf7cd731608c079
     with:
       protocol-paths: |
         src/**
@@ -31,7 +31,7 @@ jobs:
 
   conformance:
     needs: conformance-policy
-    uses: tempoxyz/mpp-tools/.github/workflows/sdk-conformance.yml@29fee62deba0aa3982d3860b40c5e72c8aa27957
+    uses: tempoxyz/mpp-tools/.github/workflows/sdk-conformance.yml@c5dde8faa684b79e2df665143cf7cd731608c079
     with:
       adapter: python
       conformance-ref: ${{ needs.conformance-policy.outputs.conformance_ref }}

--- a/src/mpp/server/__init__.py
+++ b/src/mpp/server/__init__.py
@@ -40,6 +40,14 @@ from mpp.events import (
     PaymentEvent,
     PaymentEventName,
 )
+from mpp.server.compose import (
+    ComposedChallenges,
+    ComposedHandler,
+    ComposedResult,
+    ComposeEntry,
+    ComposeOptions,
+    compose,
+)
 from mpp.server.decorator import pay
 from mpp.server.intent import (
     Intent,

--- a/src/mpp/server/compose.py
+++ b/src/mpp/server/compose.py
@@ -36,6 +36,7 @@ class ComposeOptions(TypedDict, total=False):
     fee_payer: bool
     chain_id: int | None
     extra: dict[str, str] | None
+    meta: dict[str, str] | None
 
 
 ComposeEntry: TypeAlias = tuple[Method | str, ComposeOptions]
@@ -94,10 +95,19 @@ class _PreparedOffer:
             secret_key=server.secret_key,
             method=self.offer.method.name,
             description=self.offer.options.get("description"),
+            meta=self.offer.options.get("meta"),
             expires=self.expires,
             body=self.body,
             events=server._events,
         )
+
+
+class _AmbiguousOffersError(Exception):
+    """Credential authenticates against indistinguishable configured offers."""
+
+    def __init__(self, offers: Sequence[_PreparedOffer]) -> None:
+        self.offers = tuple(offers)
+        super().__init__("credential matches multiple configured offers")
 
 
 def _parse_credential(authorization: str | None) -> Credential | None:
@@ -157,7 +167,18 @@ class ComposedHandler:
                 if offer.method.name == credential.challenge.method
                 and offer.intent == credential.challenge.intent
             ]
-            selected_offer = self._select_offer(credential, prepared_offers)
+            try:
+                selected_offer = self._select_offer(credential, prepared_offers)
+            except _AmbiguousOffersError as error:
+                challenges: list[Challenge] = []
+                for prepared_offer in error.offers:
+                    result = await prepared_offer.verify(None)
+                    if not isinstance(result, Challenge):
+                        raise RuntimeError(
+                            "offer without a credential returned a receipt"
+                        ) from error
+                    challenges.append(result)
+                return ComposedChallenges(tuple(challenges))
             if selected_offer is not None:
                 result = await selected_offer.verify(authorization)
                 return ComposedChallenges((result,)) if isinstance(result, Challenge) else result
@@ -188,20 +209,34 @@ class ComposedHandler:
             echoed_request = (
                 _b64_decode(credential.challenge.request) if credential.challenge.request else {}
             )
+            echoed_meta = (
+                _b64_decode(credential.challenge.opaque) if credential.challenge.opaque else None
+            )
         except ParseError:
             return None
 
         request_matches = [offer for offer in offers if offer.request == echoed_request]
         digest = credential.challenge.digest
-        body_matches = [
+        binding_matches = [
             offer
             for offer in request_matches
             if digest == (_body_digest.compute(offer.body) if offer.body is not None else None)
+            and echoed_meta == offer.offer.options.get("meta")
         ]
-        for prepared_offer in (*body_matches, *request_matches, *offers):
+        authenticated_matches = [offer for offer in binding_matches if offer.offer.owns(credential)]
+        if len(authenticated_matches) > 1:
+            raise _AmbiguousOffersError(authenticated_matches)
+        if authenticated_matches:
+            return authenticated_matches[0]
+
+        for prepared_offer in (*binding_matches, *request_matches, *offers):
             if prepared_offer.offer.owns(credential):
                 return prepared_offer
-        return request_matches[0] if request_matches else (offers[0] if offers else None)
+        if binding_matches:
+            return binding_matches[0]
+        if request_matches:
+            return request_matches[0]
+        return offers[0] if offers else None
 
 
 def compose(*handlers: ComposedHandler) -> ComposedHandler:
@@ -252,6 +287,15 @@ def _configure_entries(
             raise ValueError("compose() options expires and expires_in cannot both be set")
         if raw_options.get("splits") and raw_options.get("fee_payer"):
             raise ValueError("splits and fee_payer cannot be used together")
+        meta = raw_options.get("meta")
+        if meta is not None and (
+            not isinstance(meta, dict)
+            or any(
+                not isinstance(key, str) or not isinstance(value, str)
+                for key, value in meta.items()
+            )
+        ):
+            raise ValueError("meta must be a dict[str, str]")
         options = cast(ComposeOptions, raw_options)
         if not (options.get("currency") or getattr(method, "currency", None)):
             raise ValueError("currency must be set on the method or compose() offer")

--- a/src/mpp/server/compose.py
+++ b/src/mpp/server/compose.py
@@ -1,0 +1,262 @@
+"""Composition of configured server payment offers."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Mapping, Sequence
+from dataclasses import dataclass
+from datetime import timedelta
+from typing import TYPE_CHECKING, Any, Required, TypeAlias, TypedDict, TypeVar, cast
+
+from mpp import Challenge, Credential, Receipt, _body_digest
+from mpp._parsing import ParseError, _b64_decode
+from mpp._units import parse_units
+from mpp.errors import InvalidChallengeError, MalformedCredentialError
+from mpp.server.decorator import BodyParamsType, resolve_body_param, wrap_payment_handler
+from mpp.server.method import Method
+from mpp.server.verify import _authenticate_echo, _extract_payment_scheme, verify_or_challenge
+
+if TYPE_CHECKING:
+    from mpp.server.intent import Intent, VerifiableIntent
+    from mpp.server.mpp import Mpp
+
+R = TypeVar("R")
+
+
+class ComposeOptions(TypedDict, total=False):
+    """Options for one configured payment offer."""
+
+    amount: Required[str]
+    currency: str | None
+    recipient: str | None
+    description: str | None
+    expires: str | None
+    expires_in: timedelta | None
+    memo: str | None
+    splits: list[dict[str, str]] | None
+    fee_payer: bool
+    chain_id: int | None
+    extra: dict[str, str] | None
+
+
+ComposeEntry: TypeAlias = tuple[Method | str, ComposeOptions]
+
+
+@dataclass
+class ComposedChallenges:
+    """Challenges issued by an unpaid composed handler."""
+
+    challenges: tuple[Challenge, ...]
+
+
+ComposedResult: TypeAlias = ComposedChallenges | tuple[Credential, Receipt]
+_OPTION_KEYS = frozenset(ComposeOptions.__annotations__)
+
+
+@dataclass
+class _Offer:
+    """One payment offer configured on a particular Mpp server."""
+
+    server: Mpp
+    method: Method
+    intent: str
+    options: ComposeOptions
+    body: BodyParamsType
+
+    def owns(self, credential: Credential) -> bool:
+        """Return whether this offer's server authenticated the credential."""
+        if credential.challenge.realm != self.server.realm:
+            return False
+        try:
+            _authenticate_echo(credential, secret_key=self.server.secret_key)
+        except (InvalidChallengeError, MalformedCredentialError):
+            return False
+        return True
+
+
+@dataclass
+class _PreparedOffer:
+    """One configured offer resolved for the current request."""
+
+    offer: _Offer
+    intent: Intent | VerifiableIntent
+    request: dict[str, Any]
+    expires: str | None
+    body: str | bytes | dict[str, Any] | None
+
+    async def verify(self, authorization: str | None) -> Challenge | tuple[Credential, Receipt]:
+        """Verify this offer using its originating server."""
+        server = self.offer.server
+        return await verify_or_challenge(
+            authorization=authorization,
+            intent=self.intent,
+            request=self.request,
+            realm=server.realm,
+            secret_key=server.secret_key,
+            method=self.offer.method.name,
+            description=self.offer.options.get("description"),
+            expires=self.expires,
+            body=self.body,
+            events=server._events,
+        )
+
+
+def _parse_credential(authorization: str | None) -> Credential | None:
+    """Parse a Payment authorization header for offer routing."""
+    payment_scheme = _extract_payment_scheme(authorization) if authorization else None
+    try:
+        return Credential.from_authorization(payment_scheme) if payment_scheme else None
+    except ParseError:
+        return None
+
+
+async def _prepare_offer(
+    offer: _Offer,
+    request: Any,
+    body_cache: dict[int, str | bytes | dict[str, Any] | None],
+) -> _PreparedOffer:
+    """Resolve an offer's request and body for this call."""
+    intent, payment_request, expires = offer.server._build_offer_request(
+        offer.method,
+        offer.intent,
+        offer.options,
+        request,
+        api_name="compose",
+    )
+    key = id(offer.body)
+    if key not in body_cache:
+        body_cache[key] = await resolve_body_param(offer.body, request)
+    return _PreparedOffer(offer, intent, payment_request, expires, body_cache[key])
+
+
+class ComposedHandler:
+    """A configured handler containing one or more payment offers."""
+
+    def __init__(self, *handlers: ComposedHandler) -> None:
+        """Combine previously configured handlers."""
+        if not handlers:
+            raise ValueError("compose() requires at least one configured handler")
+        if any(not isinstance(handler, ComposedHandler) for handler in handlers):
+            raise TypeError("compose() accepts only configured handlers")
+        self._offers = tuple(offer for handler in handlers for offer in handler._offers)
+
+    @classmethod
+    def _from_offers(cls, offers: Sequence[_Offer]) -> ComposedHandler:
+        """Create a handler from newly configured offers."""
+        handler = cls.__new__(cls)
+        handler._offers = tuple(offers)
+        return handler
+
+    async def verify(self, authorization: str | None, request: Any = None) -> ComposedResult:
+        """Verify a matching credential or issue every configured challenge."""
+        body_cache: dict[int, str | bytes | dict[str, Any] | None] = {}
+        credential = _parse_credential(authorization)
+        if credential is not None:
+            prepared_offers = [
+                await _prepare_offer(offer, request, body_cache)
+                for offer in self._offers
+                if offer.method.name == credential.challenge.method
+                and offer.intent == credential.challenge.intent
+            ]
+            selected_offer = self._select_offer(credential, prepared_offers)
+            if selected_offer is not None:
+                result = await selected_offer.verify(authorization)
+                return ComposedChallenges((result,)) if isinstance(result, Challenge) else result
+
+        challenges: list[Challenge] = []
+        for offer in self._offers:
+            prepared_offer = await _prepare_offer(offer, request, body_cache)
+            result = await prepared_offer.verify(authorization)
+            if not isinstance(result, Challenge):
+                return result
+            challenges.append(result)
+        return ComposedChallenges(tuple(challenges))
+
+    def __call__(
+        self,
+        handler: Callable[[Any, Credential, Receipt], Awaitable[R]],
+    ) -> Callable[[Any], Awaitable[R | Any]]:
+        """Wrap a payment-protected endpoint."""
+        return wrap_payment_handler(handler, self.verify, lambda: self._offers[0].server.realm)
+
+    @staticmethod
+    def _select_offer(
+        credential: Credential,
+        offers: Sequence[_PreparedOffer],
+    ) -> _PreparedOffer | None:
+        """Choose the offer addressed by a credential."""
+        try:
+            echoed_request = (
+                _b64_decode(credential.challenge.request) if credential.challenge.request else {}
+            )
+        except ParseError:
+            return None
+
+        request_matches = [offer for offer in offers if offer.request == echoed_request]
+        digest = credential.challenge.digest
+        body_matches = [
+            offer
+            for offer in request_matches
+            if digest == (_body_digest.compute(offer.body) if offer.body is not None else None)
+        ]
+        for prepared_offer in (*body_matches, *request_matches, *offers):
+            if prepared_offer.offer.owns(credential):
+                return prepared_offer
+        return request_matches[0] if request_matches else (offers[0] if offers else None)
+
+
+def compose(*handlers: ComposedHandler) -> ComposedHandler:
+    """Combine configured handlers while preserving each handler's server."""
+    return ComposedHandler(*handlers)
+
+
+def _configure_entries(
+    server: Mpp,
+    entries: Sequence[ComposeEntry],
+    body: BodyParamsType,
+) -> ComposedHandler:
+    """Validate compose entries and bind them to a server."""
+    if not entries:
+        raise ValueError("compose() requires at least one entry")
+
+    registered = {method.name: method for method in server.methods}
+    offers: list[_Offer] = []
+    for entry in entries:
+        if not isinstance(entry, tuple) or len(entry) != 2:
+            raise ValueError("compose() entries must be (method, options) tuples")
+        method_ref, raw_options = entry
+        if isinstance(method_ref, str):
+            parts = method_ref.split("/")
+            if len(parts) not in (1, 2) or not all(parts):
+                raise ValueError(f"invalid payment method reference: {method_ref}")
+            method = registered.get(parts[0])
+            if method is None:
+                raise ValueError(f"unknown payment method: {parts[0]}")
+            intent = parts[1] if len(parts) == 2 else "charge"
+        else:
+            method = registered.get(getattr(method_ref, "name", ""))
+            if method is None or method is not method_ref:
+                raise ValueError("payment method is not registered")
+            intent = "charge"
+        if intent not in method.intents:
+            raise ValueError(f"Method {method.name} does not support {intent} intent")
+
+        if not isinstance(raw_options, Mapping):
+            raise ValueError("compose() options must be a mapping")
+        unknown = raw_options.keys() - _OPTION_KEYS
+        if unknown:
+            raise ValueError(f"unsupported compose option: {sorted(unknown, key=str)[0]}")
+        amount = raw_options.get("amount")
+        if not isinstance(amount, str) or not amount.strip():
+            raise ValueError("compose() offer requires a non-empty string amount")
+        if raw_options.get("expires") is not None and raw_options.get("expires_in") is not None:
+            raise ValueError("compose() options expires and expires_in cannot both be set")
+        if raw_options.get("splits") and raw_options.get("fee_payer"):
+            raise ValueError("splits and fee_payer cannot be used together")
+        options = cast(ComposeOptions, raw_options)
+        if not (options.get("currency") or getattr(method, "currency", None)):
+            raise ValueError("currency must be set on the method or compose() offer")
+        if not (options.get("recipient") or getattr(method, "recipient", None)):
+            raise ValueError("recipient must be set on the method or compose() offer")
+        parse_units(options["amount"], getattr(method, "decimals", 6))
+        offers.append(_Offer(server, method, intent, options, body))
+    return ComposedHandler._from_offers(offers)

--- a/src/mpp/server/decorator.py
+++ b/src/mpp/server/decorator.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import inspect
 import json as _json
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Sequence
 from functools import wraps
 from typing import TYPE_CHECKING, Any, TypeVar
 
@@ -15,6 +15,7 @@ from mpp.server._defaults import detect_realm, detect_secret_key
 from mpp.server.verify import verify_or_challenge
 
 if TYPE_CHECKING:
+    from mpp.server.compose import ComposedResult
     from mpp.server.intent import Intent, VerifiableIntent
 
 R = TypeVar("R")
@@ -120,7 +121,7 @@ def bind_framework_scope(request_params: dict[str, Any], request_obj: Any) -> di
 
 
 def make_challenge_response(
-    challenge: Challenge,
+    challenge: Challenge | Sequence[Challenge],
     realm: str,
     error: PaymentError | None = None,
 ) -> Any:
@@ -129,23 +130,28 @@ def make_challenge_response(
     Returns a Starlette ``Response`` when starlette is installed,
     otherwise a plain dict with ``_mpp_challenge``, ``status``, and ``headers``.
     """
-    error = error or PaymentRequiredError(realm=realm, description=challenge.description)
-    body = _json.dumps(error.to_problem_details(challenge.id))
-    headers = {
-        "WWW-Authenticate": challenge.to_www_authenticate(realm),
+    challenges = (challenge,) if isinstance(challenge, Challenge) else tuple(challenge)
+    error = error or PaymentRequiredError(realm=realm, description=challenges[0].description)
+    body = _json.dumps(error.to_problem_details(challenges[0].id))
+    values = [item.to_www_authenticate(item.realm or realm) for item in challenges]
+    headers: dict[str, Any] = {
         "Cache-Control": "no-store",
         "Content-Type": "application/problem+json",
     }
     try:
         from starlette.responses import Response
 
-        return Response(
+        response = Response(
             content=body,
             status_code=402,
             headers=headers,
             media_type="application/problem+json",
         )
+        for value in values:
+            response.headers.append("WWW-Authenticate", value)
+        return response
     except ImportError:
+        headers["WWW-Authenticate"] = values[0] if len(values) == 1 else values
         return {
             "_mpp_challenge": True,
             "status": 402,
@@ -168,7 +174,7 @@ async def resolve_body_param(body: BodyParamsType, request_obj: Any) -> BodyType
 
 def wrap_payment_handler(
     handler: Callable[..., Awaitable[R]],
-    verify_fn: Callable[[str | None, Any], Awaitable[Challenge | tuple[Credential, Receipt]]],
+    verify_fn: Callable[[str | None, Any], Awaitable[Challenge | ComposedResult]],
     realm_fn: Callable[[], str],
 ) -> Callable[..., Awaitable[R | Any]]:
     """Wrap a handler with the payment challenge/verify flow.
@@ -183,7 +189,7 @@ def wrap_payment_handler(
     Args:
         handler: The async endpoint handler to wrap.
         verify_fn: Called with ``(authorization, request_obj)``; must return
-            a ``Challenge`` or ``(Credential, Receipt)`` tuple.
+            a ``Challenge``, composed challenges, or ``(Credential, Receipt)`` tuple.
         realm_fn: Returns the realm string for challenge responses.
     """
     sig = inspect.signature(handler)
@@ -216,6 +222,11 @@ def wrap_payment_handler(
 
         if isinstance(result, Challenge):
             return make_challenge_response(result, realm_fn())
+
+        from mpp.server.compose import ComposedChallenges
+
+        if isinstance(result, ComposedChallenges):
+            return make_challenge_response(result.challenges, result.challenges[0].realm)
 
         credential, receipt = result
         return await handler(request_obj, credential, receipt)

--- a/src/mpp/server/mpp.py
+++ b/src/mpp/server/mpp.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable, Mapping
+from collections.abc import Awaitable, Callable, Mapping, Sequence
 from datetime import UTC, datetime, timedelta
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, Literal, TypeVar, overload
 
 from mpp import Challenge, Credential, Receipt
 from mpp._parsing import ParseError, _b64_decode, _parse_timestamp
@@ -24,6 +24,7 @@ from mpp.events import (
     Unsubscribe,
 )
 from mpp.server._defaults import detect_realm, detect_secret_key
+from mpp.server.compose import ComposedHandler, ComposedResult, ComposeEntry, ComposeOptions
 from mpp.server.decorator import (
     BodyParamsType,
     bind_framework_scope,
@@ -111,6 +112,7 @@ class Mpp:
                 accept a ``store`` (e.g., ``ChargeIntent``).
         """
         self.method = method
+        self.methods = (method,)
         self.realm = realm
         self.secret_key = secret_key
         self.defaults = defaults or {}
@@ -137,12 +139,13 @@ class Mpp:
 
     def _wire_store(self, store: Store) -> None:
         """Inject *store* into intents that have a ``_store`` attribute set to None."""
-        intents = getattr(self.method, "intents", None)
-        if not isinstance(intents, Mapping):
-            return
-        for intent_obj in intents.values():
-            if hasattr(intent_obj, "_store") and intent_obj._store is None:
-                intent_obj._store = store
+        for method in self.methods:
+            intents = getattr(method, "intents", None)
+            if not isinstance(intents, Mapping):
+                continue
+            for intent_obj in intents.values():
+                if hasattr(intent_obj, "_store") and intent_obj._store is None:
+                    intent_obj._store = store
 
     def _prepare_credential(
         self,
@@ -152,7 +155,7 @@ class Mpp:
         request: dict[str, Any] | None,
         meta: dict[str, str] | None = _CONTEXT_UNSET,
         body: str | bytes | dict[str, Any] | None = _CONTEXT_UNSET,
-    ) -> tuple[Credential, Intent | VerifiableIntent, dict[str, Any], Challenge]:
+    ) -> tuple[Credential, Method, Intent | VerifiableIntent, dict[str, Any], Challenge]:
         """Authenticate and resolve a credential outside an HTTP route."""
         credential = self._parse_credential(value)
 
@@ -164,7 +167,10 @@ class Mpp:
 
         if echo.realm != self.realm:
             raise InvalidChallengeError(echo.id, "credential realm does not match")
-        if echo.method != self.method.name:
+        method = next(
+            (candidate for candidate in self.methods if candidate.name == echo.method), None
+        )
+        if method is None:
             raise PaymentMethodUnsupportedError(echo.method)
         if intent is not None and echo.intent != intent:
             raise InvalidChallengeError(echo.id, "credential intent does not match")
@@ -180,7 +186,7 @@ class Mpp:
 
         if request is not None:
             expected_request = transform_request(
-                self.method,
+                method,
                 transform_units(request),
                 credential,
             )
@@ -195,11 +201,11 @@ class Mpp:
             if digest_error := _body_digest_error(echo.digest, expected_body):
                 raise InvalidChallengeError(echo.id, digest_error)
 
-        intent_obj = self.method.intents.get(echo.intent)
+        intent_obj = method.intents.get(echo.intent)
         if intent_obj is None:
             raise PaymentMethodUnsupportedError(f"{echo.method}/{echo.intent}")
         challenge = _challenge_from_echo(echo, echoed_request, echoed_opaque)
-        return credential, intent_obj, echoed_request, challenge
+        return credential, method, intent_obj, echoed_request, challenge
 
     @staticmethod
     def _parse_credential(value: Credential | str) -> Credential:
@@ -255,7 +261,7 @@ class Mpp:
             VerificationFailedError: If the intent does not support
                 non-mutating validation or rejects the credential.
         """
-        prepared, intent_obj, echoed_request, _ = self._prepare_credential(
+        prepared, _, intent_obj, echoed_request, _ = self._prepare_credential(
             credential,
             intent=intent,
             request=request,
@@ -307,7 +313,7 @@ class Mpp:
         """
         parsed = self._parse_credential(credential)
         try:
-            prepared, intent_obj, echoed_request, challenge = self._prepare_credential(
+            prepared, method, intent_obj, echoed_request, challenge = self._prepare_credential(
                 parsed,
                 intent=intent,
                 request=request,
@@ -316,6 +322,10 @@ class Mpp:
             )
         except Exception as error:
             echo = parsed.challenge
+            event_method = next(
+                (candidate.name for candidate in self.methods if candidate.name == echo.method),
+                self.method.name,
+            )
             try:
                 decoded_request = _b64_decode(echo.request) if echo.request else {}
             except ParseError:
@@ -328,7 +338,7 @@ class Mpp:
                     "credential": parsed,
                     "error": error,
                     "intent": intent or echo.intent,
-                    "method": self.method.name,
+                    "method": event_method,
                     "request": failed_request,
                 },
             )
@@ -337,7 +347,7 @@ class Mpp:
             "challenge": challenge,
             "credential": prepared,
             "intent": intent_obj.name,
-            "method": self.method.name,
+            "method": method.name,
             "request": echoed_request,
         }
         try:
@@ -353,28 +363,80 @@ class Mpp:
         return receipt
 
     @classmethod
+    @overload
     def create(
         cls,
         method: Method,
         realm: str | None = None,
         secret_key: str | None = None,
         store: Store | None = None,
+    ) -> Mpp: ...
+
+    @classmethod
+    @overload
+    def create(
+        cls,
+        *,
+        methods: Sequence[Method],
+        realm: str | None = None,
+        secret_key: str | None = None,
+        store: Store | None = None,
+    ) -> Mpp: ...
+
+    @classmethod
+    def create(
+        cls,
+        method: Method | None = None,
+        realm: str | None = None,
+        secret_key: str | None = None,
+        store: Store | None = None,
+        *,
+        methods: Sequence[Method] | None = None,
     ) -> Mpp:
         """Create an Mpp instance with smart defaults.
 
         Args:
             method: Payment method (e.g., tempo(currency=..., recipient=...)).
+            methods: Ordered payment methods. Mutually exclusive with ``method``.
             realm: Server realm. Auto-detected from environment if omitted.
             secret_key: HMAC secret. Required unless `MPP_SECRET_KEY` is set.
             store: Optional key-value store for replay protection.
                 Automatically wired into intents that accept a store.
         """
-        return cls(
-            method=method,
-            realm=detect_realm() if realm is None else realm,
-            secret_key=detect_secret_key() if secret_key is None else secret_key,
+        if method is not None and methods is not None:
+            raise ValueError("pass method= or methods=, not both")
+        configured = (
+            tuple(methods) if methods is not None else (() if method is None else (method,))
+        )
+        if not configured:
+            raise ValueError("method= or methods= is required")
+        names = [candidate.name for candidate in configured]
+        if len(set(names)) != len(names):
+            raise ValueError("payment method names must be unique")
+
+        resolved_realm = detect_realm() if realm is None else realm
+        resolved_secret_key = detect_secret_key() if secret_key is None else secret_key
+        server = cls(
+            method=configured[0],
+            realm=resolved_realm,
+            secret_key=resolved_secret_key,
             store=store,
         )
+        if len(configured) > 1:
+            server.methods = configured
+            if store is not None:
+                server._wire_store(store)
+        return server
+
+    def compose(
+        self,
+        *entries: ComposeEntry,
+        body: BodyParamsType = None,
+    ) -> ComposedHandler:
+        """Configure one or more payment offers for an endpoint."""
+        from mpp.server.compose import _configure_entries
+
+        return _configure_entries(self, entries, body)
 
     async def charge(
         self,
@@ -391,7 +453,7 @@ class Mpp:
         chain_id: int | None = None,
         extra: dict[str, str] | None = None,
         body: str | bytes | dict[str, Any] | None = None,
-    ) -> Challenge | tuple[Credential, Receipt]:
+    ) -> Challenge | ComposedResult:
         """Handle a charge intent.
 
         Args:
@@ -413,65 +475,42 @@ class Mpp:
                 digest and submitted credentials must echo a matching digest.
 
         Returns:
-            Challenge if payment required, or (Credential, Receipt) if verified.
+            Challenge, or ComposedChallenges for multiple methods, if payment
+            is required; otherwise (Credential, Receipt).
         """
-        intent = self.method.intents.get("charge")
-        if intent is None:
+        methods = [method for method in self.methods if "charge" in method.intents]
+        if not methods:
             raise ValueError(f"Method {self.method.name} does not support charge intent")
-
-        resolved_currency = currency or getattr(self.method, "currency", None)
-        resolved_recipient = recipient or getattr(self.method, "recipient", None)
-        if not resolved_currency:
-            raise ValueError("currency must be set on the method or passed to charge()")
-        if not resolved_recipient:
-            raise ValueError("recipient must be set on the method or passed to charge()")
-
-        decimals = getattr(self.method, "decimals", DEFAULT_DECIMALS)
-        base_amount = str(parse_units(amount, decimals))
-
-        request: dict[str, Any] = {
-            "amount": base_amount,
-            "currency": resolved_currency,
-            "recipient": resolved_recipient,
+        options: ComposeOptions = {
+            "amount": amount,
+            "currency": currency,
+            "recipient": recipient,
+            "expires": expires,
+            "description": description,
+            "memo": memo,
+            "splits": splits,
+            "fee_payer": fee_payer,
+            "chain_id": chain_id,
+            "extra": extra,
         }
+        if len(methods) > 1:
+            return await self.compose(
+                *((method, options) for method in methods),
+                body=body,
+            ).verify(authorization)
 
-        # Optional server-provided metadata that will be echoed back by the client
-        # because it is embedded in the base64url-encoded `request`.
-        if extra is not None:
-            if any((not isinstance(k, str) or not isinstance(v, str)) for k, v in extra.items()):
-                raise ValueError("extra must be a dict[str, str]")
-            request["extra"] = extra
-
-        resolved_chain_id = chain_id
-        if resolved_chain_id is None:
-            resolved_chain_id = getattr(self.method, "chain_id", None)
-
-        if splits and fee_payer:
-            raise ValueError("splits and fee_payer cannot be used together")
-
-        if memo or splits or fee_payer or resolved_chain_id is not None:
-            method_details: dict[str, Any] = {}
-            if resolved_chain_id is not None:
-                method_details["chainId"] = resolved_chain_id
-            if memo:
-                method_details["memo"] = memo
-            if splits:
-                method_details["splits"] = splits
-            if fee_payer:
-                method_details["feePayer"] = True
-            request["methodDetails"] = method_details
-
-        request = transform_request(self.method, request, None)
-
+        intent, request, challenge_expires = self._build_offer_request(
+            methods[0], "charge", options, None, api_name="charge"
+        )
         return await verify_or_challenge(
             authorization=authorization,
             intent=intent,
             request=request,
             realm=self.realm,
             secret_key=self.secret_key,
-            method=self.method.name,
+            method=methods[0].name,
             description=description,
-            expires=expires,
+            expires=challenge_expires,
             body=body,
             events=self._events,
         )
@@ -526,9 +565,23 @@ class Mpp:
             async def session_handler(request, credential, receipt):
                 return {"data": "session content"}
         """
-        intent_obj = self.method.intents.get(intent)
-        if intent_obj is None:
+        methods = [method for method in self.methods if intent in method.intents]
+        if not methods:
             raise ValueError(f"Method {self.method.name} does not support {intent} intent")
+        options: ComposeOptions = {
+            "amount": amount,
+            "currency": currency,
+            "recipient": recipient,
+            "description": description,
+            "expires_in": expires_in,
+            "chain_id": chain_id,
+            "extra": extra,
+        }
+        if len(methods) > 1:
+            return self.compose(
+                *((f"{method.name}/{intent}", options) for method in methods),
+                body=body,
+            )
 
         def decorator(
             handler: Callable[[Any, Credential, Receipt], Awaitable[R]],
@@ -536,53 +589,20 @@ class Mpp:
             async def _verify(
                 authorization: str | None, _request_obj: Any
             ) -> Challenge | tuple[Credential, Receipt]:
-                resolved_currency = currency or getattr(self.method, "currency", None)
-                resolved_recipient = recipient or getattr(self.method, "recipient", None)
-                if not resolved_currency:
-                    raise ValueError("currency must be set on the method or passed to pay()")
-                if not resolved_recipient:
-                    raise ValueError("recipient must be set on the method or passed to pay()")
-
-                decimals = getattr(self.method, "decimals", DEFAULT_DECIMALS)
-                base_amount = str(parse_units(amount, decimals))
-
-                challenge_expires: str | None = None
-                if expires_in is not None:
-                    challenge_expires = (datetime.now(UTC) + expires_in).isoformat()
-
-                request: dict[str, Any] = {
-                    "amount": base_amount,
-                    "currency": resolved_currency,
-                    "recipient": resolved_recipient,
-                }
-
-                if extra is not None:
-                    if any(
-                        not isinstance(k, str) or not isinstance(v, str) for k, v in extra.items()
-                    ):
-                        raise ValueError("extra must be a dict[str, str]")
-                    request["extra"] = extra
-
-                resolved_chain_id = chain_id
-                if resolved_chain_id is None:
-                    resolved_chain_id = getattr(self.method, "chain_id", None)
-                if resolved_chain_id is not None:
-                    request["methodDetails"] = {"chainId": resolved_chain_id}
-
-                request = transform_request(
-                    self.method,
-                    request,
-                    None,
+                intent_obj, request, challenge_expires = self._build_offer_request(
+                    methods[0],
+                    intent,
+                    options,
+                    _request_obj,
+                    api_name="pay",
                 )
-                request = bind_framework_scope(request, _request_obj)
-
                 return await verify_or_challenge(
                     authorization=authorization,
                     intent=intent_obj,
                     request=request,
                     realm=self.realm,
                     secret_key=self.secret_key,
-                    method=self.method.name,
+                    method=methods[0].name,
                     description=description,
                     expires=challenge_expires,
                     body=await resolve_body_param(body, _request_obj),
@@ -592,3 +612,65 @@ class Mpp:
             return wrap_payment_handler(handler, _verify, lambda: self.realm)
 
         return decorator
+
+    def _build_offer_request(
+        self,
+        method: Method,
+        intent_name: str,
+        options: Mapping[str, Any],
+        request_obj: Any,
+        *,
+        api_name: Literal["charge", "pay", "compose"],
+    ) -> tuple[Intent | VerifiableIntent, dict[str, Any], str | None]:
+        """Build the canonical request shared by one configured payment offer."""
+        intent = method.intents[intent_name]
+        currency = options.get("currency") or getattr(method, "currency", None)
+        recipient = options.get("recipient") or getattr(method, "recipient", None)
+        if not currency:
+            raise ValueError(f"currency must be set on the method or passed to {api_name}()")
+        if not recipient:
+            raise ValueError(f"recipient must be set on the method or passed to {api_name}()")
+
+        request: dict[str, Any] = {
+            "amount": str(
+                parse_units(options["amount"], getattr(method, "decimals", DEFAULT_DECIMALS))
+            ),
+            "currency": currency,
+            "recipient": recipient,
+        }
+        extra = options.get("extra")
+        if extra is not None:
+            if any(
+                not isinstance(key, str) or not isinstance(value, str)
+                for key, value in extra.items()
+            ):
+                raise ValueError("extra must be a dict[str, str]")
+            request["extra"] = extra
+
+        chain_id = options.get("chain_id")
+        if chain_id is None:
+            chain_id = getattr(method, "chain_id", None)
+        splits = options.get("splits")
+        fee_payer = options.get("fee_payer", False)
+        if splits and fee_payer:
+            raise ValueError("splits and fee_payer cannot be used together")
+        memo = options.get("memo")
+        details = {
+            key: value
+            for key, value in (("memo", memo), ("splits", splits), ("feePayer", fee_payer))
+            if value
+        }
+        if chain_id is not None:
+            details["chainId"] = chain_id
+        if details:
+            request["methodDetails"] = details
+
+        expires = options.get("expires")
+        expires_in = options.get("expires_in")
+        if expires is not None and expires_in is not None:
+            raise ValueError("expires and expires_in cannot both be set")
+        if expires_in is not None:
+            expires = (datetime.now(UTC) + expires_in).isoformat()
+
+        request = transform_request(method, request, None)
+        return intent, bind_framework_scope(request, request_obj), expires

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -1,0 +1,342 @@
+"""Externally meaningful guarantees for composed server payments."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, cast
+
+import pytest
+
+from mpp import Challenge, Credential, Receipt
+from mpp.server import ComposedChallenges, Intent, Mpp, VerifiableIntent, compose
+from mpp.store import MemoryStore
+from tests import MockRequest
+
+
+class MockIntent:
+    def __init__(self, name: str, reference: str) -> None:
+        self.name = name
+        self.reference = reference
+        self._store: MemoryStore | None = None
+        self.settlements = 0
+
+    async def verify(self, credential: Credential, request: dict[str, Any]) -> Receipt:
+        del credential, request
+        self.settlements += 1
+        return Receipt.success(self.reference)
+
+
+class MockMethod:
+    def __init__(self, name: str, intent: str = "charge", reference: str | None = None) -> None:
+        self.name = name
+        self.currency = f"{name}-currency"
+        self.recipient = f"{name}-recipient"
+        self.decimals = 2
+        self.intent = MockIntent(intent, reference or name)
+        self.intents: Mapping[str, Intent | VerifiableIntent] = {intent: self.intent}
+
+    def transform_request(
+        self,
+        request: dict[str, Any],
+        _credential: Credential | None,
+    ) -> dict[str, Any]:
+        return {**request, "transformedBy": self.name}
+
+    async def create_credential(self, challenge: Challenge) -> Credential:
+        del challenge
+        raise NotImplementedError
+
+
+def response_challenges(response: Any) -> list[Challenge]:
+    if hasattr(response, "raw_headers"):
+        values = [
+            value.decode()
+            for name, value in response.raw_headers
+            if name.lower() == b"www-authenticate"
+        ]
+    else:
+        raw = response["headers"]["WWW-Authenticate"]
+        values = [raw] if isinstance(raw, str) else raw
+    return [Challenge.from_www_authenticate(value) for value in values]
+
+
+def credential(challenge: Challenge) -> Credential:
+    return Credential(challenge=challenge.to_echo(), payload={})
+
+
+def test_multi_method_creation_wires_store_and_validates_configuration() -> None:
+    class Server(Mpp):
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            self.received_store = kwargs.get("store")
+            super().__init__(*args, **kwargs)
+
+    first = MockMethod("first")
+    second = MockMethod("second")
+    store = MemoryStore()
+    server = Server.create(
+        methods=[first, second],
+        realm="api.example.com",
+        secret_key="secret",
+        store=store,
+    )
+
+    assert isinstance(server, Server)
+    assert server.method is first
+    assert server.methods == (first, second)
+    assert first.intent._store is store
+    assert second.intent._store is store
+    assert server.received_store is store
+
+    create = cast(Any, Mpp.create)
+    with pytest.raises(ValueError, match="method= or methods="):
+        create(realm="api.example.com", secret_key="secret")
+    with pytest.raises(ValueError, match="not both"):
+        create(method=first, methods=[second])
+    with pytest.raises(ValueError, match="unique"):
+        Mpp.create(
+            methods=[first, first],
+            realm="api.example.com",
+            secret_key="secret",
+        )
+
+
+def test_compose_validates_public_entries_at_configuration_time() -> None:
+    method = MockMethod("first")
+    server = Mpp.create(method=method, realm="api.example.com", secret_key="secret")
+
+    with pytest.raises(ValueError, match="at least one entry"):
+        server.compose()
+    with pytest.raises(ValueError, match="non-empty string amount"):
+        server.compose(cast(Any, (method, {})))
+    with pytest.raises(ValueError, match="unsupported compose option"):
+        server.compose(cast(Any, (method, {"amount": "1", "ammount": "1"})))
+    with pytest.raises(ValueError, match="does not support refund"):
+        server.compose(cast(Any, ("first/refund", {"amount": "1"})))
+    with pytest.raises(ValueError, match="unknown payment method"):
+        server.compose(cast(Any, ("other", {"amount": "1"})))
+
+
+@pytest.mark.asyncio
+async def test_explicit_compose_renders_all_offers_and_dispatches_one_payment() -> None:
+    first = MockMethod("first")
+    second = MockMethod("second")
+    server = Mpp.create(
+        methods=[first, second],
+        realm="api.example.com",
+        secret_key="secret",
+    )
+    successes: list[dict[str, Any]] = []
+    server.on_payment_success(successes.append)
+    configured = server.compose(
+        (first, {"amount": "1.50"}),
+        ("second/charge", {"amount": "2.00"}),
+    )
+
+    @configured
+    async def endpoint(
+        _request: MockRequest,
+        _credential: Credential,
+        receipt: Receipt,
+    ) -> str:
+        return receipt.reference
+
+    request = MockRequest(path="/paid", route="/paid")
+    challenges = response_challenges(await endpoint(request))
+    assert [item.request["amount"] for item in challenges] == ["150", "200"]
+
+    paid_request = MockRequest(
+        authorization=credential(challenges[1]).to_authorization(),
+        path="/paid",
+        route="/paid",
+    )
+    assert await endpoint(paid_request) == "second"
+    assert second.intent.settlements == 1
+    assert [event["method"] for event in successes] == ["second"]
+
+
+@pytest.mark.asyncio
+async def test_implicit_charge_and_pay_are_composition_conveniences() -> None:
+    first = MockMethod("first")
+    second = MockMethod("second")
+    server = Mpp.create(
+        methods=[first, second],
+        realm="api.example.com",
+        secret_key="secret",
+    )
+
+    unpaid = await server.charge(None, "1.50")
+    assert isinstance(unpaid, ComposedChallenges)
+    assert [item.method for item in unpaid.challenges] == ["first", "second"]
+    paid = await server.charge(
+        credential(unpaid.challenges[1]).to_authorization(),
+        "1.50",
+    )
+    assert not isinstance(paid, (Challenge, ComposedChallenges))
+    assert paid[1].reference == "second"
+
+    @server.pay(amount="2.00")
+    async def endpoint(
+        _request: MockRequest,
+        _credential: Credential,
+        receipt: Receipt,
+    ) -> str:
+        return receipt.reference
+
+    challenges = response_challenges(await endpoint(MockRequest(path="/paid")))
+    assert [item.method for item in challenges] == ["first", "second"]
+    assert (
+        await endpoint(
+            MockRequest(
+                authorization=credential(challenges[0]).to_authorization(),
+                path="/paid",
+            )
+        )
+        == "first"
+    )
+
+    only_charge = Mpp.create(
+        methods=[MockMethod("charge"), MockMethod("session", intent="session")],
+        realm="api.example.com",
+        secret_key="secret",
+    )
+    assert isinstance(await only_charge.charge(None, "1.00"), Challenge)
+
+
+@pytest.mark.asyncio
+async def test_implicit_pay_supports_shared_non_charge_intents() -> None:
+    first = MockMethod("first", intent="session")
+    second = MockMethod("second", intent="session")
+    server = Mpp.create(
+        methods=[first, second],
+        realm="api.example.com",
+        secret_key="secret",
+    )
+
+    @server.pay(amount="1.00", intent="session")
+    async def endpoint(
+        _request: MockRequest,
+        _credential: Credential,
+        receipt: Receipt,
+    ) -> str:
+        return receipt.reference
+
+    challenges = response_challenges(await endpoint(MockRequest(path="/session")))
+    assert [item.intent for item in challenges] == ["session", "session"]
+    assert (
+        await endpoint(
+            MockRequest(
+                authorization=credential(challenges[1]).to_authorization(),
+                path="/session",
+            )
+        )
+        == "second"
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("first_realm", "second_realm", "second_secret", "second_body"),
+    [
+        ("first.example.com", "second.example.com", "first-secret", b"first"),
+        ("shared.example.com", "shared.example.com", "second-secret", b"first"),
+        ("shared.example.com", "shared.example.com", "first-secret", b"second"),
+    ],
+)
+async def test_static_nested_compose_preserves_cross_instance_ownership(
+    first_realm: str,
+    second_realm: str,
+    second_secret: str,
+    second_body: bytes,
+) -> None:
+    first_method = MockMethod("shared", reference="first")
+    second_method = MockMethod("shared", reference="second")
+    first = Mpp.create(
+        method=first_method,
+        realm=first_realm,
+        secret_key="first-secret",
+    )
+    second = Mpp.create(
+        method=second_method,
+        realm=second_realm,
+        secret_key=second_secret,
+    )
+    first_events: list[dict[str, Any]] = []
+    second_events: list[dict[str, Any]] = []
+    first.on_payment_success(first_events.append)
+    second.on_payment_success(second_events.append)
+    first_offer = first.compose((first_method, {"amount": "1.00"}), body=b"first")
+    second_offer = second.compose((second_method, {"amount": "1.00"}), body=second_body)
+    configured = compose(first_offer, compose(second_offer))
+
+    @configured
+    async def endpoint(
+        _request: MockRequest,
+        _credential: Credential,
+        receipt: Receipt,
+    ) -> str:
+        return receipt.reference
+
+    challenges = response_challenges(await endpoint(MockRequest()))
+    assert [item.realm for item in challenges] == [first_realm, second_realm]
+    assert challenges[0].request == challenges[1].request
+
+    paid = await configured.verify(credential(challenges[1]).to_authorization())
+    assert not isinstance(paid, ComposedChallenges)
+    assert paid[1].reference == "second"
+    assert first_method.intent.settlements == 0
+    assert first_events == []
+    assert len(second_events) == 1
+
+
+@pytest.mark.asyncio
+async def test_repeated_offers_keep_body_hmac_and_route_scope_bindings() -> None:
+    method = MockMethod("first")
+    server = Mpp.create(method=method, realm="api.example.com", secret_key="secret")
+    failures: list[dict[str, Any]] = []
+    server.on_payment_failed(failures.append)
+    body_calls = 0
+
+    def body(request: MockRequest) -> bytes:
+        nonlocal body_calls
+        body_calls += 1
+        assert request.body is not None
+        return request.body
+
+    configured = server.compose(
+        (method, {"amount": "1.00"}),
+        (method, {"amount": "2.00"}),
+        body=body,
+    )
+    request = MockRequest(path="/paid", route="/paid", body=b"bound body")
+    unpaid = await configured.verify(None, request)
+    assert isinstance(unpaid, ComposedChallenges)
+    assert [item.request["amount"] for item in unpaid.challenges] == ["100", "200"]
+    assert body_calls == 1
+    selected = credential(unpaid.challenges[1])
+
+    forged = Credential(
+        challenge=Challenge.create(
+            secret_key="wrong-secret",
+            realm="api.example.com",
+            method="first",
+            intent="charge",
+            request=unpaid.challenges[1].request,
+            expires=unpaid.challenges[1].expires,
+            digest=unpaid.challenges[1].digest,
+        ).to_echo(),
+        payload={},
+    )
+    rejected = [
+        (forged, request),
+        (selected, MockRequest(path="/paid", route="/paid", body=b"wrong body")),
+        (selected, MockRequest(path="/other", route="/other", body=b"bound body")),
+    ]
+    for submitted, submitted_request in rejected:
+        result = await configured.verify(submitted.to_authorization(), submitted_request)
+        assert isinstance(result, ComposedChallenges)
+
+    paid = await configured.verify(selected.to_authorization(), request)
+    assert not isinstance(paid, ComposedChallenges)
+    assert paid[1].reference == "first"
+    assert method.intent.settlements == 1
+    assert len(failures) == 3

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from dataclasses import replace
 from typing import Any, cast
 
 import pytest
@@ -110,6 +111,8 @@ def test_compose_validates_public_entries_at_configuration_time() -> None:
         server.compose(cast(Any, (method, {})))
     with pytest.raises(ValueError, match="unsupported compose option"):
         server.compose(cast(Any, (method, {"amount": "1", "ammount": "1"})))
+    with pytest.raises(ValueError, match=r"meta must be a dict\[str, str\]"):
+        server.compose(cast(Any, (method, {"amount": "1", "meta": {"plan": 1}})))
     with pytest.raises(ValueError, match="does not support refund"):
         server.compose(cast(Any, ("first/refund", {"amount": "1"})))
     with pytest.raises(ValueError, match="unknown payment method"):
@@ -286,6 +289,156 @@ async def test_static_nested_compose_preserves_cross_instance_ownership(
     assert first_method.intent.settlements == 0
     assert first_events == []
     assert len(second_events) == 1
+
+
+@pytest.mark.asyncio
+async def test_meta_disambiguates_wire_identical_cross_instance_offers() -> None:
+    first_method = MockMethod("shared", reference="first")
+    second_method = MockMethod("shared", reference="second")
+    first = Mpp.create(
+        method=first_method,
+        realm="shared.example.com",
+        secret_key="shared-secret",
+    )
+    second = Mpp.create(
+        method=second_method,
+        realm="shared.example.com",
+        secret_key="shared-secret",
+    )
+    configured = compose(
+        first.compose((first_method, {"amount": "1.00", "meta": {"plan": "first"}})),
+        second.compose((second_method, {"amount": "1.00", "meta": {"plan": "second"}})),
+    )
+
+    unpaid = await configured.verify(None)
+    assert isinstance(unpaid, ComposedChallenges)
+    assert [challenge.opaque for challenge in unpaid.challenges] == [
+        {"plan": "first"},
+        {"plan": "second"},
+    ]
+
+    paid = await configured.verify(credential(unpaid.challenges[1]).to_authorization())
+    assert not isinstance(paid, ComposedChallenges)
+    assert paid[1].reference == "second"
+    assert first_method.intent.settlements == 0
+    assert second_method.intent.settlements == 1
+
+
+@pytest.mark.asyncio
+async def test_wire_identical_cross_instance_offers_fail_closed() -> None:
+    first_method = MockMethod("shared", reference="first")
+    second_method = MockMethod("shared", reference="second")
+    first = Mpp.create(
+        method=first_method,
+        realm="shared.example.com",
+        secret_key="shared-secret",
+    )
+    second = Mpp.create(
+        method=second_method,
+        realm="shared.example.com",
+        secret_key="shared-secret",
+    )
+    configured = compose(
+        first.compose((first_method, {"amount": "1.00"})),
+        second.compose((second_method, {"amount": "1.00"})),
+    )
+
+    unpaid = await configured.verify(None)
+    assert isinstance(unpaid, ComposedChallenges)
+    rejected = await configured.verify(credential(unpaid.challenges[1]).to_authorization())
+
+    assert isinstance(rejected, ComposedChallenges)
+    assert len(rejected.challenges) == 2
+    assert first_method.intent.settlements == 0
+    assert second_method.intent.settlements == 0
+
+
+@pytest.mark.asyncio
+async def test_composed_offer_rejects_tampered_opaque() -> None:
+    method = MockMethod("first")
+    server = Mpp.create(
+        method=method,
+        realm="api.example.com",
+        secret_key="shared-secret",
+    )
+    configured = server.compose(
+        (method, {"amount": "1.00", "meta": {"plan": "original"}}),
+    )
+    unpaid = await configured.verify(None)
+    assert isinstance(unpaid, ComposedChallenges)
+    challenge = unpaid.challenges[0]
+    tampered_opaque = (
+        Challenge.create(
+            secret_key="shared-secret",
+            realm=challenge.realm,
+            method=challenge.method,
+            intent=challenge.intent,
+            request=challenge.request,
+            expires=challenge.expires,
+            digest=challenge.digest,
+            meta={"plan": "tampered"},
+        )
+        .to_echo()
+        .opaque
+    )
+    tampered = Credential(
+        challenge=replace(challenge.to_echo(), opaque=tampered_opaque),
+        payload={},
+    )
+
+    rejected = await configured.verify(tampered.to_authorization())
+    assert isinstance(rejected, ComposedChallenges)
+    assert method.intent.settlements == 0
+
+
+@pytest.mark.asyncio
+async def test_compose_rejects_unusable_authorization_without_settlement() -> None:
+    first = MockMethod("first")
+    second = MockMethod("second")
+    server = Mpp.create(
+        methods=[first, second],
+        realm="api.example.com",
+        secret_key="shared-secret",
+    )
+    configured = server.compose(
+        (first, {"amount": "1.00"}),
+        (second, {"amount": "2.00"}),
+    )
+    unpaid = await configured.verify(None)
+    assert isinstance(unpaid, ComposedChallenges)
+    first_challenge = unpaid.challenges[0]
+    unusable = [
+        "Bearer token",
+        "Payment not-base64!!",
+        credential(
+            Challenge.create(
+                secret_key="shared-secret",
+                realm=first_challenge.realm,
+                method="unknown",
+                intent="charge",
+                request=first_challenge.request,
+                expires=first_challenge.expires,
+            )
+        ).to_authorization(),
+        credential(
+            Challenge.create(
+                secret_key="shared-secret",
+                realm=first_challenge.realm,
+                method="first",
+                intent="refund",
+                request=first_challenge.request,
+                expires=first_challenge.expires,
+            )
+        ).to_authorization(),
+    ]
+
+    for authorization in unusable:
+        rejected = await configured.verify(authorization)
+        assert isinstance(rejected, ComposedChallenges)
+        assert len(rejected.challenges) == 2
+
+    assert first.intent.settlements == 0
+    assert second.intent.settlements == 0
 
 
 @pytest.mark.asyncio

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -218,6 +218,7 @@ async def test_bound_broadcast_emits_failures() -> None:
     [
         (_bound(realm="other.example.com"), None),
         (_bound({"amount": "1000"}), {"amount": "2000"}),
+        (_bound(method="stripe"), None),
     ],
 )
 async def test_bound_broadcast_emits_preparation_failures(
@@ -228,13 +229,14 @@ async def test_bound_broadcast_emits_preparation_failures(
     failures: list[dict[str, Any]] = []
     server.on_payment_failed(failures.append)
 
-    with pytest.raises(InvalidChallengeError):
+    with pytest.raises((InvalidChallengeError, PaymentMethodUnsupportedError)):
         await server.broadcast_credential(credential, request=route_request)
 
     assert len(failures) == 1
     assert failures[0]["challenge"].id == credential.challenge.id
     assert failures[0]["credential"] == credential
-    assert isinstance(failures[0]["error"], InvalidChallengeError)
+    assert failures[0]["method"] == "tempo"
+    assert isinstance(failures[0]["error"], (InvalidChallengeError, PaymentMethodUnsupportedError))
 
 
 @pytest.mark.asyncio

--- a/tests/typecheck/compose_consumer.py
+++ b/tests/typecheck/compose_consumer.py
@@ -1,0 +1,35 @@
+# pyright: reportUnnecessaryTypeIgnoreComment=error
+"""Consumer-facing type probes for payment composition."""
+
+from typing import assert_type
+
+import mpp.server as server_api
+from mpp import Challenge, Credential, Receipt
+from mpp.methods.tempo import ChargeIntent, tempo
+
+method = tempo(
+    intents={"charge": ChargeIntent()},
+    currency="usd",
+    recipient="acct_consumer",
+)
+server = server_api.Mpp.create(method=method, realm="example.com", secret_key="secret")
+options: server_api.ComposeOptions = {"amount": "1.00"}
+entry: server_api.ComposeEntry = (method, options)
+handler = server.compose(entry)
+assert_type(handler, server_api.ComposedHandler)
+assert_type(server_api.compose(handler), server_api.ComposedHandler)
+
+
+async def check_result() -> None:
+    result = await handler.verify(None)
+    assert_type(result, server_api.ComposedResult)
+    if isinstance(result, server_api.ComposedChallenges):
+        assert_type(result.challenges, tuple[Challenge, ...])
+    else:
+        assert_type(result, tuple[Credential, Receipt])
+
+
+server.compose((method, {}))  # pyright: ignore[reportArgumentType]
+server.compose((method, {"amount": 1}))  # pyright: ignore[reportArgumentType]
+server_api.Mpp.create()  # pyright: ignore[reportCallIssue]
+server_api.Mpp.create(method=method, methods=[method])  # pyright: ignore[reportCallIssue]

--- a/tests/typecheck/compose_consumer.py
+++ b/tests/typecheck/compose_consumer.py
@@ -13,7 +13,7 @@ method = tempo(
     recipient="acct_consumer",
 )
 server = server_api.Mpp.create(method=method, realm="example.com", secret_key="secret")
-options: server_api.ComposeOptions = {"amount": "1.00"}
+options: server_api.ComposeOptions = {"amount": "1.00", "meta": {"plan": "pro"}}
 entry: server_api.ComposeEntry = (method, options)
 handler = server.compose(entry)
 assert_type(handler, server_api.ComposedHandler)


### PR DESCRIPTION
Allow one endpoint to offer and accept multiple payment methods while preserving each handler's authentication and settlement context.

- Add explicit composition for independently configured handlers.
- Route implicit multi-method charge and pay through the same composition path.
- Preserve existing single-method behavior and public result shapes.

Reference: https://github.com/wevm/mppx/pull/166