### PR TITLE
chore: update GitHub STS action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - name: Fetch GitHub token via STS
         id: app-token
-        uses: tempoxyz/gh-actions/actions/github-sts@183a02178c660ce295e9a262edc5857cb7135f06
+        uses: tempoxyz/gh-actions/actions/github-sts@8819cf80bdcb39c36c34700e3f2ecc08bde54f23
         with:
           policy: release-pr
 


### PR DESCRIPTION
## Summary

- Pin the GitHub STS action to `8819cf80bdcb39c36c34700e3f2ecc08bde54f23`.
- Route post-job token revocation through STS so GitHub and the D1 ownership ledger are updated together.
- Retain the action’s direct GitHub revocation fallback and ledger reconciliation.

Previous action revisions revoked tokens directly at GitHub, leaving their STS rows marked active until expiration. This pin includes tempoxyz/gh-actions#73 and the paired tempoxyz/github-sts#39 service behavior.

## Validation

- `actionlint` on the changed workflows
- `git diff --check`