### PR TITLE
fix(server): reject timezone-naive expires instead of raising

### DIFF
--- a/.changelog/hot-bees-climb.md
+++ b/.changelog/hot-bees-climb.md
@@ -1,0 +1,5 @@
+---
+pympp: patch
+---
+
+Fixed `verify_or_challenge` raising `TypeError` when a challenge carried a timezone-naive `expires` value. A naive timestamp parsed successfully but could not be compared to an aware `now`, surfacing as a server error instead of a fail-closed rejection; it is now rejected like any other invalid `expires`.

--- a/.changelog/quiet-heron-verify.md
+++ b/.changelog/quiet-heron-verify.md
@@ -1,0 +1,5 @@
+---
+pympp: patch
+---
+
+Fixed `verify_or_challenge` raising `TypeError` when a challenge carried a timezone-naive `expires`. Such a value parsed but could not be compared to an aware `now`, so an expired credential surfaced as a server error instead of a fail-closed rejection; it is now rejected like any other unusable `expires`.

--- a/.changelog/quiet-heron-verify.md
+++ b/.changelog/quiet-heron-verify.md
@@ -1,5 +1,0 @@
----
-pympp: patch
----
-
-Fixed `verify_or_challenge` raising `TypeError` when a challenge carried a timezone-naive `expires`. Such a value parsed but could not be compared to an aware `now`, so an expired credential surfaced as a server error instead of a fail-closed rejection; it is now rejected like any other unusable `expires`.

--- a/src/mpp/server/verify.py
+++ b/src/mpp/server/verify.py
@@ -212,6 +212,11 @@ async def verify_or_challenge(
         expires_dt = datetime.fromisoformat(echo.expires.replace("Z", "+00:00"))
     except ValueError:
         return await fail(InvalidChallengeError(echo.id, "invalid expires"), credential)
+    if expires_dt.tzinfo is None:
+        # A timestamp without an offset does not name an instant, and comparing
+        # it to an aware "now" raises TypeError. Reject it like any other
+        # unparseable value so the route still fails closed.
+        return await fail(InvalidChallengeError(echo.id, "invalid expires"), credential)
     if expires_dt < datetime.now(UTC):
         return await fail(PaymentExpiredError(echo.expires), credential)
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -633,6 +633,42 @@ class TestChallengeExpiryEnforcement:
 
         assert isinstance(result, Challenge)
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "expires",
+        ["2099-01-01T00:00:00", "2000-01-01T00:00:00"],
+        ids=["future", "past"],
+    )
+    async def test_rejects_timezone_naive_expires(self, expires: str) -> None:
+        """Should reject an expires without an offset instead of raising.
+
+        A naive timestamp parses, so it reached the comparison against an
+        aware ``now`` and raised TypeError — turning an expired credential
+        into a server error rather than a fail-closed rejection.
+        """
+
+        @intent(name="charge")
+        async def test_intent(credential: Credential, request: dict) -> Receipt:
+            return Receipt.success("0x123")
+
+        credential = make_bound_credential(
+            payload={"hash": "0xabc"},
+            request={"amount": "1000"},
+            realm="api.example.com",
+            secret_key="test-secret",
+            expires=expires,
+        )
+
+        result = await verify_or_challenge(
+            authorization=credential.to_authorization(),
+            intent=test_intent,
+            request={"amount": "1000"},
+            realm="api.example.com",
+            secret_key="test-secret",
+        )
+
+        assert isinstance(result, Challenge)
+
 
 class TestCrossEndpointReplay:
     @pytest.mark.asyncio


### PR DESCRIPTION
## Motivation

Timezone-naive `expires` values can raise while verifying a credential instead of being rejected.

## Summary

- Reject timezone-naive credential expiry timestamps.
- Cover rejection and expired-credential behavior.

## Key design considerations

- Treat naive timestamps as unusable expiry values, preserving fail-closed verification.