### PR TITLE
feat(stripe): mark machine payment intents

### DIFF
--- a/.changelog/calm-otters-pay.md
+++ b/.changelog/calm-otters-pay.md
@@ -1,0 +1,5 @@
+---
+pympp: patch
+---
+
+Added a machine-payment metadata field to every Stripe PaymentIntent created by pympp.

--- a/src/mpp/methods/stripe/intents.py
+++ b/src/mpp/methods/stripe/intents.py
@@ -174,7 +174,11 @@ class ChargeIntent:
         spt = parsed.spt
 
         user_metadata = parsed_request.methodDetails.metadata
-        resolved_metadata = {**_build_analytics(credential), **(user_metadata or {})}
+        resolved_metadata = {
+            **_build_analytics(credential),
+            **(user_metadata or {}),
+            "machine_payment": "true",
+        }
 
         if self._client is not None:
             pi = await self._create_with_client(

--- a/tests/test_stripe.py
+++ b/tests/test_stripe.py
@@ -650,6 +650,7 @@ class TestChargeIntent:
         assert metadata["mpp_challenge_id"] == "test-challenge-id"
         assert metadata["mpp_server_id"] == "api.example.com"
         assert metadata["mpp_client_id"] == "stripe:test"
+        assert metadata["machine_payment"] == "true"
 
     @pytest.mark.asyncio
     async def test_idempotency_key(self):
@@ -716,12 +717,16 @@ class TestChargeIntent:
             **SAMPLE_REQUEST,
             "methodDetails": {
                 **SAMPLE_REQUEST["methodDetails"],
-                "metadata": {"mpp_version": "custom", "user_key": "user_val"},
+                "metadata": {
+                    "mpp_version": "custom",
+                    "user_key": "user_val",
+                },
             },
         }
         await intent.verify(credential, request_with_metadata)
 
         metadata = captured[0][0][0]["metadata"]
+        assert metadata["machine_payment"] == "true"
         assert metadata["mpp_version"] == "custom"
         assert metadata["user_key"] == "user_val"
 
@@ -835,6 +840,7 @@ class TestChargeIntentRawHttp:
         await intent.verify(credential, SAMPLE_REQUEST)
 
         data = mock_client.post.call_args.kwargs["data"]
+        assert data["metadata[machine_payment]"] == "true"
         assert data["metadata[mpp_is_mpp]"] == "true"
         assert data["metadata[mpp_version]"] == "1"
 


### PR DESCRIPTION
Add metadata.machine_payment=true to Stripe PaymentIntents created through both Stripe SDK clients and the raw HTTP fallback.

This will help users identify machine payments.