### PR TITLE
fix: canonicalize challenge-bound JSON

### DIFF
--- a/.changelog/evil-pigs-read.md
+++ b/.changelog/evil-pigs-read.md
@@ -1,0 +1,5 @@
+---
+pympp: patch
+---
+
+Fixed payment challenge request and opaque serialization to use RFC 8785 JSON Canonicalization Scheme (JCS) via the `rfc8785` library, replacing ad-hoc `json.dumps` calls across HTTP and MCP transports. This ensures challenge IDs are reproducible from the exact bytes emitted on the wire, including non-ASCII characters and JCS number formatting.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "httpx>=0.27",
+    "rfc8785>=0.1.4",
 ]
 authors = [
     {name = "Tempo"}

--- a/src/mpp/__init__.py
+++ b/src/mpp/__init__.py
@@ -8,12 +8,12 @@ from __future__ import annotations
 import base64
 import hashlib
 import hmac
-import json
 import re
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any, Literal
 
+from mpp._canonical import canonical_b64url
 from mpp._parsing import (
     ParseError,
     format_authorization,
@@ -135,13 +135,11 @@ def generate_challenge_id(
             request={"amount": "1000000", "currency": "0x...", "recipient": "0x..."},
         )
     """
-    request_json = json.dumps(request, separators=(",", ":"), sort_keys=True, ensure_ascii=False)
-    request_b64 = _b64url_encode(request_json)
+    request_b64 = canonical_b64url(request)
 
     opaque_b64 = ""
     if opaque is not None:
-        opaque_json = json.dumps(opaque, separators=(",", ":"), sort_keys=True, ensure_ascii=False)
-        opaque_b64 = _b64url_encode(opaque_json)
+        opaque_b64 = canonical_b64url(opaque)
 
     hmac_parts = [
         realm,
@@ -265,13 +263,7 @@ class Challenge:
             opaque=meta,
             header=header,
         )
-        request_json = json.dumps(
-            request,
-            separators=(",", ":"),
-            sort_keys=True,
-            ensure_ascii=False,
-        )
-        request_b64 = _b64url_encode(request_json)
+        request_b64 = canonical_b64url(request)
         return cls(
             id=challenge_id,
             method=method,
@@ -331,13 +323,7 @@ class Challenge:
         """
         opaque_b64 = None
         if self.opaque is not None:
-            opaque_json = json.dumps(
-                self.opaque,
-                separators=(",", ":"),
-                sort_keys=True,
-                ensure_ascii=False,
-            )
-            opaque_b64 = _b64url_encode(opaque_json)
+            opaque_b64 = canonical_b64url(self.opaque)
         return ChallengeEcho(
             id=self.id,
             realm=self.realm,

--- a/src/mpp/_canonical.py
+++ b/src/mpp/_canonical.py
@@ -1,0 +1,14 @@
+"""RFC 8785 canonical JSON helpers for challenge-bound values."""
+
+from __future__ import annotations
+
+import base64
+from typing import Any
+
+import rfc8785
+
+
+def canonical_b64url(data: Any) -> str:
+    """Encode data as JCS JSON in unpadded base64url form."""
+    canonical = rfc8785.dumps(data)
+    return base64.urlsafe_b64encode(canonical).decode("ascii").rstrip("=")

--- a/src/mpp/_parsing.py
+++ b/src/mpp/_parsing.py
@@ -18,6 +18,8 @@ import re
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
+from mpp._canonical import canonical_b64url
+
 if TYPE_CHECKING:
     from mpp import Challenge, Credential, Receipt
 
@@ -172,7 +174,7 @@ def format_www_authenticate(challenge: Challenge, realm: str) -> str:
         Payment id="...", realm="...", method="...", intent="...", request="<base64url>"
     """
     # Encode request as base64url JSON
-    request_b64 = _b64_encode(challenge.request)
+    request_b64 = canonical_b64url(challenge.request)
 
     # Build auth-params
     parts = [
@@ -193,7 +195,7 @@ def format_www_authenticate(challenge: Challenge, realm: str) -> str:
     if challenge.header:
         parts.append(f'header="{_escape_quoted(challenge.header)}"')
     if challenge.opaque is not None:
-        opaque_b64 = _b64_encode(challenge.opaque)
+        opaque_b64 = canonical_b64url(challenge.opaque)
         parts.append(f'opaque="{opaque_b64}"')
 
     return "Payment " + ", ".join(parts)

--- a/src/mpp/extensions/mcp/types.py
+++ b/src/mpp/extensions/mcp/types.py
@@ -15,6 +15,8 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Literal
 
+from mpp._canonical import canonical_b64url
+
 if TYPE_CHECKING:
     from mpp import Challenge, Credential, Receipt
 
@@ -84,13 +86,9 @@ class MCPChallenge:
 
     def to_core(self) -> Challenge:
         """Convert to core Challenge type, preserving MCP challenge metadata."""
-        import base64
-        import json
-
         from mpp import Challenge
 
-        request_json = json.dumps(self.request, separators=(",", ":"), sort_keys=True)
-        request_b64 = base64.urlsafe_b64encode(request_json.encode()).decode().rstrip("=")
+        request_b64 = canonical_b64url(self.request)
 
         return Challenge(
             id=self.id,
@@ -182,18 +180,13 @@ class MCPCredential:
 
     def to_core(self) -> Credential:
         """Convert to core Credential type."""
-        import base64
-        import json
-
         from mpp import ChallengeEcho, Credential
 
-        request_json = json.dumps(self.challenge.request, separators=(",", ":"), sort_keys=True)
-        request_b64 = base64.urlsafe_b64encode(request_json.encode()).decode().rstrip("=")
+        request_b64 = canonical_b64url(self.challenge.request)
 
         opaque_b64 = None
         if self.challenge.opaque is not None:
-            opaque_json = json.dumps(self.challenge.opaque, separators=(",", ":"), sort_keys=True)
-            opaque_b64 = base64.urlsafe_b64encode(opaque_json.encode()).decode().rstrip("=")
+            opaque_b64 = canonical_b64url(self.challenge.opaque)
 
         echo = ChallengeEcho(
             id=self.challenge.id,

--- a/src/mpp/extensions/mcp/verify.py
+++ b/src/mpp/extensions/mcp/verify.py
@@ -38,6 +38,8 @@ from __future__ import annotations
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
+import rfc8785
+
 from mpp import _constant_time_equal, generate_challenge_id
 from mpp.errors import PaymentError, PaymentOutcomeUnknownError
 from mpp.extensions.mcp.constants import META_CREDENTIAL
@@ -144,16 +146,19 @@ async def verify_or_challenge(
     # Stateless challenge verification: recompute expected challenge ID from
     # echoed parameters and compare to the credential's challenge ID.
     echoed = mcp_credential.challenge
-    expected_id = generate_challenge_id(
-        secret_key=secret_key,
-        realm=echoed.realm,
-        method=echoed.method,
-        intent=echoed.intent,
-        request=echoed.request,
-        expires=echoed.expires,
-        digest=echoed.digest,
-        opaque=echoed.opaque,
-    )
+    try:
+        expected_id = generate_challenge_id(
+            secret_key=secret_key,
+            realm=echoed.realm,
+            method=echoed.method,
+            intent=echoed.intent,
+            request=echoed.request,
+            expires=echoed.expires,
+            digest=echoed.digest,
+            opaque=echoed.opaque,
+        )
+    except rfc8785.CanonicalizationError:
+        return new_challenge()
     if not _constant_time_equal(echoed.id, expected_id):
         return new_challenge()
 

--- a/src/mpp/server/verify.py
+++ b/src/mpp/server/verify.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
+import rfc8785
+
 from mpp import (
     Challenge,
     Credential,
@@ -278,17 +280,20 @@ def _authenticate_echo(
     except ParseError as error:
         raise MalformedCredentialError(str(error)) from error
 
-    expected_id = generate_challenge_id(
-        secret_key=secret_key,
-        realm=echo.realm,
-        method=echo.method,
-        intent=echo.intent,
-        request=echo_request,
-        expires=echo.expires,
-        digest=echo.digest,
-        opaque=echo_opaque,
-        header=echo.header,
-    )
+    try:
+        expected_id = generate_challenge_id(
+            secret_key=secret_key,
+            realm=echo.realm,
+            method=echo.method,
+            intent=echo.intent,
+            request=echo_request,
+            expires=echo.expires,
+            digest=echo.digest,
+            opaque=echo_opaque,
+            header=echo.header,
+        )
+    except rfc8785.CanonicalizationError as error:
+        raise MalformedCredentialError("Challenge contains non-canonical JSON") from error
     if not _constant_time_equal(echo.id, expected_id):
         raise InvalidChallengeError(echo.id, "challenge was not issued by this server")
     return echo_request, echo_opaque

--- a/tests/test_challenge_id.py
+++ b/tests/test_challenge_id.py
@@ -4,9 +4,15 @@ These tests use the cross-SDK conformance test vectors to ensure
 Python SDK produces identical challenge IDs to TypeScript and Rust SDKs.
 """
 
+import base64
+import hashlib
+import hmac
+
 import pytest
+import rfc8785
 
 from mpp import Challenge, generate_challenge_id
+from mpp._canonical import canonical_b64url
 
 
 class TestGenerateChallengeId:
@@ -573,3 +579,92 @@ class TestCredentialHeader:
                 request={"amount": "1000000"},
                 header="Payment Authorization",
             )
+
+
+class TestJcsChallengeEncoding:
+    """RFC 8785 vectors exercised through every HMAC-bound representation."""
+
+    @pytest.mark.parametrize(
+        ("data", "expected"),
+        [
+            (
+                {"description": "Payment for café ☕", "amount": "1000000"},
+                "eyJhbW91bnQiOiIxMDAwMDAwIiwiZGVzY3JpcHRpb24iOiJQYXltZW50IGZvciBjYWbDqSDimJUifQ",
+            ),
+            (
+                {"\U00010000": "supplementary", "\ue000": "private"},
+                "eyLwkICAIjoic3VwcGxlbWVudGFyeSIsIu6AgCI6InByaXZhdGUifQ",
+            ),
+            (
+                {
+                    "integer": 333333333.33333329,
+                    "large": 1e21,
+                    "negativeZero": -0.0,
+                    "scientific": 1e-7,
+                    "small": 1e-6,
+                },
+                "eyJpbnRlZ2VyIjozMzMzMzMzMzMuMzMzMzMzMywibGFyZ2UiOjFlKzIxLCJuZWdhdGl2ZVplcm8iOjAsInNjaWVudGlmaWMiOjFlLTcsInNtYWxsIjowLjAwMDAwMX0",
+            ),
+        ],
+    )
+    def test_matches_rfc8785_vectors(self, data: dict[str, object], expected: str) -> None:
+        assert canonical_b64url(data) == expected
+
+    @pytest.mark.parametrize(
+        "data",
+        [
+            {"value": float("nan")},
+            {"value": float("inf")},
+            {"value": 2**100},
+            {1: "not-a-string-key"},
+        ],
+    )
+    def test_rejects_values_outside_jcs(self, data: dict[object, object]) -> None:
+        with pytest.raises(rfc8785.CanonicalizationError):
+            canonical_b64url(data)
+
+    def test_http_wire_form_echo_and_hmac_use_identical_jcs_bytes(self) -> None:
+        request = {"description": "Payment for café ☕", "amount": "1000000"}
+        opaque = {"\U00010000": "supplementary", "\ue000": "private"}
+        challenge = Challenge.create(
+            secret_key="test-secret",
+            realm="api.example.com",
+            method="tempo",
+            intent="charge",
+            request=request,
+            meta=opaque,
+            header="Payment-Authorization",
+        )
+
+        header = challenge.to_www_authenticate(challenge.realm)
+        request_b64 = header.split('request="', 1)[1].split('"', 1)[0]
+        opaque_b64 = header.split('opaque="', 1)[1].split('"', 1)[0]
+        hmac_input = "|".join(
+            [
+                challenge.realm,
+                challenge.method,
+                challenge.intent,
+                request_b64,
+                "",
+                "",
+                "Payment-Authorization",
+                opaque_b64,
+            ]
+        )
+        expected_id = (
+            base64.urlsafe_b64encode(
+                hmac.new(b"test-secret", hmac_input.encode(), hashlib.sha256).digest()
+            )
+            .decode()
+            .rstrip("=")
+        )
+
+        assert request_b64 == canonical_b64url(request)
+        assert opaque_b64 == canonical_b64url(opaque)
+        assert challenge.id == expected_id
+        assert challenge.to_echo().request == request_b64
+        assert challenge.to_echo().opaque == opaque_b64
+
+        parsed = Challenge.from_www_authenticate(header)
+        assert parsed.verify("test-secret", "api.example.com")
+        assert parsed.to_www_authenticate(parsed.realm) == header

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -7,6 +7,7 @@ from datetime import UTC, datetime, timedelta
 import pytest
 
 from mpp import Challenge, Credential, Receipt, generate_challenge_id
+from mpp._canonical import canonical_b64url
 from mpp.errors import PaymentOutcomeUnknownError, VerificationFailedError
 from mpp.extensions.mcp import (
     CODE_MALFORMED_CREDENTIAL,
@@ -159,6 +160,18 @@ class TestMCPChallenge:
         core = mcp_challenge.to_core()
         assert core.digest == "sha-256=abc"
         assert core.opaque == {"pi": "pi_123"}
+
+    def test_to_core_uses_jcs_request_encoding(self) -> None:
+        request = {"description": "Payment for café ☕", "amount": "1000"}
+        core = MCPChallenge(
+            id="ch_abc",
+            realm="api.example.com",
+            method="tempo",
+            intent="charge",
+            request=request,
+        ).to_core()
+
+        assert core.request_b64 == canonical_b64url(request)
 
     def test_from_core(self) -> None:
         core = Challenge(
@@ -687,6 +700,36 @@ class TestVerifyOrChallenge:
 
         result = await verify_or_challenge(
             meta=mcp_credential.to_meta(),
+            intent=MockIntent(),  # type: ignore[arg-type]
+            request={"amount": "1000"},
+            realm="api.example.com",
+            secret_key=MCP_TEST_SECRET,
+        )
+
+        assert isinstance(result, MCPChallenge)
+
+    @pytest.mark.parametrize("field", ["request", "opaque"])
+    async def test_rejects_credential_with_non_jcs_echo(self, field: str) -> None:
+        """Reject echoed JSON that cannot be canonically encoded for HMAC verification."""
+
+        class MockIntent:
+            name = "charge"
+
+            async def verify(self, credential: object, request: dict) -> Receipt:
+                return Receipt.success(reference="0x123")
+
+        challenge = MCPChallenge(
+            id="forged-id",
+            realm="api.example.com",
+            method="tempo",
+            intent="charge",
+            request={"value": 2**100} if field == "request" else {"amount": "1000"},
+            opaque={"value": 2**100} if field == "opaque" else None,  # type: ignore[arg-type]
+        )
+        credential = MCPCredential(challenge=challenge, payload={"signature": "0xabc"})
+
+        result = await verify_or_challenge(
+            meta=credential.to_meta(),
             intent=MockIntent(),  # type: ignore[arg-type]
             request={"amount": "1000"},
             realm="api.example.com",
@@ -1384,8 +1427,8 @@ class TestMCPCredentialToCoreDigestOpaque:
         assert core.challenge.opaque is None
 
     def test_to_core_roundtrip_hmac_with_opaque(self) -> None:
-        opaque = {"pi": "pi_abc"}
-        request = {"amount": "1000"}
+        opaque = {"\U00010000": "supplementary", "\ue000": "private"}
+        request = {"amount": "1000", "description": "Payment for café ☕"}
         challenge = _make_bound_mcp_challenge(
             request=request,
             opaque=opaque,
@@ -1396,6 +1439,8 @@ class TestMCPCredentialToCoreDigestOpaque:
         from mpp._parsing import _b64_decode
 
         echo = core.challenge
+        assert echo.request == canonical_b64url(request)
+        assert echo.opaque == canonical_b64url(opaque)
         echo_request = _b64_decode(echo.request) if echo.request else {}
         echo_opaque = _b64_decode(echo.opaque) if echo.opaque else None
         recomputed_id = generate_challenge_id(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,8 +1,18 @@
 """Tests for server-side verification."""
 
+import json
+
 import pytest
 
-from mpp import PAYMENT_AUTHORIZATION_HEADER, BodyDigest, Challenge, Credential, Receipt
+from mpp import (
+    PAYMENT_AUTHORIZATION_HEADER,
+    BodyDigest,
+    Challenge,
+    ChallengeEcho,
+    Credential,
+    Receipt,
+    _b64url_encode,
+)
 from mpp.errors import VerificationFailedError
 from mpp.events import EventDispatcher
 from mpp.server import Mpp, intent, pay, verify_or_challenge
@@ -323,6 +333,35 @@ class TestVerificationError:
 
         result = await verify_or_challenge(
             authorization="Payment not-valid-base64!!",
+            intent=test_intent,
+            request={"amount": "1000"},
+            realm="api.example.com",
+            secret_key="test-secret",
+        )
+
+        assert isinstance(result, Challenge)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("field", ["request", "opaque"])
+    async def test_returns_challenge_on_non_jcs_echo(self, field: str) -> None:
+        """Reject echoed JSON that cannot be canonically encoded for HMAC verification."""
+
+        @intent(name="charge")
+        async def test_intent(credential: Credential, request: dict) -> Receipt:
+            return Receipt.success("0x123")
+
+        echo = ChallengeEcho(
+            id="forged-id",
+            realm="api.example.com",
+            method="tempo",
+            intent="charge",
+            request=_b64url_encode(json.dumps({"amount": 2**100} if field == "request" else {})),
+            opaque=(_b64url_encode(json.dumps({"value": 2**100})) if field == "opaque" else None),
+        )
+        credential = Credential(challenge=echo, payload={})
+
+        result = await verify_or_challenge(
+            authorization=credential.to_authorization(),
             intent=test_intent,
             request={"amount": "1000"},
             realm="api.example.com",


### PR DESCRIPTION
## Motivation

Challenge IDs must bind to the same deterministic request and opaque bytes that are emitted by HTTP and MCP transports.

## Summary

- use RFC 8785 JSON Canonicalization Scheme for challenge-bound request and opaque values
- apply the shared encoding to HMAC generation, HTTP challenges, challenge echoes, and MCP conversions
- add JCS, wire-binding, and MCP regression coverage

## Key design considerations

- uses the dependency-free-at-runtime RFC 8785 implementation rather than a partial local serializer
- preserves the existing generic JSON encoding for credentials and receipts, which are not challenge-bound
