### PR TITLE
feat: add requires_auth so Payment credentials use Payment-Authorization

### DIFF
--- a/.changelog/payment-authorization-header.md
+++ b/.changelog/payment-authorization-header.md
@@ -1,0 +1,5 @@
+---
+pympp: patch
+---
+
+Added a `requires_auth` server option that uses `Payment-Authorization` for Payment credentials so `Authorization` remains available for application authentication.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ server = Mpp.create(
 @app.get("/paid")
 @server.pay(amount="0.50")
 async def handler(request, credential: Credential, receipt: Receipt):
-        return {"data": "...", "payer": credential.source}
+    return {"data": "...", "payer": credential.source}
 ```
 
 If the endpoint already uses `Authorization` (API keys, Bearer tokens), create the server with `requires_auth=True`. Challenges then advertise `header="Payment-Authorization"`, and clients send the Payment credential in that header instead of `Authorization`.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,19 @@ server = Mpp.create(
 @app.get("/paid")
 @server.pay(amount="0.50")
 async def handler(request, credential: Credential, receipt: Receipt):
-    return {"data": "...", "payer": credential.source}
+        return {"data": "...", "payer": credential.source}
+```
+
+If the endpoint already uses `Authorization` (API keys, Bearer tokens), create the server with `requires_auth=True`. Challenges then advertise `header="Payment-Authorization"`, and clients send the Payment credential in that header instead of `Authorization`.
+
+```python
+server = Mpp.create(method=tempo(...), requires_auth=True)
+
+result = await server.charge(
+    authorization=request.headers.get("Authorization"),
+    amount="0.50",
+    payment_authorization=request.headers.get("Payment-Authorization"),
+)
 ```
 
 ### Client

--- a/examples/httpx-client.md
+++ b/examples/httpx-client.md
@@ -89,6 +89,6 @@ async with httpx.AsyncClient() as client:
     # Retry with credential
     res2 = await client.get(
         "https://api.example.com/resource",
-        headers={"Authorization": credential.to_authorization()},
+        headers={challenge.credential_header: credential.to_authorization()},
     )
 ```

--- a/src/mpp/__init__.py
+++ b/src/mpp/__init__.py
@@ -9,6 +9,7 @@ import base64
 import hashlib
 import hmac
 import json
+import re
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any, Literal
@@ -49,6 +50,29 @@ from mpp.events import (
     PaymentEventName,
 )
 
+AUTHORIZATION_HEADER = "Authorization"
+PAYMENT_AUTHORIZATION_HEADER = "Payment-Authorization"
+_HTTP_HEADER_NAME_RE = re.compile(r"^[!#$%&'*+.^_`|~0-9A-Za-z-]+$")
+
+
+def is_default_credential_header(header: str | None) -> bool:
+    """True when the credential header is omitted or is the implicit Authorization default."""
+    return header is None or header == "" or header.lower() == AUTHORIZATION_HEADER.lower()
+
+
+def advertised_credential_header(header: str | None) -> str | None:
+    """Return an advertised credential header, or None for the Authorization default.
+
+    ``Authorization`` is the implicit protocol default and is intentionally not
+    advertised on the wire. This preserves the legacy challenge binding.
+    """
+    if is_default_credential_header(header):
+        return None
+    name = str(header)
+    if not _HTTP_HEADER_NAME_RE.fullmatch(name):
+        raise ValueError("Invalid HTTP header name")
+    return name
+
 
 def _b64url_encode(data: str) -> str:
     """Encode a string to base64url without padding."""
@@ -72,6 +96,7 @@ def generate_challenge_id(
     expires: str | None = None,
     digest: str | None = None,
     opaque: dict[str, str] | None = None,
+    header: str | None = None,
 ) -> str:
     """Generate HMAC-SHA256 challenge ID per spec.
 
@@ -80,8 +105,10 @@ def generate_challenge_id(
     verification - the server can verify a challenge was issued by it without
     storing state.
 
-    HMAC input format: realm|method|intent|request_b64|expires|digest|opaque (pipe-delimited).
-    All fields are always included; absent optional fields use empty string.
+    HMAC input format: realm|method|intent|request_b64|expires|digest|opaque
+    (pipe-delimited). Challenges that advertise a credential header insert it
+    immediately before the final opaque slot. Authorization is the implicit
+    default and is never included, preserving the legacy binding.
     Output: base64url(HMAC-SHA256(secret_key, input))
 
     Args:
@@ -93,6 +120,8 @@ def generate_challenge_id(
         expires: Optional expiration timestamp (ISO 8601).
         digest: Optional digest of request body.
         opaque: Optional server-defined correlation data.
+        header: Optional HTTP field for the Payment credential. Authorization
+            is omitted; any other value is bound into the ID.
 
     Returns:
         Base64url-encoded HMAC-SHA256 of the challenge parameters.
@@ -114,17 +143,19 @@ def generate_challenge_id(
         opaque_json = json.dumps(opaque, separators=(",", ":"), sort_keys=True, ensure_ascii=False)
         opaque_b64 = _b64url_encode(opaque_json)
 
-    hmac_input = "|".join(
-        [
-            realm,
-            method,
-            intent,
-            request_b64,
-            expires or "",
-            digest or "",
-            opaque_b64,
-        ]
-    )
+    hmac_parts = [
+        realm,
+        method,
+        intent,
+        request_b64,
+        expires or "",
+        digest or "",
+    ]
+    advertised = advertised_credential_header(header)
+    if advertised:
+        hmac_parts.append(advertised)
+    hmac_parts.append(opaque_b64)
+    hmac_input = "|".join(hmac_parts)
 
     mac = hmac.new(
         secret_key.encode("utf-8"),
@@ -172,6 +203,17 @@ class Challenge:
     expires: str | None = None
     description: str | None = None
     opaque: dict[str, str] | None = None
+    header: str | None = None
+
+    def __post_init__(self) -> None:
+        advertised = advertised_credential_header(self.header)
+        if advertised != self.header:
+            object.__setattr__(self, "header", advertised)
+
+    @property
+    def credential_header(self) -> str:
+        """HTTP field a client must use for the payment credential."""
+        return self.header or AUTHORIZATION_HEADER
 
     @classmethod
     def create(
@@ -186,6 +228,7 @@ class Challenge:
         digest: str | None = None,
         description: str | None = None,
         meta: dict[str, str] | None = None,
+        header: str | None = None,
     ) -> Challenge:
         """Create a Challenge with an HMAC-bound ID.
 
@@ -204,10 +247,13 @@ class Challenge:
             digest: Optional digest of request body.
             description: Optional human-readable description.
             meta: Optional server-defined correlation data (stored as opaque).
+            header: Optional HTTP field for the Payment credential. Authorization
+                is the implicit default and is not advertised.
 
         Returns:
             A Challenge with an HMAC-bound ID.
         """
+        header = advertised_credential_header(header)
         challenge_id = generate_challenge_id(
             secret_key=secret_key,
             realm=realm,
@@ -217,6 +263,7 @@ class Challenge:
             expires=expires,
             digest=digest,
             opaque=meta,
+            header=header,
         )
         request_json = json.dumps(
             request,
@@ -236,6 +283,7 @@ class Challenge:
             expires=expires,
             description=description,
             opaque=meta,
+            header=header,
         )
 
     @classmethod
@@ -271,6 +319,7 @@ class Challenge:
             expires=self.expires,
             digest=self.digest,
             opaque=self.opaque,
+            header=self.header,
         )
         return _constant_time_equal(self.id, expected_id)
 
@@ -298,6 +347,7 @@ class Challenge:
             expires=self.expires,
             digest=self.digest,
             opaque=opaque_b64,
+            header=self.header,
         )
 
 
@@ -326,6 +376,12 @@ class ChallengeEcho:
     expires: str | None = None
     digest: str | None = None
     opaque: str | None = None
+    header: str | None = None
+
+    def __post_init__(self) -> None:
+        advertised = advertised_credential_header(self.header)
+        if advertised != self.header:
+            object.__setattr__(self, "header", advertised)
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/mpp/_parsing.py
+++ b/src/mpp/_parsing.py
@@ -102,9 +102,9 @@ def parse_www_authenticate(header: str) -> Challenge:
     Expected format (per IETF draft-ietf-httpauth-payment):
         Payment id="...", realm="...", method="...", intent="...", request="<base64url>"
 
-    Optional parameters: digest, expires, description
+    Optional parameters: digest, expires, description, header, opaque
     """
-    from mpp import Challenge
+    from mpp import Challenge, advertised_credential_header
 
     header = header.strip()
 
@@ -145,6 +145,11 @@ def parse_www_authenticate(header: str) -> Challenge:
     if opaque_b64:
         opaque = _b64_decode(opaque_b64)
 
+    try:
+        credential_header = advertised_credential_header(params.get("header"))
+    except ValueError as error:
+        raise ParseError(str(error)) from error
+
     return Challenge(
         id=id_,
         method=method,
@@ -156,6 +161,7 @@ def parse_www_authenticate(header: str) -> Challenge:
         expires=params.get("expires"),
         description=params.get("description"),
         opaque=opaque,
+        header=credential_header,
     )
 
 
@@ -184,6 +190,8 @@ def format_www_authenticate(challenge: Challenge, realm: str) -> str:
         parts.append(f'expires="{_escape_quoted(challenge.expires)}"')
     if challenge.description:
         parts.append(f'description="{_escape_quoted(challenge.description)}"')
+    if challenge.header:
+        parts.append(f'header="{_escape_quoted(challenge.header)}"')
     if challenge.opaque is not None:
         opaque_b64 = _b64_encode(challenge.opaque)
         parts.append(f'opaque="{opaque_b64}"')
@@ -202,7 +210,7 @@ def parse_authorization(header: str) -> Credential:
         - payload: Method-specific credential data
         - source: Optional payer DID
     """
-    from mpp import ChallengeEcho, Credential
+    from mpp import ChallengeEcho, Credential, advertised_credential_header
 
     header = header.strip()
 
@@ -226,6 +234,13 @@ def parse_authorization(header: str) -> Credential:
     method = str(challenge_data.get("method", ""))
     _validate_payment_method_id(method)
 
+    try:
+        credential_header = advertised_credential_header(
+            str(challenge_data["header"]) if challenge_data.get("header") else None
+        )
+    except ValueError as error:
+        raise ParseError(str(error)) from error
+
     echo = ChallengeEcho(
         id=str(challenge_data["id"]),
         realm=str(challenge_data.get("realm", "")),
@@ -235,6 +250,7 @@ def parse_authorization(header: str) -> Credential:
         expires=str(challenge_data["expires"]) if challenge_data.get("expires") else None,
         digest=str(challenge_data["digest"]) if challenge_data.get("digest") else None,
         opaque=str(challenge_data["opaque"]) if challenge_data.get("opaque") else None,
+        header=credential_header,
     )
 
     return Credential(
@@ -266,6 +282,8 @@ def format_authorization(credential: Credential) -> str:
         challenge_dict["expires"] = credential.challenge.expires
     if credential.challenge.digest:
         challenge_dict["digest"] = credential.challenge.digest
+    if credential.challenge.header:
+        challenge_dict["header"] = credential.challenge.header
     if credential.challenge.opaque is not None:
         challenge_dict["opaque"] = credential.challenge.opaque
 

--- a/src/mpp/client/transport.py
+++ b/src/mpp/client/transport.py
@@ -4,7 +4,7 @@ Implements automatic 402 Payment Required handling by:
 1. Sending the initial request
 2. If 402, parsing the WWW-Authenticate challenge
 3. Finding a matching method to create credentials
-4. Retrying with the Authorization header
+4. Retrying with the credential header selected by the challenge
 """
 
 from __future__ import annotations
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING, Any
 
 import httpx
 
-from mpp import Challenge, Credential
+from mpp import AUTHORIZATION_HEADER, PAYMENT_AUTHORIZATION_HEADER, Challenge, Credential
 from mpp._parsing import ParseError
 from mpp.errors import (
     InvalidChallengeError,
@@ -41,6 +41,22 @@ if TYPE_CHECKING:
 
 _MAX_PAYMENT_RETRIES = 3
 _ORIGINAL_ORIGIN_EXTENSION = "mpp.original_origin"
+_CREDENTIAL_HEADERS = (AUTHORIZATION_HEADER, PAYMENT_AUTHORIZATION_HEADER)
+
+
+def _set_payment_credential(headers: httpx.Headers, header: str, value: str) -> None:
+    """Attach a Payment credential, preserving ordinary Authorization values."""
+    for stale in _CREDENTIAL_HEADERS:
+        existing = headers.get(stale)
+        if (
+            existing is not None
+            and stale.lower() == AUTHORIZATION_HEADER.lower()
+            and not existing.startswith("Payment ")
+        ):
+            continue
+        if existing is not None:
+            del headers[stale]
+    headers[header] = value
 
 
 def _origin(url: httpx.URL) -> tuple[str, str, int | None]:
@@ -250,7 +266,7 @@ class PaymentTransport(httpx.AsyncBaseTransport):
                 raise
 
             headers = httpx.Headers(request.headers)
-            headers["Authorization"] = auth_header
+            _set_payment_credential(headers, challenge.credential_header, auth_header)
             retry_request = httpx.Request(
                 method=request.method,
                 url=request.url,

--- a/src/mpp/server/compose.py
+++ b/src/mpp/server/compose.py
@@ -99,6 +99,7 @@ class _PreparedOffer:
             expires=self.expires,
             body=self.body,
             events=server._events,
+            header=server.credential_header,
         )
 
 
@@ -197,7 +198,13 @@ class ComposedHandler:
         handler: Callable[[Any, Credential, Receipt], Awaitable[R]],
     ) -> Callable[[Any], Awaitable[R | Any]]:
         """Wrap a payment-protected endpoint."""
-        return wrap_payment_handler(handler, self.verify, lambda: self._offers[0].server.realm)
+        server = self._offers[0].server
+        return wrap_payment_handler(
+            handler,
+            self.verify,
+            lambda: server.realm,
+            requires_auth=server.requires_auth,
+        )
 
     @staticmethod
     def _select_offer(

--- a/src/mpp/server/decorator.py
+++ b/src/mpp/server/decorator.py
@@ -8,7 +8,7 @@ from collections.abc import Awaitable, Callable, Sequence
 from functools import wraps
 from typing import TYPE_CHECKING, Any, TypeVar
 
-from mpp import Challenge, Credential, Receipt
+from mpp import PAYMENT_AUTHORIZATION_HEADER, Challenge, Credential, Receipt
 from mpp.errors import PaymentError, PaymentRequiredError
 from mpp.events import EventDispatcher
 from mpp.server._defaults import detect_realm, detect_secret_key
@@ -31,10 +31,29 @@ def get_authorization(request: Any) -> str | None:
     Supports Starlette/FastAPI (request.headers), Django (request.META),
     and any object with a ``headers`` dict-like attribute.
     """
+    return get_header(request, "authorization")
+
+
+def get_payment_authorization(request: Any) -> str | None:
+    """Extract Payment-Authorization header from various request types."""
+    return get_header(request, "payment-authorization")
+
+
+def get_header(request: Any, name: str) -> str | None:
+    """Extract an HTTP header from various request types.
+
+    Supports Starlette/FastAPI (request.headers), Django (request.META),
+    and any object with a ``headers`` dict-like attribute.
+    """
+    canonical = "-".join(part.capitalize() for part in name.split("-"))
     if hasattr(request, "headers"):
-        return request.headers.get("authorization") or request.headers.get("Authorization")
+        return (
+            request.headers.get(name)
+            or request.headers.get(name.lower())
+            or request.headers.get(canonical)
+        )
     if hasattr(request, "META"):
-        return request.META.get("HTTP_AUTHORIZATION")
+        return request.META.get("HTTP_" + name.upper().replace("-", "_"))
     return None
 
 
@@ -176,6 +195,8 @@ def wrap_payment_handler(
     handler: Callable[..., Awaitable[R]],
     verify_fn: Callable[[str | None, Any], Awaitable[Challenge | ComposedResult]],
     realm_fn: Callable[[], str],
+    *,
+    requires_auth: bool = False,
 ) -> Callable[..., Awaitable[R | Any]]:
     """Wrap a handler with the payment challenge/verify flow.
 
@@ -191,6 +212,8 @@ def wrap_payment_handler(
         verify_fn: Called with ``(authorization, request_obj)``; must return
             a ``Challenge``, composed challenges, or ``(Credential, Receipt)`` tuple.
         realm_fn: Returns the realm string for challenge responses.
+        requires_auth: When True, read the Payment credential from
+            ``Payment-Authorization`` instead of ``Authorization``.
     """
     sig = inspect.signature(handler)
     params = [p for name, p in sig.parameters.items() if name not in ("credential", "receipt")]
@@ -211,7 +234,11 @@ def wrap_payment_handler(
                 "The decorated handler must receive a request object as its first argument."
             )
 
-        authorization = get_authorization(request_obj)
+        authorization = (
+            get_payment_authorization(request_obj)
+            if requires_auth
+            else get_authorization(request_obj)
+        )
 
         try:
             result = await verify_fn(authorization, request_obj)
@@ -246,6 +273,7 @@ def pay(
     description: str | None = None,
     body: BodyParamsType = None,
     events: EventDispatcher | None = None,
+    requires_auth: bool = False,
 ) -> Callable[
     [Callable[[Any, Credential, Receipt], Awaitable[R]]],
     Callable[[Any], Awaitable[R | Any]],
@@ -274,6 +302,9 @@ def pay(
         body: Optional static body bytes/string/dict or callback receiving the
             request object. The resolved value is bound into issued challenges
             via digest and used to verify paid retries.
+        requires_auth: When True, challenges advertise
+            ``header="Payment-Authorization"`` and credentials are read from
+            that header so ``Authorization`` can carry application auth.
 
     Example:
         @app.get("/resource")
@@ -310,8 +341,11 @@ def pay(
                 description=description,
                 body=await resolve_body_param(body, request_obj),
                 events=events,
+                header=PAYMENT_AUTHORIZATION_HEADER if requires_auth else None,
             )
 
-        return wrap_payment_handler(handler, _verify, lambda: resolved_realm)
+        return wrap_payment_handler(
+            handler, _verify, lambda: resolved_realm, requires_auth=requires_auth
+        )
 
     return decorator

--- a/src/mpp/server/mpp.py
+++ b/src/mpp/server/mpp.py
@@ -6,7 +6,7 @@ from collections.abc import Awaitable, Callable, Mapping, Sequence
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any, Literal, TypeVar, overload
 
-from mpp import Challenge, Credential, Receipt
+from mpp import PAYMENT_AUTHORIZATION_HEADER, Challenge, Credential, Receipt
 from mpp._parsing import ParseError, _b64_decode, _parse_timestamp
 from mpp._units import parse_units, transform_units
 from mpp.errors import (
@@ -98,6 +98,7 @@ class Mpp:
         secret_key: str,
         defaults: dict[str, Any] | None = None,
         store: Store | None = None,
+        requires_auth: bool = False,
     ) -> None:
         """Initialize the payment handler.
 
@@ -110,12 +111,17 @@ class Mpp:
             store: Optional key-value store for replay protection.
                 When provided, automatically wired into intents that
                 accept a ``store`` (e.g., ``ChargeIntent``).
+            requires_auth: When True, challenges advertise
+                ``header="Payment-Authorization"`` so ``Authorization`` remains
+                available for application authentication.
         """
         self.method = method
         self.methods = (method,)
         self.realm = realm
         self.secret_key = secret_key
         self.defaults = defaults or {}
+        self.requires_auth = requires_auth
+        self.credential_header = PAYMENT_AUTHORIZATION_HEADER if requires_auth else None
         self._events = EventDispatcher()
 
         if store is not None:
@@ -370,6 +376,8 @@ class Mpp:
         realm: str | None = None,
         secret_key: str | None = None,
         store: Store | None = None,
+        *,
+        requires_auth: bool = False,
     ) -> Mpp: ...
 
     @classmethod
@@ -381,6 +389,7 @@ class Mpp:
         realm: str | None = None,
         secret_key: str | None = None,
         store: Store | None = None,
+        requires_auth: bool = False,
     ) -> Mpp: ...
 
     @classmethod
@@ -392,6 +401,7 @@ class Mpp:
         store: Store | None = None,
         *,
         methods: Sequence[Method] | None = None,
+        requires_auth: bool = False,
     ) -> Mpp:
         """Create an Mpp instance with smart defaults.
 
@@ -402,6 +412,9 @@ class Mpp:
             secret_key: HMAC secret. Required unless `MPP_SECRET_KEY` is set.
             store: Optional key-value store for replay protection.
                 Automatically wired into intents that accept a store.
+            requires_auth: Uses ``Payment-Authorization`` for Payment credentials
+                so ``Authorization`` remains available for application
+                authentication.
         """
         if method is not None and methods is not None:
             raise ValueError("pass method= or methods=, not both")
@@ -421,6 +434,7 @@ class Mpp:
             realm=resolved_realm,
             secret_key=resolved_secret_key,
             store=store,
+            requires_auth=requires_auth,
         )
         if len(configured) > 1:
             server.methods = configured
@@ -438,6 +452,18 @@ class Mpp:
 
         return _configure_entries(self, entries, body)
 
+    def payment_credential_value(
+        self,
+        authorization: str | None,
+        payment_authorization: str | None = None,
+    ) -> str | None:
+        """Select the HTTP header value that carries the Payment credential.
+
+        When ``requires_auth`` is True, Payment credentials ride in
+        ``Payment-Authorization`` so ``Authorization`` can hold application auth.
+        """
+        return payment_authorization if self.requires_auth else authorization
+
     async def charge(
         self,
         authorization: str | None,
@@ -453,6 +479,7 @@ class Mpp:
         chain_id: int | None = None,
         extra: dict[str, str] | None = None,
         body: str | bytes | dict[str, Any] | None = None,
+        payment_authorization: str | None = None,
     ) -> Challenge | ComposedResult:
         """Handle a charge intent.
 
@@ -473,6 +500,8 @@ class Mpp:
             body: Actual request body bytes, string, or JSON-like dict to bind
                 with a SHA-256 digest. If provided, new challenges include a
                 digest and submitted credentials must echo a matching digest.
+            payment_authorization: The Payment-Authorization header value.
+                Used when the server was created with ``requires_auth=True``.
 
         Returns:
             Challenge, or ComposedChallenges for multiple methods, if payment
@@ -497,13 +526,13 @@ class Mpp:
             return await self.compose(
                 *((method, options) for method in methods),
                 body=body,
-            ).verify(authorization)
+            ).verify(self.payment_credential_value(authorization, payment_authorization))
 
         intent, request, challenge_expires = self._build_offer_request(
             methods[0], "charge", options, None, api_name="charge"
         )
         return await verify_or_challenge(
-            authorization=authorization,
+            authorization=self.payment_credential_value(authorization, payment_authorization),
             intent=intent,
             request=request,
             realm=self.realm,
@@ -513,6 +542,7 @@ class Mpp:
             expires=challenge_expires,
             body=body,
             events=self._events,
+            header=self.credential_header,
         )
 
     def pay(
@@ -607,9 +637,12 @@ class Mpp:
                     expires=challenge_expires,
                     body=await resolve_body_param(body, _request_obj),
                     events=self._events,
+                    header=self.credential_header,
                 )
 
-            return wrap_payment_handler(handler, _verify, lambda: self.realm)
+            return wrap_payment_handler(
+                handler, _verify, lambda: self.realm, requires_auth=self.requires_auth
+            )
 
         return decorator
 

--- a/src/mpp/server/verify.py
+++ b/src/mpp/server/verify.py
@@ -44,6 +44,7 @@ async def verify_or_challenge(
     expires: str | None = None,
     body: str | bytes | dict[str, Any] | None = None,
     events: EventDispatcher | None = None,
+    header: str | None = None,
 ) -> Challenge | tuple[Credential, Receipt]:
     """Verify a payment credential or generate a new challenge.
 
@@ -73,6 +74,9 @@ async def verify_or_challenge(
             a SHA-256 digest. If provided, new challenges include a digest and
             submitted credentials must echo a matching digest.
         events: Optional dispatcher for challenge/payment lifecycle events.
+        header: Optional HTTP field for the Payment credential. When set to
+            ``Payment-Authorization``, issued challenges advertise that field
+            so ``Authorization`` can carry application authentication.
 
     Returns:
         If no valid Authorization header:
@@ -106,7 +110,16 @@ async def verify_or_challenge(
 
     async def new_challenge() -> Challenge:
         challenge = _create_challenge(
-            method_name, intent.name, request, realm, secret_key, description, meta, expires, body
+            method_name,
+            intent.name,
+            request,
+            realm,
+            secret_key,
+            description,
+            meta,
+            expires,
+            body,
+            header,
         )
         if events is not None:
             await events.emit(
@@ -269,6 +282,7 @@ def _authenticate_echo(
         expires=echo.expires,
         digest=echo.digest,
         opaque=echo_opaque,
+        header=echo.header,
     )
     if not _constant_time_equal(echo.id, expected_id):
         raise InvalidChallengeError(echo.id, "challenge was not issued by this server")
@@ -285,6 +299,7 @@ def _create_challenge(
     meta: dict[str, str] | None = None,
     expires: str | None = None,
     body: str | bytes | dict[str, Any] | None = None,
+    header: str | None = None,
 ) -> Challenge:
     """Create a new payment challenge with HMAC-bound ID.
 
@@ -312,6 +327,7 @@ def _create_challenge(
         digest=digest,
         description=description,
         meta=meta,
+        header=header,
     )
 
 
@@ -345,6 +361,7 @@ def _challenge_from_echo(
         expires=echo.expires,
         digest=echo.digest,
         opaque=opaque,
+        header=echo.header,
     )
 
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -57,6 +57,7 @@ def make_bound_credential(
     expires: str | None = None,
     digest: str | None = None,
     meta: dict[str, str] | None = None,
+    header: str | None = None,
 ) -> Credential:
     """Create a Credential with an HMAC-bound challenge ID for testing.
 
@@ -76,6 +77,7 @@ def make_bound_credential(
         expires=expires,
         digest=digest,
         meta=meta,
+        header=header,
     )
     echo = challenge.to_echo()
     return Credential(challenge=echo, payload=payload, source=source)
@@ -91,8 +93,13 @@ class MockRequest:
         path: str | None = None,
         route: str | None = None,
         query_string: str | None = None,
+        payment_authorization: str | None = None,
     ) -> None:
-        self.headers = {"authorization": authorization} if authorization else {}
+        self.headers: dict[str, str] = {}
+        if authorization:
+            self.headers["authorization"] = authorization
+        if payment_authorization:
+            self.headers["payment-authorization"] = payment_authorization
         self.body = body
         if path is not None:
             self.path = path

--- a/tests/test_challenge_id.py
+++ b/tests/test_challenge_id.py
@@ -4,6 +4,8 @@ These tests use the cross-SDK conformance test vectors to ensure
 Python SDK produces identical challenge IDs to TypeScript and Rust SDKs.
 """
 
+import pytest
+
 from mpp import Challenge, generate_challenge_id
 
 
@@ -504,3 +506,70 @@ class TestOpaque:
             meta={},
         )
         assert challenge.opaque == {}
+
+
+class TestCredentialHeader:
+    """HMAC binding and serialization of the optional credential header."""
+
+    def test_authorization_header_does_not_change_challenge_id(self) -> None:
+        params = {
+            "secret_key": "test-secret-key-12345",
+            "realm": "api.example.com",
+            "method": "tempo",
+            "intent": "charge",
+            "request": {"amount": "1000000"},
+        }
+        implicit = Challenge.create(**params)
+        explicit = Challenge.create(**params, header="Authorization")
+
+        assert implicit.header is None
+        assert explicit.header is None
+        assert implicit.id == explicit.id
+        assert "header=" not in implicit.to_www_authenticate("api.example.com")
+        assert implicit.credential_header == "Authorization"
+
+    def test_payment_authorization_header_is_bound_into_id(self) -> None:
+        params = {
+            "secret_key": "test-secret-key-12345",
+            "realm": "api.example.com",
+            "method": "tempo",
+            "intent": "charge",
+            "request": {"amount": "1000000"},
+        }
+        implicit = Challenge.create(**params)
+        advertised = Challenge.create(**params, header="Payment-Authorization")
+
+        assert implicit.id != advertised.id
+        assert advertised.header == "Payment-Authorization"
+        assert advertised.verify("test-secret-key-12345", "api.example.com")
+        assert 'header="Payment-Authorization"' in advertised.to_www_authenticate("api.example.com")
+
+    def test_header_sits_before_opaque_in_hmac(self) -> None:
+        """Header is inserted immediately before the final opaque slot."""
+        params = {
+            "secret_key": "test-secret",
+            "realm": "api.example.com",
+            "method": "tempo",
+            "intent": "charge",
+            "request": {"amount": "1000000"},
+        }
+        with_header = Challenge.create(**params, header="Payment-Authorization")
+        with_both = Challenge.create(
+            **params, header="Payment-Authorization", meta={"pi": "pi_123"}
+        )
+        with_opaque = Challenge.create(**params, meta={"pi": "pi_123"})
+
+        assert with_header.id != with_both.id
+        assert with_both.id != with_opaque.id
+        assert with_both.verify("test-secret", "api.example.com")
+
+    def test_rejects_invalid_header_name(self) -> None:
+        with pytest.raises(ValueError, match="Invalid HTTP header name"):
+            Challenge.create(
+                secret_key="test-secret",
+                realm="api.example.com",
+                method="tempo",
+                intent="charge",
+                request={"amount": "1000000"},
+                header="Payment Authorization",
+            )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -135,6 +135,39 @@ class TestPaymentTransport:
         method.create_credential.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_retry_uses_advertised_payment_authorization_header(self) -> None:
+        challenge = Challenge(
+            id="test-id",
+            method="tempo",
+            intent="charge",
+            request={"amount": "1000"},
+            header="Payment-Authorization",
+        )
+        www_auth = challenge.to_www_authenticate("example.com")
+
+        inner = MockTransport(
+            [
+                httpx.Response(402, headers={"www-authenticate": www_auth}),
+                httpx.Response(200, content=b'{"data": "ok"}'),
+            ]
+        )
+        method = MockMethod()
+        transport = PaymentTransport(methods=[method], inner=inner)
+
+        request = httpx.Request(
+            "GET",
+            "https://example.com",
+            headers={"Authorization": "Bearer app-token"},
+        )
+        response = await transport.handle_async_request(request)
+
+        assert response.status_code == 200
+        retry_request = inner.requests[1]
+        assert retry_request.headers["Authorization"] == "Bearer app-token"
+        assert retry_request.headers["Payment-Authorization"].startswith("Payment ")
+        method.create_credential.assert_called_once()
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "target_url",
         [

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -493,3 +493,32 @@ async def test_repeated_offers_keep_body_hmac_and_route_scope_bindings() -> None
     assert paid[1].reference == "first"
     assert method.intent.settlements == 1
     assert len(failures) == 3
+
+
+@pytest.mark.asyncio
+async def test_requires_auth_compose_advertises_and_accepts_payment_authorization() -> None:
+    first = MockMethod("first")
+    second = MockMethod("second")
+    server = Mpp.create(
+        methods=[first, second],
+        realm="api.example.com",
+        secret_key="secret",
+        requires_auth=True,
+    )
+    configured = server.compose(
+        (first, {"amount": "1.00"}),
+        (second, {"amount": "1.00"}),
+    )
+
+    unpaid = await configured.verify("Bearer app-token")
+    assert isinstance(unpaid, ComposedChallenges)
+    assert all(challenge.header == "Payment-Authorization" for challenge in unpaid.challenges)
+    assert all(
+        'header="Payment-Authorization"' in challenge.to_www_authenticate(server.realm)
+        for challenge in unpaid.challenges
+    )
+
+    paid = await configured.verify(credential(unpaid.challenges[1]).to_authorization())
+    assert not isinstance(paid, ComposedChallenges)
+    assert paid[1].reference == "second"
+    assert second.intent.settlements == 1

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -173,6 +173,47 @@ class TestChallenge:
         with pytest.raises(ParseError, match="invalid CRLF"):
             challenge.to_www_authenticate("api.example.com")
 
+    def test_www_authenticate_roundtrip_preserves_credential_header(self) -> None:
+        challenge = Challenge.create(
+            secret_key="test-secret",
+            realm="api.example.com",
+            method="tempo",
+            intent="charge",
+            request={"amount": "1000000"},
+            header="Payment-Authorization",
+        )
+        header = challenge.to_www_authenticate("api.example.com")
+        parsed = Challenge.from_www_authenticate(header)
+
+        assert 'header="Payment-Authorization"' in header
+        assert parsed.header == "Payment-Authorization"
+        assert parsed.credential_header == "Payment-Authorization"
+        assert parsed.verify("test-secret", "api.example.com")
+
+    def test_www_authenticate_omits_default_authorization_header(self) -> None:
+        challenge = Challenge.create(
+            secret_key="test-secret",
+            realm="api.example.com",
+            method="tempo",
+            intent="charge",
+            request={"amount": "1000000"},
+            header="authorization",
+        )
+        header = challenge.to_www_authenticate("api.example.com")
+
+        assert "header=" not in header
+        assert challenge.header is None
+
+    def test_parse_www_authenticate_rejects_invalid_header_name(self) -> None:
+        request_b64 = _b64_json({"amount": "1000000"})
+        header = (
+            'Payment id="abc", realm="api.example.com", method="tempo", '
+            f'intent="charge", request="{request_b64}", header="not a header"'
+        )
+
+        with pytest.raises(ParseError, match="Invalid HTTP header name"):
+            Challenge.from_www_authenticate(header)
+
 
 class TestCredential:
     def test_roundtrip(self) -> None:
@@ -292,6 +333,23 @@ class TestCredential:
 
         assert parsed.challenge.digest == credential.challenge.digest
         assert parsed.challenge.opaque == credential.challenge.opaque
+
+    def test_roundtrip_preserves_header(self) -> None:
+        echo = ChallengeEcho(
+            id="test-id",
+            realm="api.example.com",
+            method="tempo",
+            intent="charge",
+            request="eyJhbW91bnQiOiIxMDAwMDAwIn0",
+            header="Payment-Authorization",
+        )
+        credential = Credential(
+            challenge=echo,
+            payload={"type": "transaction", "signature": "0xabc"},
+        )
+        parsed = Credential.from_authorization(credential.to_authorization())
+
+        assert parsed.challenge.header == "Payment-Authorization"
 
 
 class TestReceipt:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from mpp import BodyDigest, Challenge, Credential, Receipt
+from mpp import PAYMENT_AUTHORIZATION_HEADER, BodyDigest, Challenge, Credential, Receipt
 from mpp.errors import VerificationFailedError
 from mpp.events import EventDispatcher
 from mpp.server import Mpp, intent, pay, verify_or_challenge
@@ -673,8 +673,16 @@ class TestCrossEndpointReplay:
 class DjangoStyleRequest:
     """Mock Django-style request object for testing."""
 
-    def __init__(self, authorization: str | None = None) -> None:
-        self.META = {"HTTP_AUTHORIZATION": authorization} if authorization else {}
+    def __init__(
+        self,
+        authorization: str | None = None,
+        payment_authorization: str | None = None,
+    ) -> None:
+        self.META: dict[str, str] = {}
+        if authorization:
+            self.META["HTTP_AUTHORIZATION"] = authorization
+        if payment_authorization:
+            self.META["HTTP_PAYMENT_AUTHORIZATION"] = payment_authorization
 
 
 class TestWrapPaymentHandler:
@@ -1141,7 +1149,7 @@ class TestPay:
         assert challenge.method == "custompay"
 
 
-def _make_server(test_intent):
+def _make_server(test_intent, *, requires_auth: bool = False):
     """Create an Mpp instance with a mock method for testing."""
 
     class MockMethod:
@@ -1158,6 +1166,7 @@ def _make_server(test_intent):
         method=MockMethod(),
         realm="api.example.com",
         secret_key="test-secret",
+        requires_auth=requires_auth,
     )
 
 
@@ -2372,3 +2381,107 @@ class TestCrossRealmPrevention:
         assert isinstance(result, tuple), "Should accept matching credential"
         _, receipt = result
         assert receipt.reference == "0xOK"
+
+
+class TestRequiresAuth:
+    @pytest.mark.asyncio
+    async def test_charge_advertises_payment_authorization_header(self) -> None:
+        @intent(name="charge")
+        async def test_intent(credential: Credential, request: dict) -> Receipt:
+            return Receipt.success("0x123")
+
+        server = _make_server(test_intent, requires_auth=True)
+        result = await server.charge(authorization="Bearer app-token", amount="0.50")
+
+        assert isinstance(result, Challenge)
+        assert result.header == PAYMENT_AUTHORIZATION_HEADER
+        assert f'header="{PAYMENT_AUTHORIZATION_HEADER}"' in result.to_www_authenticate(
+            server.realm
+        )
+
+    @pytest.mark.asyncio
+    async def test_charge_verifies_payment_authorization_and_ignores_bearer(self) -> None:
+        @intent(name="charge")
+        async def test_intent(credential: Credential, request: dict) -> Receipt:
+            return Receipt.success("0x123")
+
+        server = _make_server(test_intent, requires_auth=True)
+        challenge = await server.charge(authorization="Bearer app-token", amount="0.50")
+        assert isinstance(challenge, Challenge)
+        credential = Credential(challenge=challenge.to_echo(), payload={"type": "test"})
+
+        ignored = await server.charge(
+            authorization=credential.to_authorization(),
+            amount="0.50",
+        )
+        assert isinstance(ignored, Challenge)
+
+        paid = await server.charge(
+            authorization="Bearer app-token",
+            amount="0.50",
+            payment_authorization=credential.to_authorization(),
+        )
+        assert isinstance(paid, tuple)
+        assert paid[1].status == "success"
+
+    @pytest.mark.asyncio
+    async def test_pay_decorator_reads_payment_authorization(self) -> None:
+        @intent(name="charge")
+        async def test_intent(credential: Credential, request: dict) -> Receipt:
+            return Receipt.success("0x123")
+
+        server = _make_server(test_intent, requires_auth=True)
+
+        @server.pay(amount="0.50")
+        async def handler(req: MockRequest, credential: Credential, receipt: Receipt) -> dict:
+            return {"paid": True, "ref": receipt.reference}
+
+        challenge_result = await handler(MockRequest(authorization="Bearer app-token"))
+        challenge = challenge_from_402(challenge_result)
+        assert challenge.header == PAYMENT_AUTHORIZATION_HEADER
+
+        credential = make_bound_credential(
+            payload={},
+            request=challenge.request,
+            realm="api.example.com",
+            secret_key="test-secret",
+            expires=challenge.expires,
+            header=PAYMENT_AUTHORIZATION_HEADER,
+        )
+        result = await handler(
+            MockRequest(
+                authorization="Bearer app-token",
+                payment_authorization=credential.to_authorization(),
+            )
+        )
+        assert result == {"paid": True, "ref": "0x123"}
+
+    @pytest.mark.asyncio
+    async def test_standalone_pay_requires_auth(self) -> None:
+        @intent(name="charge")
+        async def test_intent(credential: Credential, request: dict) -> Receipt:
+            return Receipt.success("0x123")
+
+        @pay(
+            intent=test_intent,
+            request={"amount": "1000"},
+            realm="api.example.com",
+            secret_key="test-secret",
+            requires_auth=True,
+        )
+        async def handler(req: MockRequest, credential: Credential, receipt: Receipt) -> dict:
+            return {"paid": True}
+
+        challenge_result = await handler(MockRequest(authorization="Bearer app-token"))
+        challenge = challenge_from_402(challenge_result)
+        assert challenge.header == PAYMENT_AUTHORIZATION_HEADER
+
+        credential = make_bound_credential(
+            payload={},
+            request={"amount": "1000"},
+            realm="api.example.com",
+            secret_key="test-secret",
+            header=PAYMENT_AUTHORIZATION_HEADER,
+        )
+        result = await handler(MockRequest(payment_authorization=credential.to_authorization()))
+        assert result == {"paid": True}


### PR DESCRIPTION
When an endpoint already uses Authorization for application auth, challenges advertise header="Payment-Authorization" and clients send the credential there instead.

Mirrors mppx change: https://github.com/wevm/mppx/pull/821

Follows spec change here: https://github.com/tempoxyz/mpp-specs/pull/328