### PR TITLE
feat(server): add payment method hooks

### DIFF
--- a/src/mpp/methods/__init__.py
+++ b/src/mpp/methods/__init__.py
@@ -1,1 +1,16 @@
 """Payment method implementations."""
+
+from collections.abc import Awaitable as _Awaitable
+from collections.abc import Callable as _Callable
+from typing import Any as _Any
+from typing import TypeAlias as _TypeAlias
+
+from mpp.events import ServerPaymentSuccessPayload as _ServerPaymentSuccessPayload
+
+# Decides whether a composed payment offer is available for a canonical request.
+CanOfferFn: _TypeAlias = _Callable[[dict[str, _Any]], bool | _Awaitable[bool]]
+
+# Handles a successful payment for its configured method.
+PaymentSuccessHandler: _TypeAlias = _Callable[
+    [_ServerPaymentSuccessPayload], None | _Awaitable[None]
+]

--- a/src/mpp/methods/stripe/client.py
+++ b/src/mpp/methods/stripe/client.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 from mpp import Challenge, Credential
+from mpp.methods import CanOfferFn, PaymentSuccessHandler
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -67,6 +68,8 @@ class StripeMethod:
     network_id: str | None = None
     payment_method_types: list[str] = field(default_factory=lambda: ["card"])
     _intents: dict[str, Intent | VerifiableIntent] = field(default_factory=dict)
+    can_offer: CanOfferFn | None = field(default=None, kw_only=True)
+    on_payment_success: PaymentSuccessHandler | None = field(default=None, kw_only=True)
 
     @property
     def intents(self) -> dict[str, Intent | VerifiableIntent]:
@@ -194,6 +197,8 @@ def stripe(
     recipient: str | None = None,
     network_id: str | None = None,
     payment_method_types: list[str] | None = None,
+    can_offer: CanOfferFn | None = None,
+    on_payment_success: PaymentSuccessHandler | None = None,
 ) -> StripeMethod:
     """Create a Stripe payment method.
 
@@ -212,6 +217,8 @@ def stripe(
             challenge ``methodDetails.networkId``.
         payment_method_types: Stripe payment method types (default: ``["card"]``).
             Included in challenge ``methodDetails.paymentMethodTypes``.
+        can_offer: Optional callback that filters this method's composed offers.
+        on_payment_success: Optional callback invoked after successful verification.
 
     Returns:
         A configured :class:`StripeMethod` instance.
@@ -244,6 +251,8 @@ def stripe(
         recipient=recipient,
         network_id=network_id,
         payment_method_types=payment_method_types or ["card"],
+        can_offer=can_offer,
+        on_payment_success=on_payment_success,
     )
     method._intents = dict(intents)
     return method

--- a/src/mpp/methods/tempo/client.py
+++ b/src/mpp/methods/tempo/client.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, cast
 
 from mpp import Challenge, Credential
+from mpp.methods import CanOfferFn, PaymentSuccessHandler
 from mpp.methods.tempo._attribution import encode as encode_attribution
 from mpp.methods.tempo._defaults import (
     CHAIN_ID,
@@ -78,6 +79,8 @@ class TempoMethod:
     decimals: int = 6
     client_id: str | None = None
     _intents: dict[str, Intent | VerifiableIntent] = field(default_factory=dict)
+    can_offer: CanOfferFn | None = field(default=None, kw_only=True)
+    on_payment_success: PaymentSuccessHandler | None = field(default=None, kw_only=True)
     _cached_chain_ids: dict[str, int] = field(default_factory=dict, init=False, repr=False)
     _chain_id_explicit: bool = field(default=False, init=False, repr=False)
     _chain_id_lock: asyncio.Lock | None = field(default=None, init=False, repr=False)
@@ -397,6 +400,8 @@ def tempo(
     decimals: int = 6,
     client_id: str | None = None,
     relay: Relay | None = None,
+    can_offer: CanOfferFn | None = None,
+    on_payment_success: PaymentSuccessHandler | None = None,
 ) -> TempoMethod:
     """Create a Tempo payment method.
 
@@ -419,6 +424,8 @@ def tempo(
         decimals: Token decimal places for amount conversion (default: 6).
         client_id: Optional client identity for attribution memos.
         relay: Optional server-side Tempo API relay for the charge intent.
+        can_offer: Optional callback that filters this method's composed offers.
+        on_payment_success: Optional callback invoked after successful verification.
 
     Returns:
         A configured TempoMethod instance.
@@ -465,6 +472,8 @@ def tempo(
         recipient=recipient,
         decimals=decimals,
         client_id=client_id,
+        can_offer=can_offer,
+        on_payment_success=on_payment_success,
     )
     method._chain_id_explicit = chain_id_explicit
     method._rpc_url_explicit = rpc_url_explicit

--- a/src/mpp/server/compose.py
+++ b/src/mpp/server/compose.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import inspect
 from collections.abc import Awaitable, Callable, Mapping, Sequence
+from copy import deepcopy
 from dataclasses import dataclass
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any, Required, TypeAlias, TypedDict, TypeVar, cast
@@ -12,7 +14,7 @@ from mpp._parsing import ParseError, _b64_decode
 from mpp._units import parse_units
 from mpp.errors import InvalidChallengeError, MalformedCredentialError
 from mpp.server.decorator import BodyParamsType, resolve_body_param, wrap_payment_handler
-from mpp.server.method import Method
+from mpp.server.method import Method, _SupportsCanOffer
 from mpp.server.verify import _authenticate_echo, _extract_payment_scheme, verify_or_challenge
 
 if TYPE_CHECKING:
@@ -83,6 +85,24 @@ class _PreparedOffer:
     request: dict[str, Any]
     expires: str | None
     body: str | bytes | dict[str, Any] | None
+
+    async def is_available(self) -> bool:
+        """Return whether the method wants to advertise this prepared offer."""
+        callback = (
+            self.offer.method.can_offer
+            if isinstance(self.offer.method, _SupportsCanOffer)
+            else None
+        )
+        if callback is None:
+            return True
+        if not callable(callback):
+            raise ValueError("can_offer must be callable")
+        available = callback(deepcopy(self.request))
+        if inspect.isawaitable(available):
+            available = await available
+        if not isinstance(available, bool):
+            raise ValueError("can_offer must return bool")
+        return available
 
     async def verify(self, authorization: str | None) -> Challenge | tuple[Credential, Receipt]:
         """Verify this offer using its originating server."""
@@ -186,10 +206,14 @@ class ComposedHandler:
         challenges: list[Challenge] = []
         for offer in self._offers:
             prepared_offer = await _prepare_offer(offer, request, body_cache)
+            if not await prepared_offer.is_available():
+                continue
             result = await prepared_offer.verify(authorization)
             if not isinstance(result, Challenge):
                 return result
             challenges.append(result)
+        if not challenges:
+            raise ValueError("No payment offers are available for this request")
         return ComposedChallenges(tuple(challenges))
 
     def __call__(

--- a/src/mpp/server/method.py
+++ b/src/mpp/server/method.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
+from mpp.methods import CanOfferFn, PaymentSuccessHandler
+
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
@@ -52,6 +54,20 @@ class Method(Protocol):
             A credential that satisfies the challenge.
         """
         ...
+
+
+@runtime_checkable
+class _SupportsCanOffer(Protocol):
+    """A method that can decide whether to advertise a prepared offer."""
+
+    can_offer: CanOfferFn | None
+
+
+@runtime_checkable
+class _SupportsPaymentSuccess(Protocol):
+    """A method that handles its own successfully verified payments."""
+
+    on_payment_success: PaymentSuccessHandler | None
 
 
 def transform_request(

--- a/src/mpp/server/mpp.py
+++ b/src/mpp/server/mpp.py
@@ -34,7 +34,7 @@ from mpp.server.decorator import (
 from mpp.server.intent import Validation
 from mpp.server.intent import broadcast_credential as broadcast_intent_credential
 from mpp.server.intent import validate_credential as validate_intent_credential
-from mpp.server.method import transform_request
+from mpp.server.method import _SupportsPaymentSuccess, transform_request
 from mpp.server.verify import (
     _authenticate_echo,
     _body_digest_error,
@@ -44,6 +44,7 @@ from mpp.server.verify import (
 from mpp.store import Store
 
 if TYPE_CHECKING:
+    from mpp.events import ServerPaymentSuccessPayload
     from mpp.server.intent import Intent, VerifiableIntent
     from mpp.server.method import Method
 
@@ -117,6 +118,7 @@ class Mpp:
         self.secret_key = secret_key
         self.defaults = defaults or {}
         self._events = EventDispatcher()
+        self._register_method_payment_success_handler(method)
 
         if store is not None:
             self._wire_store(store)
@@ -146,6 +148,21 @@ class Mpp:
             for intent_obj in intents.values():
                 if hasattr(intent_obj, "_store") and intent_obj._store is None:
                     intent_obj._store = store
+
+    def _register_method_payment_success_handler(self, method: Method) -> None:
+        """Forward successful payments to a method's optional callback."""
+        handler = method.on_payment_success if isinstance(method, _SupportsPaymentSuccess) else None
+        if handler is None:
+            return
+        if not callable(handler):
+            raise ValueError("on_payment_success must be callable")
+
+        def dispatch(payload: ServerPaymentSuccessPayload) -> Any:
+            if payload["method"] == method.name:
+                return handler(payload)
+            return None
+
+        self._events.on(PAYMENT_SUCCESS, dispatch)
 
     def _prepare_credential(
         self,
@@ -426,6 +443,8 @@ class Mpp:
             server.methods = configured
             if store is not None:
                 server._wire_store(store)
+            for configured_method in configured[1:]:
+                server._register_method_payment_success_handler(configured_method)
         return server
 
     def compose(

--- a/tests/test_method_hooks.py
+++ b/tests/test_method_hooks.py
@@ -1,0 +1,262 @@
+"""Coverage for per-method offer and payment-success hooks."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+
+from mpp import Challenge, Credential, Receipt
+from mpp.events import ServerPaymentSuccessPayload
+from mpp.methods import CanOfferFn, PaymentSuccessHandler
+from mpp.methods.stripe import stripe
+from mpp.methods.tempo import tempo
+from mpp.server import ComposedChallenges, Mpp, compose, intent
+from tests import MockRequest
+
+
+class ThirdPartyMethod:
+    def __init__(
+        self,
+        name: str,
+        *,
+        can_offer: CanOfferFn | None = None,
+        on_payment_success: PaymentSuccessHandler | None = None,
+    ) -> None:
+        self.name = name
+        self.can_offer = can_offer
+        self.on_payment_success = on_payment_success
+        self.currency = f"{name}-currency"
+        self.recipient = f"{name}-recipient"
+        self.decimals = 2
+
+        @intent(name="charge")
+        async def verify(_credential: Credential, _request: dict[str, Any]) -> Receipt:
+            return Receipt.success(name)
+
+        self.intents = {"charge": verify}
+
+    def transform_request(
+        self, request: dict[str, Any], _credential: Credential | None
+    ) -> dict[str, Any]:
+        return {**request, "transformedBy": self.name}
+
+    async def create_credential(self, challenge: Challenge) -> Credential:  # pragma: no cover
+        del challenge
+        raise NotImplementedError
+
+
+def create_server(*methods: ThirdPartyMethod) -> Mpp:
+    return Mpp.create(
+        methods=methods,
+        realm="api.example.com",
+        secret_key="secret",
+    )
+
+
+def credential(challenge: Challenge) -> Credential:
+    return Credential(challenge=challenge.to_echo(), payload={})
+
+
+@pytest.mark.asyncio
+async def test_can_offer_filters_normalized_composed_offers_before_challenge_events() -> None:
+    seen: list[tuple[str, dict[str, Any]]] = []
+
+    def reject_first(request: dict[str, Any]) -> bool:
+        seen.append(("first", request))
+        return False
+
+    async def offer_second(request: dict[str, Any]) -> bool:
+        seen.append(("second", request))
+        request["amount"] = "999"
+        request["_mppx_scope"]["resource"] = "/tampered"
+        return True
+
+    first = ThirdPartyMethod("first", can_offer=reject_first)
+    second = ThirdPartyMethod("second", can_offer=offer_second)
+    server = create_server(first, second)
+    challenged: list[str] = []
+    server.on_challenge_created(lambda payload: challenged.append(payload["method"]))
+
+    result = await server.compose(
+        (first, {"amount": "1.50"}),
+        (second, {"amount": "1.50"}),
+    ).verify(None, MockRequest(path="/paid", route="/paid"))
+
+    assert isinstance(result, ComposedChallenges)
+    assert [challenge.method for challenge in result.challenges] == ["second"]
+    assert result.challenges[0].request["amount"] == "150"
+    assert result.challenges[0].request["_mppx_scope"]["resource"] == "/paid"
+    assert challenged == ["second"]
+    assert [name for name, _request in seen] == ["first", "second"]
+    assert seen[0][1] == {
+        "amount": "150",
+        "currency": "first-currency",
+        "recipient": "first-recipient",
+        "transformedBy": "first",
+        "_mppx_scope": {"resource": "/paid", "route": "/paid"},
+    }
+
+
+@pytest.mark.asyncio
+async def test_can_offer_checks_repeated_offers_but_not_direct_handlers_or_redemption() -> None:
+    amounts: list[str] = []
+
+    def can_offer(request: dict[str, Any]) -> bool:
+        amounts.append(request["amount"])
+        return request["amount"] == "200"
+
+    method = ThirdPartyMethod("only", can_offer=can_offer)
+    server = create_server(method)
+
+    direct = await server.charge(None, "1.00")
+    assert isinstance(direct, Challenge)
+    assert amounts == []
+
+    configured = server.compose(
+        (method, {"amount": "1.00"}),
+        (method, {"amount": "2.00"}),
+    )
+    result = await configured.verify(None)
+    assert isinstance(result, ComposedChallenges)
+    assert [challenge.request["amount"] for challenge in result.challenges] == ["200"]
+    assert amounts == ["100", "200"]
+
+    paid = await configured.verify(credential(result.challenges[0]).to_authorization())
+    assert not isinstance(paid, ComposedChallenges)
+    assert paid[1].reference == "only"
+    assert amounts == ["100", "200"]
+
+
+@pytest.mark.asyncio
+async def test_can_offer_rejects_invalid_results_and_propagates_errors() -> None:
+    non_callable = ThirdPartyMethod("non-callable", can_offer=cast(CanOfferFn, object()))
+    with pytest.raises(ValueError, match="can_offer must be callable"):
+        await create_server(non_callable).compose((non_callable, {"amount": "1.00"})).verify(None)
+
+    invalid = ThirdPartyMethod("invalid", can_offer=lambda _request: cast(Any, "yes"))
+    with pytest.raises(ValueError, match="can_offer must return bool"):
+        await create_server(invalid).compose((invalid, {"amount": "1.00"})).verify(None)
+
+    def fail(_request: dict[str, Any]) -> bool:
+        raise RuntimeError("offer hook failure")
+
+    failing = ThirdPartyMethod("failing", can_offer=fail)
+    with pytest.raises(RuntimeError, match="offer hook failure"):
+        await create_server(failing).compose((failing, {"amount": "1.00"})).verify(None)
+
+    unavailable = ThirdPartyMethod("unavailable", can_offer=lambda _request: False)
+    with pytest.raises(ValueError, match="No payment offers"):
+        await create_server(unavailable).compose((unavailable, {"amount": "1.00"})).verify(None)
+
+
+@pytest.mark.asyncio
+async def test_success_hook_runs_only_for_the_settled_method() -> None:
+    first_calls: list[ServerPaymentSuccessPayload] = []
+    second_calls: list[ServerPaymentSuccessPayload] = []
+
+    async def record_second(payload: ServerPaymentSuccessPayload) -> None:
+        second_calls.append(payload)
+
+    first = ThirdPartyMethod("first", on_payment_success=first_calls.append)
+    second = ThirdPartyMethod("second", on_payment_success=record_second)
+    server = create_server(first, second)
+    global_calls: list[ServerPaymentSuccessPayload] = []
+    server.on_payment_success(global_calls.append)
+    configured = server.compose(
+        (first, {"amount": "1.00"}),
+        (second, {"amount": "2.00"}),
+    )
+    offered = await configured.verify(None)
+    assert isinstance(offered, ComposedChallenges)
+
+    paid = await configured.verify(credential(offered.challenges[1]).to_authorization())
+
+    assert not isinstance(paid, ComposedChallenges)
+    assert first_calls == []
+    assert second_calls == global_calls
+    assert second_calls[0]["method"] == "second"
+    assert second_calls[0]["intent"] == "charge"
+    assert second_calls[0]["request"]["amount"] == "200"
+    assert second_calls[0]["receipt"].reference == "second"
+
+
+@pytest.mark.asyncio
+async def test_static_composition_uses_only_the_owning_method_success_hook() -> None:
+    first_calls: list[ServerPaymentSuccessPayload] = []
+    second_calls: list[ServerPaymentSuccessPayload] = []
+    first_method = ThirdPartyMethod("shared", on_payment_success=first_calls.append)
+    second_method = ThirdPartyMethod("shared", on_payment_success=second_calls.append)
+    first = Mpp.create(
+        method=first_method,
+        realm="api.example.com",
+        secret_key="first-secret",
+    )
+    second = Mpp.create(
+        method=second_method,
+        realm="api.example.com",
+        secret_key="second-secret",
+    )
+    configured = compose(
+        first.compose((first_method, {"amount": "1.00"})),
+        second.compose((second_method, {"amount": "1.00"})),
+    )
+    offered = await configured.verify(None)
+    assert isinstance(offered, ComposedChallenges)
+
+    paid = await configured.verify(credential(offered.challenges[1]).to_authorization())
+
+    assert not isinstance(paid, ComposedChallenges)
+    assert first_calls == []
+    assert [payload["receipt"].reference for payload in second_calls] == ["shared"]
+
+
+@pytest.mark.asyncio
+async def test_success_hook_errors_do_not_interrupt_bound_broadcast() -> None:
+    calls: list[str] = []
+
+    def fail(payload: ServerPaymentSuccessPayload) -> None:
+        calls.append(payload["receipt"].reference or "")
+        raise RuntimeError("hook failure")
+
+    method = ThirdPartyMethod("only", on_payment_success=fail)
+    server = create_server(method)
+    challenge = await server.charge(None, "1.00")
+    assert isinstance(challenge, Challenge)
+
+    receipt = await server.broadcast_credential(credential(challenge))
+
+    assert receipt.reference == "only"
+    assert calls == ["only"]
+
+
+def test_method_factories_preserve_hooks() -> None:
+    def can_offer(_request: dict[str, Any]) -> bool:
+        return True
+
+    def on_payment_success(_payload: ServerPaymentSuccessPayload) -> None:
+        pass
+
+    stripe_method = stripe(
+        intents={},
+        currency="usd",
+        recipient="acct_123",
+        can_offer=can_offer,
+        on_payment_success=on_payment_success,
+    )
+    tempo_method = tempo(
+        intents={},
+        currency="0xcurrency",
+        recipient="0xrecipient",
+        can_offer=can_offer,
+        on_payment_success=on_payment_success,
+    )
+
+    assert stripe_method.can_offer is tempo_method.can_offer is can_offer
+    assert stripe_method.on_payment_success is tempo_method.on_payment_success is on_payment_success
+
+
+def test_non_callable_success_hook_is_rejected_at_configuration_time() -> None:
+    method = ThirdPartyMethod("only", on_payment_success=cast(PaymentSuccessHandler, object()))
+    with pytest.raises(ValueError, match="on_payment_success must be callable"):
+        create_server(method)

--- a/tests/typecheck/compose_consumer.py
+++ b/tests/typecheck/compose_consumer.py
@@ -5,13 +5,24 @@ from typing import assert_type
 
 import mpp.server as server_api
 from mpp import Challenge, Credential, Receipt
+from mpp.events import ServerPaymentSuccessPayload
+from mpp.methods import CanOfferFn, PaymentSuccessHandler
 from mpp.methods.tempo import ChargeIntent, tempo
+
+
+async def on_payment_success(_payload: ServerPaymentSuccessPayload) -> None:
+    pass
+
 
 method = tempo(
     intents={"charge": ChargeIntent()},
     currency="usd",
     recipient="acct_consumer",
+    can_offer=lambda _request: True,
+    on_payment_success=on_payment_success,
 )
+assert_type(method.can_offer, CanOfferFn | None)
+assert_type(method.on_payment_success, PaymentSuccessHandler | None)
 server = server_api.Mpp.create(method=method, realm="example.com", secret_key="secret")
 options: server_api.ComposeOptions = {"amount": "1.00", "meta": {"plan": "pro"}}
 entry: server_api.ComposeEntry = (method, options)


### PR DESCRIPTION
Let integrations filter composed payment offers for each request and run method-specific work after successful settlement.

This is similar to work we recently landed in mppx:
- Generic offer availability: https://github.com/wevm/mppx/pull/751
- Per-method payment-success hook: https://github.com/wevm/mppx/pull/767