### PR TITLE
fix: validate configured currency during challenge matching

### DIFF
--- a/.changelog/big-winds-rest.md
+++ b/.changelog/big-winds-rest.md
@@ -1,0 +1,5 @@
+---
+pympp: patch
+---
+
+Fixed currency validation during challenge matching by introducing a `_method_accepts_currency` helper that enforces case-insensitive currency comparison when a method has a configured currency constraint. Applied the check in both `PaymentRuntime` and `McpClient` challenge matching and credential creation paths.

--- a/src/mpp/extensions/mcp/client.py
+++ b/src/mpp/extensions/mcp/client.py
@@ -33,6 +33,7 @@ from mpp.errors import PaymentOutcomeUnknownError as PaymentOutcomeUnknownError
 from mpp.extensions.mcp.constants import CODE_PAYMENT_REQUIRED, META_RECEIPT
 from mpp.extensions.mcp.types import MCPChallenge, MCPCredential, MCPReceipt
 from mpp.runtime import Method as Method
+from mpp.runtime import _method_accepts_currency
 
 logger = logging.getLogger(__name__)
 
@@ -231,7 +232,11 @@ class McpClient:
         for method in self._methods:
             supported_intents = self._intent_names(method)
             for challenge in challenges:
-                if challenge.method == method.name and challenge.intent in supported_intents:
+                if (
+                    challenge.method == method.name
+                    and challenge.intent in supported_intents
+                    and _method_accepts_currency(method, challenge.to_core())
+                ):
                     return challenge, method
 
         available = [challenge.method for challenge in challenges]

--- a/src/mpp/methods/tempo/client.py
+++ b/src/mpp/methods/tempo/client.py
@@ -80,6 +80,7 @@ class TempoMethod:
     _intents: dict[str, Intent | VerifiableIntent] = field(default_factory=dict)
     _cached_chain_ids: dict[str, int] = field(default_factory=dict, init=False, repr=False)
     _chain_id_explicit: bool = field(default=False, init=False, repr=False)
+    _currency_explicit: bool = field(default=True, init=False, repr=False)
     _chain_id_lock: asyncio.Lock | None = field(default=None, init=False, repr=False)
     _rpc_url_explicit: bool = field(default=False, init=False, repr=False)
 
@@ -452,6 +453,7 @@ def tempo(
             raise ValueError("chain_id or rpc_url is required")
         rpc_url = rpc_url_for_chain(resolved_chain_id)
 
+    currency_explicit = currency is not None
     if currency is None:
         currency = default_currency_for_chain(resolved_chain_id)
 
@@ -467,6 +469,7 @@ def tempo(
         client_id=client_id,
     )
     method._chain_id_explicit = chain_id_explicit
+    method._currency_explicit = currency_explicit
     method._rpc_url_explicit = rpc_url_explicit
     for intent in intents.values():
         if hasattr(intent, "rpc_url") and intent.rpc_url is None:  # type: ignore[union-attr]

--- a/src/mpp/runtime.py
+++ b/src/mpp/runtime.py
@@ -24,6 +24,8 @@ class Method(Protocol):
 
 def _method_accepts_currency(method: Method, challenge: Challenge) -> bool:
     """Return whether a Challenge matches a method's optional currency constraint."""
+    if getattr(method, "_currency_explicit", True) is False:
+        return True
     configured_currency = getattr(method, "currency", None)
     if configured_currency is None:
         return True
@@ -45,11 +47,11 @@ class PaymentRuntime:
         events: EventDispatcher | None = None,
     ) -> None:
         self.methods = tuple(methods)
-        self._methods: dict[tuple[str, str], Method] = {}
+        self._methods: dict[tuple[str, str], list[Method]] = {}
         for method in self.methods:
             intents = getattr(method, "intents", ("charge",))
             for intent in intents:
-                self._methods[(method.name, intent)] = method
+                self._methods.setdefault((method.name, intent), []).append(method)
         self.events = events if events is not None else EventDispatcher()
 
     def match_challenge(
@@ -58,9 +60,10 @@ class PaymentRuntime:
     ) -> tuple[Challenge, Method]:
         """Return the first challenge with a configured method and intent."""
         for challenge in challenges:
-            method = self._methods.get((challenge.method, challenge.intent))
-            if method is not None and _method_accepts_currency(method, challenge):
-                return challenge, method
+            methods = self._methods.get((challenge.method, challenge.intent), ())
+            for method in methods:
+                if _method_accepts_currency(method, challenge):
+                    return challenge, method
 
         offered = [challenge.method for challenge in challenges]
         raise ValueError(f"No compatible payment method for challenges: {offered}")

--- a/src/mpp/runtime.py
+++ b/src/mpp/runtime.py
@@ -22,6 +22,19 @@ class Method(Protocol):
         ...
 
 
+def _method_accepts_currency(method: Method, challenge: Challenge) -> bool:
+    """Return whether a Challenge matches a method's optional currency constraint."""
+    configured_currency = getattr(method, "currency", None)
+    if configured_currency is None:
+        return True
+    offered_currency = challenge.request.get("currency")
+    return (
+        isinstance(configured_currency, str)
+        and isinstance(offered_currency, str)
+        and offered_currency.lower() == configured_currency.lower()
+    )
+
+
 class PaymentRuntime:
     """Match challenges and create credentials on the caller's event loop."""
 
@@ -46,7 +59,7 @@ class PaymentRuntime:
         """Return the first challenge with a configured method and intent."""
         for challenge in challenges:
             method = self._methods.get((challenge.method, challenge.intent))
-            if method is not None:
+            if method is not None and _method_accepts_currency(method, challenge):
                 return challenge, method
 
         offered = [challenge.method for challenge in challenges]
@@ -64,6 +77,13 @@ class PaymentRuntime:
             raise ValueError("Method is not installed in this PaymentRuntime")
         if challenge.method != method.name:
             raise ValueError(f"Method {method.name!r} does not support {challenge.method!r}")
+        if not _method_accepts_currency(method, challenge):
+            configured_currency = getattr(method, "currency", None)
+            offered_currency = challenge.request.get("currency")
+            raise ValueError(
+                f"Method {method.name!r} currency {configured_currency!r} "
+                f"does not support {offered_currency!r}"
+            )
         if challenge.expires is not None:
             try:
                 expires = datetime.fromisoformat(challenge.expires)

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -70,6 +70,7 @@ class FakeMethod:
     """Fake payment method for testing."""
 
     name: str = "tempo"
+    currency: str | None = None
     _intents: dict[str, Any] | None = None
     _credential_to_return: Credential | None = None
 
@@ -99,13 +100,14 @@ class FakeMethod:
 def _make_challenge_dict(
     method: str = "tempo",
     intent: str = "charge",
+    currency: str = "0x20c0",
 ) -> dict[str, Any]:
     return {
         "id": "ch_test123",
         "realm": "api.example.com",
         "method": method,
         "intent": intent,
-        "request": {"amount": "1000", "currency": "0x20c0", "recipient": "0xdead"},
+        "request": {"amount": "1000", "currency": currency, "recipient": "0xdead"},
         "expires": "2099-01-01T00:00:00Z",
     }
 
@@ -125,8 +127,11 @@ def _make_receipt_meta() -> dict[str, Any]:
 def _make_challenge(
     method: str = "tempo",
     intent: str = "charge",
+    currency: str = "0x20c0",
 ) -> MCPChallenge:
-    return MCPChallenge.from_dict(_make_challenge_dict(method=method, intent=intent))
+    return MCPChallenge.from_dict(
+        _make_challenge_dict(method=method, intent=intent, currency=currency)
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -568,6 +573,19 @@ class TestMcpClientMethodMatching:
         ]
         _, matched = client._match_challenge(challenges)
         assert matched is stripe_method
+
+    def test_match_skips_currency_rejected_by_configured_method(self) -> None:
+        method = FakeMethod(currency="0xUsdc")
+        client = McpClient(AsyncMock(), methods=[method])
+        challenges = [
+            _make_challenge(currency="0xMachineUsd"),
+            _make_challenge(currency="0xUSDC"),
+        ]
+
+        challenge, matched = client._match_challenge(challenges)
+
+        assert challenge.request["currency"] == "0xUSDC"
+        assert matched is method
 
     def test_no_match_raises(self) -> None:
         method = FakeMethod(name="tempo", _intents={"charge": True})

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -35,6 +35,7 @@ class MockMethod:
     def __init__(self, *intents: str) -> None:
         self.intents = dict.fromkeys(intents or ("charge",), True)
         self.currency: str | None = None
+        self._currency_explicit = True
         self.loops: list[asyncio.AbstractEventLoop] = []
 
     async def create_credential(self, challenge: Challenge) -> Credential:
@@ -85,6 +86,33 @@ def test_matching_skips_currency_rejected_by_configured_method() -> None:
     assert runtime.match_challenge(offered) == (offered[1], method)
     with pytest.raises(ValueError, match="No compatible payment method"):
         runtime.match_challenge(offered[:1])
+
+
+def test_matching_considers_each_same_key_method_currency_constraint() -> None:
+    usdc_method = MockMethod("charge")
+    usdc_method.currency = "0xUsdc"
+    machine_usd_method = MockMethod("charge")
+    machine_usd_method.currency = "0xMachineUsd"
+    runtime = PaymentRuntime([usdc_method, machine_usd_method])
+
+    usdc_challenge = challenge("usdc", currency="0xUSDC")
+    machine_usd_challenge = challenge("machine-usd", currency="0xMACHINEUSD")
+
+    assert runtime.match_challenge([usdc_challenge]) == (usdc_challenge, usdc_method)
+    assert runtime.match_challenge([machine_usd_challenge]) == (
+        machine_usd_challenge,
+        machine_usd_method,
+    )
+
+
+def test_matching_ignores_implicit_currency_default() -> None:
+    method = MockMethod("charge")
+    method.currency = "0xUsdc"
+    method._currency_explicit = False
+    runtime = PaymentRuntime([method])
+    offered = challenge("machine-usd", currency="0xMachineUsd")
+
+    assert runtime.match_challenge([offered]) == (offered, method)
 
 
 def test_matching_preserves_legacy_methods_without_intent_metadata() -> None:

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -18,12 +18,13 @@ def challenge(
     method: str = "tempo",
     intent: str = "charge",
     expires: str | None = None,
+    currency: str | None = None,
 ) -> Challenge:
     return Challenge(
         id=identifier,
         method=method,
         intent=intent,
-        request={},
+        request={} if currency is None else {"currency": currency},
         expires=expires,
     )
 
@@ -33,6 +34,7 @@ class MockMethod:
 
     def __init__(self, *intents: str) -> None:
         self.intents = dict.fromkeys(intents or ("charge",), True)
+        self.currency: str | None = None
         self.loops: list[asyncio.AbstractEventLoop] = []
 
     async def create_credential(self, challenge: Challenge) -> Credential:
@@ -69,6 +71,20 @@ def test_matching_skips_unsupported_intent_before_supported_challenge() -> None:
     ]
 
     assert runtime.match_challenge(offered) == (offered[1], method)
+
+
+def test_matching_skips_currency_rejected_by_configured_method() -> None:
+    method = MockMethod("charge")
+    method.currency = "0xUsdc"
+    runtime = PaymentRuntime([method])
+    offered = [
+        challenge("machine-usd", currency="0xMachineUsd"),
+        challenge("usdc", currency="0xUSDC"),
+    ]
+
+    assert runtime.match_challenge(offered) == (offered[1], method)
+    with pytest.raises(ValueError, match="No compatible payment method"):
+        runtime.match_challenge(offered[:1])
 
 
 def test_matching_preserves_legacy_methods_without_intent_metadata() -> None:
@@ -144,6 +160,17 @@ async def test_credential_creation_validates_method() -> None:
         await runtime.create_credential(challenge(), MockMethod())
     with pytest.raises(ValueError, match="does not support"):
         await runtime.create_credential(challenge(method="stripe"), method)
+
+    assert method.loops == []
+
+
+async def test_credential_creation_rejects_mismatched_currency() -> None:
+    method = MockMethod()
+    method.currency = "0xUsdc"
+    runtime = PaymentRuntime([method])
+
+    with pytest.raises(ValueError, match="currency '0xUsdc' does not support '0xMachineUsd'"):
+        await runtime.create_credential(challenge(currency="0xMachineUsd"), method)
 
     assert method.loops == []
 

--- a/tests/test_tempo.py
+++ b/tests/test_tempo.py
@@ -137,6 +137,16 @@ class TestTempoMethod:
         assert isinstance(method, TempoMethod)
         assert method.name == "tempo"
 
+    def test_tempo_default_currency_is_not_a_client_constraint(self) -> None:
+        method = tempo(intents={"charge": ChargeIntent()})
+
+        assert method._currency_explicit is False
+
+    def test_tempo_provided_currency_is_a_client_constraint(self) -> None:
+        method = tempo(currency="0xUsdc", intents={"charge": ChargeIntent()})
+
+        assert method._currency_explicit is True
+
     def test_tempo_with_account(self) -> None:
         """tempo() should accept account and rpc_url."""
         key = "0x" + "d" * 64


### PR DESCRIPTION
## Summary

- match payment Challenges against a client's configured currency
- skip unsupported currencies for both HTTP and MCP clients
- reject direct credential creation when the offered currency conflicts with client configuration

## Testing

- `uv run --extra tempo --extra mcp pytest` (887 passed, 41 skipped)
- `uv run ruff check src/mpp/runtime.py src/mpp/extensions/mcp/client.py tests/test_runtime.py tests/test_mcp_client.py`
- `uv run pyright src/mpp/runtime.py src/mpp/extensions/mcp/client.py tests/test_runtime.py tests/test_mcp_client.py`

Prompted by: @brendanjryan
